### PR TITLE
fix: add PDS_SERVICE_HANDLE_DOMAINS to enable @user.trainers.gg handles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ next-app
 
 # AT Protocol OAuth - auto-generated locally
 apps/web/public/oauth/jwks.json
+.fly

--- a/infra/pds/README.md
+++ b/infra/pds/README.md
@@ -158,6 +158,9 @@ fly secrets set PDS_JWT_SECRET=$(openssl rand -hex 32)
 
 # Set PLC rotation key (generate once, never change!)
 fly secrets set PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX=$(openssl rand -hex 32)
+
+# Enable @username.trainers.gg handles (leading dot required)
+fly secrets set "PDS_SERVICE_HANDLE_DOMAINS=.trainers.gg"
 ```
 
 #### 5. Deploy
@@ -265,6 +268,9 @@ The web/mobile apps have an integrated signup flow that:
 | `PDS_JWT_SECRET`                            | (secret)                           | Yes      |
 | `PDS_ADMIN_PASSWORD`                        | (secret)                           | Yes      |
 | `PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX` | (secret)                           | Yes      |
+| `PDS_SERVICE_HANDLE_DOMAINS`                | `.trainers.gg`                     | Yes      |
+
+> **Note:** `PDS_SERVICE_HANDLE_DOMAINS` tells the PDS which domains are valid for user handles. Without it, the PDS only accepts handles under `*.pds.trainers.gg` (derived from `PDS_HOSTNAME`). Setting it to `.trainers.gg` (with leading dot) enables `@username.trainers.gg` handles.
 
 ## Monitoring
 
@@ -325,6 +331,17 @@ Scale up as needed:
 - Check admin password is set
 - Verify PLC rotation key is configured
 - Check logs for validation errors
+
+### "UnsupportedDomain" error when creating accounts
+
+If `create-account.sh` fails with `"Not a supported handle domain"`, the `PDS_SERVICE_HANDLE_DOMAINS` secret is missing or incorrect:
+
+```bash
+# Set it to allow @username.trainers.gg handles
+flyctl secrets set "PDS_SERVICE_HANDLE_DOMAINS=.trainers.gg" --app trainers-pds
+```
+
+The leading dot is required. Without this, the PDS only accepts handles under `*.pds.trainers.gg`.
 
 ## Resources
 

--- a/infra/pds/deploy.sh
+++ b/infra/pds/deploy.sh
@@ -179,6 +179,13 @@ if [ "$SKIP_FLY" = false ]; then
     log_success "PLC rotation key configured"
   fi
 
+  if echo "$EXISTING_SECRETS" | grep -q "PDS_SERVICE_HANDLE_DOMAINS"; then
+    log_warning "PDS_SERVICE_HANDLE_DOMAINS already set. Skipping."
+  else
+    fly secrets set "PDS_SERVICE_HANDLE_DOMAINS=.${DOMAIN}" --app "$FLY_APP_NAME"
+    log_success "Handle domains configured (.${DOMAIN})"
+  fi
+
   # Deploy
   log_step "Deploying PDS..."
   fly deploy --app "$FLY_APP_NAME"

--- a/infra/pds/setup.sh
+++ b/infra/pds/setup.sh
@@ -71,6 +71,13 @@ else
     fly secrets set PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX="$(openssl rand -hex 32)" --app trainers-pds
 fi
 
+if echo "$EXISTING_SECRETS" | grep -q "PDS_SERVICE_HANDLE_DOMAINS"; then
+    echo "⚠️  PDS_SERVICE_HANDLE_DOMAINS already set. Skipping."
+else
+    echo "   Setting PDS_SERVICE_HANDLE_DOMAINS=.trainers.gg (enables @user.trainers.gg handles)..."
+    fly secrets set "PDS_SERVICE_HANDLE_DOMAINS=.trainers.gg" --app trainers-pds
+fi
+
 echo ""
 echo "✅ Secrets configured"
 echo ""


### PR DESCRIPTION
Without this env var, the PDS only accepts handles under *.pds.trainers.gg (derived from PDS_HOSTNAME). Setting PDS_SERVICE_HANDLE_DOMAINS=.trainers.gg allows account creation with @username.trainers.gg handles.

- Add to deploy.sh and setup.sh so it's set automatically
- Document in README.md env vars table and troubleshooting section
- Gitignore .fly directory (Fly CLI local state)