### PR TITLE
fix: resolve middleware INVOCATION_FAILED error and add maintenance mode

### DIFF
--- a/apps/web/src/app/coming-soon/page.tsx
+++ b/apps/web/src/app/coming-soon/page.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import { Construction } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function ComingSoonPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-8">
+      <div className="mx-auto max-w-2xl text-center">
+        <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/30">
+          <Construction className="h-10 w-10 text-amber-600 dark:text-amber-400" />
+        </div>
+
+        <h1 className="text-primary mb-4 text-5xl font-bold tracking-tight">
+          trainers.gg
+        </h1>
+
+        <p className="text-muted-foreground mb-4 text-xl">Coming Soon</p>
+
+        <p className="text-muted-foreground mb-8">
+          We&apos;re building something special for Pokemon trainers.
+          <br />
+          Check back soon!
+        </p>
+
+        <Link href="/">
+          <Button variant="outline">Back to Home</Button>
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -5,11 +5,13 @@
       "type": "local",
       "command": [
         "npx",
-        "@playwright/mcp",
+        "-y",
+        "@playwright/mcp@latest",
         "--browser",
         "chrome",
         "--extension"
-      ]
+      ],
+      "enabled": true
     }
-  }
+  },
 }


### PR DESCRIPTION
## Summary

- Fix `MIDDLEWARE_INVOCATION_FAILED` error caused by invalid `path-to-regexp` syntax in `createRouteMatcher`
- Add environment-based maintenance mode with dedicated `/coming-soon` page

## Changes

### Middleware Fix
The root cause was using `/*` wildcard syntax which is incompatible with `path-to-regexp` v6.x:
- `/api/auth/*` → `/api/auth(.*)`
- `/api/webhooks/*` → `/api/webhooks(.*)`

### Maintenance Mode
When `MAINTENANCE_MODE=true` is set:
- `/` (home page) remains accessible
- `/coming-soon` page is accessible
- Webhooks continue to work
- All other routes redirect to `/coming-soon`

### New Coming Soon Page
Simple branded page at `/coming-soon` with:
- Construction icon with amber accent
- "trainers.gg" branding
- Dark mode support

## How to Enable

Set in Vercel dashboard (or `.env.local` for local testing):
```
MAINTENANCE_MODE=true
```