### PR TITLE
fix(oauth): remove incorrect pds_status update in AT Protocol link

### DIFF
--- a/apps/web/src/app/api/oauth/link/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/link/__tests__/route.test.ts
@@ -3,7 +3,6 @@
  */
 
 import { POST } from "../route";
-import { NextResponse } from "next/server";
 
 // Mock dependencies
 const mockGetUser = jest.fn();
@@ -13,7 +12,6 @@ const mockMaybeSingle = jest.fn();
 const mockUpdate = jest.fn();
 const mockFrom = jest.fn();
 const mockDelete = jest.fn();
-const mockCookies = jest.fn();
 
 jest.mock("@/lib/supabase/server", () => ({
   createAtprotoClient: jest.fn(async () => ({
@@ -25,7 +23,7 @@ jest.mock("@/lib/supabase/server", () => ({
 }));
 
 jest.mock("next/headers", () => ({
-  cookies: mockCookies,
+  cookies: jest.fn(async () => ({ delete: mockDelete })),
 }));
 
 jest.mock("botid/server", () => ({
@@ -45,9 +43,6 @@ describe("POST /api/oauth/link", () => {
     // Setup default mock for update().eq()
     const mockUpdateEq = jest.fn().mockResolvedValue({ error: null });
     mockUpdate.mockReturnValue({ eq: mockUpdateEq });
-
-    // Setup default mock for cookies
-    mockCookies.mockResolvedValue({ delete: mockDelete });
 
     // Setup default authenticated user
     mockGetUser.mockResolvedValue({


### PR DESCRIPTION
## Summary
Fixes TGG-233 - Remove incorrect `pds_status: "active"` setting in OAuth link route

## Changes
- Removed `pds_status: "active"` from the DID link update
- Added comment explaining that PDS status transitions are handled by the edge function

## Why
The OAuth link route was incorrectly setting `pds_status` to "active" when linking a Bluesky DID. This bypasses the proper account lifecycle management that should be handled by the PDS edge function.

## Test Plan
- [x] Typecheck passes
- [x] Linter passes
- [ ] Manual testing: Link Bluesky account and verify `pds_status` is managed correctly by edge function

🤖 Generated with [Claude Code](https://claude.com/claude-code)