### PR TITLE
fix(types): TypeScript type safety improvements from audit

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -81,6 +81,24 @@ export type CreateTournamentInput = z.infer<typeof createTournamentSchema>;
 
 Zod itself is re-exported from `@trainers/validators` — import `z` from there for single-source access.
 
+## Type Exports
+
+When a query or mutation returns a useful composite type (joins, computed fields), **always export a named type**:
+
+```ts
+// In packages/supabase/src/queries/audit-log.ts
+/** Single audit log row with joined actor user. */
+export type AuditLogEntry = NonNullable<
+  Awaited<ReturnType<typeof getAuditLog>>["data"]
+>[number];
+```
+
+Then re-export from the barrel (`queries/index.ts` and `src/index.ts`).
+
+**Never define a type in `apps/web/` that mirrors a query return shape.** If the type doesn't exist in the package yet, add and export it there — don't create a local duplicate.
+
+For simple table row types, use `Tables<"table_name">` from `@trainers/supabase` instead of defining an interface.
+
 ## Code Reuse
 
 Extract abstractions after 2-3 repetitions. Always check existing patterns before creating new ones.

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -16,6 +16,18 @@ Project-wide coding standards for all TypeScript and TSX code in the trainers.gg
 - **No `@ts-expect-error` or `@ts-ignore`** — fix the type error instead
 - **No `globalThis`** for accessing Node.js globals — use proper imports or configure `tsconfig`/`jest.config` instead
 
+## Type Safety
+
+- **Always specify generic parameters** — `ActionResult<void>`, not bare `ActionResult`
+- **Use Supabase type helpers** for database types:
+  - `Tables<"table_name">` for row types
+  - `TablesInsert<"table_name">` for insert payloads
+  - `TablesUpdate<"table_name">` for update payloads
+  - `Enums<"enum_name">` for database enums (not `Database["public"]["Enums"]["x"]`)
+- **Never duplicate types locally** that exist in a shared package — import them from `@trainers/supabase`, `@trainers/validators`, etc.
+- **Derive query result types** with `NonNullable<Awaited<ReturnType<typeof fn>>>` — see architecture.md
+- **Export useful composite types** from queries — when a query returns a joined/enriched shape, export it as a named type so consumers don't redefine it
+
 ## React Compiler
 
 This project uses React Compiler for automatic memoization across all packages (web and mobile). ESLint uses `eslint-plugin-react-hooks` v7 with `recommended-latest` (bundles compiler rules). `exhaustive-deps` is disabled — the compiler handles memoization and stale closure prevention.

--- a/.claude/rules/nextjs-conventions.md
+++ b/.claude/rules/nextjs-conventions.md
@@ -69,7 +69,7 @@ Located in `src/actions/`, one file per domain (e.g., `tournaments.ts`, `communi
 
 ### Return Type
 
-Every server action returns `Promise<ActionResult<T>>`:
+Every server action returns `Promise<ActionResult<T>>`. **Always specify the generic** — use `ActionResult<void>` for actions with no return data, not bare `ActionResult`:
 
 ```ts
 export type ActionResult<T = void> =

--- a/.claude/rules/supabase-patterns.md
+++ b/.claude/rules/supabase-patterns.md
@@ -62,6 +62,42 @@ Choose the most restrictive client that satisfies the need. Prefer `createStatic
 - Generated types flow through the monorepo via `@trainers/supabase`
 - Use the generated `Database` type for `TypedClient` — never manually define table types
 
+## Type Helpers
+
+Use the generated type helpers from `@trainers/supabase` instead of manual type definitions:
+
+```ts
+import {
+  type Tables,
+  type TablesInsert,
+  type TablesUpdate,
+  type Enums,
+} from "@trainers/supabase";
+
+// Row types (for reads)
+type Tournament = Tables<"tournaments">;
+
+// Insert types (for mutations that create)
+type NewTournament = TablesInsert<"tournaments">;
+
+// Update types (for mutations that modify)
+type TournamentUpdate = TablesUpdate<"tournaments">;
+
+// Enum types (for database enums)
+type TournamentStatus = Enums<"tournament_status">;
+```
+
+**When to export query result types:** If a query returns a joined/enriched shape (e.g., tournament + organization + registration count), export a named type from the query file:
+
+```ts
+/** Tournament with joined org and computed counts. */
+export type TournamentWithOrg = NonNullable<
+  Awaited<ReturnType<typeof listTournamentsGrouped>>
+>["active"][number];
+```
+
+Then re-export from `queries/index.ts`. Never let consumers manually redefine a type that matches a query return shape.
+
 ## Query Organization
 
 - One file per domain in `packages/supabase/src/queries/` (e.g., `communities.ts`, `tournaments.ts`)

--- a/apps/web/src/actions/__tests__/profile.test.ts
+++ b/apps/web/src/actions/__tests__/profile.test.ts
@@ -71,29 +71,29 @@ describe("checkUsernameAvailability", () => {
   it("rejects usernames shorter than 3 code points", async () => {
     const result = await checkUsernameAvailability("ab");
 
-    expect(result.available).toBe(false);
-    expect(result.error).toBeTruthy();
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toBeTruthy();
   });
 
   it("rejects usernames with invalid characters", async () => {
     const result = await checkUsernameAvailability("user name!");
 
-    expect(result.available).toBe(false);
-    expect(result.error).toBeTruthy();
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toBeTruthy();
   });
 
   it("rejects temp_ placeholder usernames", async () => {
     const result = await checkUsernameAvailability("temp_abc123");
 
-    expect(result.available).toBe(false);
-    expect(result.error).toBeTruthy();
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toBeTruthy();
   });
 
   it("rejects user_ placeholder usernames", async () => {
     const result = await checkUsernameAvailability("user_abc123");
 
-    expect(result.available).toBe(false);
-    expect(result.error).toBeTruthy();
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toBeTruthy();
   });
 
   it("returns available when username is free in both users and alts tables", async () => {
@@ -113,8 +113,8 @@ describe("checkUsernameAvailability", () => {
 
     const result = await checkUsernameAvailability("available_name");
 
-    expect(result.available).toBe(true);
-    expect(result.error).toBeNull();
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.available).toBe(true);
   });
 
   it("returns unavailable when username exists in users table", async () => {
@@ -127,9 +127,17 @@ describe("checkUsernameAvailability", () => {
       })
     );
 
+    // Alts table check — both queries run in parallel via Promise.all
+    mockFrom.mockReturnValueOnce(
+      createQueryBuilder({
+        maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+      })
+    );
+
     const result = await checkUsernameAvailability("taken_user");
 
-    expect(result.available).toBe(false);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.available).toBe(false);
   });
 
   it("returns unavailable when username exists in alts table", async () => {
@@ -151,7 +159,8 @@ describe("checkUsernameAvailability", () => {
 
     const result = await checkUsernameAvailability("alt_taken");
 
-    expect(result.available).toBe(false);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.available).toBe(false);
   });
 
   it("returns unavailable when PDS handle is taken", async () => {
@@ -174,8 +183,11 @@ describe("checkUsernameAvailability", () => {
 
     const result = await checkUsernameAvailability("pdstaken");
 
-    expect(result.available).toBe(false);
-    expect(result.error).toMatch(/Bluesky/);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.available).toBe(false);
+      expect(result.data.reason).toMatch(/Bluesky/);
+    }
   });
 
   it("handles users table query errors gracefully", async () => {
@@ -190,8 +202,8 @@ describe("checkUsernameAvailability", () => {
 
     const result = await checkUsernameAvailability("test_query_err");
 
-    expect(result.available).toBe(false);
-    expect(result.error).toBeTruthy();
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toBeTruthy();
   });
 
   it("handles alts table query errors gracefully", async () => {
@@ -214,8 +226,8 @@ describe("checkUsernameAvailability", () => {
 
     const result = await checkUsernameAvailability("test_alt_err");
 
-    expect(result.available).toBe(false);
-    expect(result.error).toBeTruthy();
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toBeTruthy();
   });
 
   it("excludes current user from users table check when authenticated", async () => {
@@ -257,7 +269,7 @@ describe("getCurrentUserProfile", () => {
 
     const result = await getCurrentUserProfile();
 
-    expect(result).toBeNull();
+    expect(result).toEqual({ success: true, data: null });
   });
 
   it("returns null when user not found in DB", async () => {
@@ -273,7 +285,7 @@ describe("getCurrentUserProfile", () => {
 
     const result = await getCurrentUserProfile();
 
-    expect(result).toBeNull();
+    expect(result).toEqual({ success: true, data: null });
   });
 
   it("returns profile data when user exists", async () => {
@@ -302,16 +314,19 @@ describe("getCurrentUserProfile", () => {
     const result = await getCurrentUserProfile();
 
     expect(result).toEqual({
-      id: "user-1",
-      username: "pikachu",
-      pdsStatus: "active",
-      pdsHandle: "pikachu.trainers.gg",
-      did: "did:plc:abc123",
-      birthDate: "2000-01-15",
-      country: "US",
-      mainAltId: null,
-      altAvatarUrl: null,
-      bio: null,
+      success: true,
+      data: {
+        id: "user-1",
+        username: "pikachu",
+        pdsStatus: "active",
+        pdsHandle: "pikachu.trainers.gg",
+        did: "did:plc:abc123",
+        birthDate: "2000-01-15",
+        country: "US",
+        mainAltId: null,
+        altAvatarUrl: null,
+        bio: null,
+      },
     });
   });
 
@@ -355,17 +370,20 @@ describe("getCurrentUserProfile", () => {
     const result = await getCurrentUserProfile();
 
     expect(result).toEqual({
-      id: "user-1",
-      username: "cynthia",
-      pdsStatus: null,
-      pdsHandle: null,
-      did: null,
-      birthDate: null,
-      country: "JP",
-      mainAltId: 42,
-      altAvatarUrl:
-        "https://play.pokemonshowdown.com/sprites/gen5/garchomp.png",
-      bio: null,
+      success: true,
+      data: {
+        id: "user-1",
+        username: "cynthia",
+        pdsStatus: null,
+        pdsHandle: null,
+        did: null,
+        birthDate: null,
+        country: "JP",
+        mainAltId: 42,
+        altAvatarUrl:
+          "https://play.pokemonshowdown.com/sprites/gen5/garchomp.png",
+        bio: null,
+      },
     });
   });
 
@@ -405,12 +423,15 @@ describe("getCurrentUserProfile", () => {
 
     const result = await getCurrentUserProfile();
 
-    expect(result).toEqual(
-      expect.objectContaining({
-        mainAltId: 42,
-        altAvatarUrl: null,
-      })
-    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual(
+        expect.objectContaining({
+          mainAltId: 42,
+          altAvatarUrl: null,
+        })
+      );
+    }
   });
 
   it("returns null on database error", async () => {
@@ -429,7 +450,10 @@ describe("getCurrentUserProfile", () => {
 
     const result = await getCurrentUserProfile();
 
-    expect(result).toBeNull();
+    expect(result).toEqual({
+      success: false,
+      error: "Failed to fetch profile",
+    });
   });
 });
 

--- a/apps/web/src/actions/matches.ts
+++ b/apps/web/src/actions/matches.ts
@@ -45,7 +45,7 @@ export async function submitGameSelectionAction(
   gameId: number,
   selectedWinnerAltId: number,
   tournamentId: number
-): Promise<ActionResult> {
+): Promise<ActionResult<void>> {
   return withAction(async () => {
     await rejectBots();
     const validGameId = idSchema.parse(gameId);

--- a/apps/web/src/actions/profile.ts
+++ b/apps/web/src/actions/profile.ts
@@ -1,6 +1,11 @@
 "use server";
 
-import { z, usernameSchema, pdsStatusSchema } from "@trainers/validators";
+import {
+  z,
+  usernameSchema,
+  pdsStatusSchema,
+  type ActionResult,
+} from "@trainers/validators";
 import { checkBotId } from "botid/server";
 import { createClient } from "@/lib/supabase/server";
 import { escapeLike } from "@trainers/utils";
@@ -29,18 +34,35 @@ const updateProfileSchema = z.object({
   bio: z.string().max(160, "Bio must be 160 characters or less").optional(),
 });
 
+// --- Interfaces ---
+
+interface UserProfile {
+  id: string;
+  username: string | null;
+  pdsStatus: "pending" | "active" | "failed" | "suspended" | "external" | null;
+  pdsHandle: string | null;
+  did: string | null;
+  birthDate: string | null;
+  country: string | null;
+  mainAltId: number | null;
+  altAvatarUrl: string | null;
+  bio: string | null;
+}
+
 // --- Actions ---
 
 /**
  * Check if a username is available (excluding the current user)
  */
-export async function checkUsernameAvailability(username: string) {
+export async function checkUsernameAvailability(
+  username: string
+): Promise<ActionResult<{ available: boolean; reason?: string }>> {
   try {
     // usernameSchema rejects temp_*/user_* placeholders + profanity
     const validated = usernameSchema.safeParse(username);
     if (!validated.success) {
       return {
-        available: false,
+        success: false,
         error: validated.error.errors[0]?.message ?? "Invalid username",
       };
     }
@@ -77,25 +99,25 @@ export async function checkUsernameAvailability(username: string) {
     if (usersResult.error) {
       console.error("Error checking username in users:", usersResult.error);
       return {
-        available: false,
+        success: false,
         error: "Failed to check username availability",
       };
     }
 
     if (usersResult.data) {
-      return { available: false, error: null };
+      return { success: true, data: { available: false } };
     }
 
     if (altsResult.error) {
       console.error("Error checking username in alts:", altsResult.error);
       return {
-        available: false,
+        success: false,
         error: "Failed to check username availability",
       };
     }
 
     if (altsResult.data) {
-      return { available: false, error: null };
+      return { success: true, data: { available: false } };
     }
 
     // Check PDS handle availability (skip for emoji-only usernames)
@@ -105,23 +127,28 @@ export async function checkUsernameAvailability(username: string) {
 
       if (!pdsAvailable) {
         return {
-          available: false,
-          error: "This handle is already registered on Bluesky",
+          success: true,
+          data: {
+            available: false,
+            reason: "This handle is already registered on Bluesky",
+          },
         };
       }
     }
 
-    return { available: true, error: null };
+    return { success: true, data: { available: true } };
   } catch (error) {
     console.error("Error in checkUsernameAvailability:", error);
-    return { available: false, error: "An unexpected error occurred" };
+    return { success: false, error: "An unexpected error occurred" };
   }
 }
 
 /**
  * Get the current user's profile data
  */
-export async function getCurrentUserProfile() {
+export async function getCurrentUserProfile(): Promise<
+  ActionResult<UserProfile | null>
+> {
   try {
     const supabase = await createClient();
 
@@ -129,7 +156,7 @@ export async function getCurrentUserProfile() {
       data: { user },
     } = await supabase.auth.getUser();
 
-    if (!user) return null;
+    if (!user) return { success: true, data: null };
 
     const { data: userData, error: dbError } = await supabase
       .from("users")
@@ -141,10 +168,10 @@ export async function getCurrentUserProfile() {
 
     if (dbError) {
       console.error("Error fetching user profile:", dbError);
-      return null;
+      return { success: false, error: "Failed to fetch profile" };
     }
 
-    if (!userData) return null;
+    if (!userData) return { success: true, data: null };
 
     // Fetch main alt's avatar URL and bio if a main alt exists
     let altAvatarUrl: string | null = null;
@@ -160,26 +187,29 @@ export async function getCurrentUserProfile() {
     }
 
     return {
-      id: userData.id,
-      username: userData.username,
-      pdsStatus: userData.pds_status as
-        | "pending"
-        | "active"
-        | "failed"
-        | "suspended"
-        | "external"
-        | null,
-      pdsHandle: userData.pds_handle,
-      did: userData.did,
-      birthDate: userData.birth_date,
-      country: userData.country,
-      mainAltId: userData.main_alt_id,
-      altAvatarUrl,
-      bio,
+      success: true,
+      data: {
+        id: userData.id,
+        username: userData.username,
+        pdsStatus: userData.pds_status as
+          | "pending"
+          | "active"
+          | "failed"
+          | "suspended"
+          | "external"
+          | null,
+        pdsHandle: userData.pds_handle,
+        did: userData.did,
+        birthDate: userData.birth_date,
+        country: userData.country,
+        mainAltId: userData.main_alt_id,
+        altAvatarUrl,
+        bio,
+      },
     };
   } catch (error) {
     console.error("Error in getCurrentUserProfile:", error);
-    return null;
+    return { success: false, error: "An unexpected error occurred" };
   }
 }
 
@@ -192,7 +222,7 @@ export async function updateProfile(data: {
   birthDate?: string;
   country?: string;
   bio?: string;
-}) {
+}): Promise<ActionResult> {
   const { isBot } = await checkBotId();
   if (isBot) return { success: false, error: "Access denied" };
 
@@ -499,7 +529,7 @@ export async function updateProfile(data: {
       invalidatePlayerRankingCaches();
     }
 
-    return { success: true, error: null };
+    return { success: true, data: undefined };
   } catch (error) {
     if (error instanceof z.ZodError) {
       return {

--- a/apps/web/src/actions/profile.ts
+++ b/apps/web/src/actions/profile.ts
@@ -222,7 +222,7 @@ export async function updateProfile(data: {
   birthDate?: string;
   country?: string;
   bio?: string;
-}): Promise<ActionResult> {
+}): Promise<ActionResult<void>> {
   const { isBot } = await checkBotId();
   if (isBot) return { success: false, error: "Access denied" };
 

--- a/apps/web/src/app/(app)/admin/activity-tab.tsx
+++ b/apps/web/src/app/(app)/admin/activity-tab.tsx
@@ -7,7 +7,11 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { Activity, RefreshCw } from "lucide-react";
-import { getAuditLog, getAuditLogStats } from "@trainers/supabase";
+import {
+  getAuditLog,
+  getAuditLogStats,
+  type AuditLogEntry,
+} from "@trainers/supabase";
 import type { TypedSupabaseClient, Database } from "@trainers/supabase";
 import { useSupabaseQuery } from "@/lib/supabase";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -28,7 +32,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { columns, type AuditLogEntry } from "./activity/columns";
+import { columns } from "./activity/columns";
 
 type AuditAction = Database["public"]["Enums"]["audit_action"];
 

--- a/apps/web/src/app/(app)/admin/activity/columns.tsx
+++ b/apps/web/src/app/(app)/admin/activity/columns.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ColumnDef } from "@tanstack/react-table";
-import type { Database } from "@trainers/supabase";
+import { type AuditLogEntry } from "@trainers/supabase";
 import { formatTimeAgo } from "@trainers/utils";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
@@ -10,29 +10,6 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { AuditActionBadge } from "./audit-action-badge";
-
-type AuditAction = Database["public"]["Enums"]["audit_action"];
-
-// Shape of a single audit log row returned by getAuditLog (with joined actor)
-export interface AuditLogEntry {
-  id: number;
-  action: AuditAction;
-  actor_user_id: string | null;
-  actor_alt_id: number | null;
-  tournament_id: number | null;
-  match_id: number | null;
-  game_id: number | null;
-  community_id: number | null;
-  metadata: Record<string, unknown> | null;
-  created_at: string;
-  actor_user: {
-    id: string;
-    username: string | null;
-    first_name: string | null;
-    last_name: string | null;
-    image: string | null;
-  } | null;
-}
 
 // --- Helpers ---
 
@@ -67,7 +44,7 @@ function getActorDisplayName(actor: AuditLogEntry["actor_user"]): string {
  */
 function extractDetails(entry: AuditLogEntry): string {
   const meta = entry.metadata;
-  if (!meta) return "";
+  if (!meta || typeof meta !== "object" || Array.isArray(meta)) return "";
 
   // If there is an explicit description, use it
   if (typeof meta.description === "string" && meta.description) {

--- a/apps/web/src/app/(app)/admin/config/flag-dialog.tsx
+++ b/apps/web/src/app/(app)/admin/config/flag-dialog.tsx
@@ -15,18 +15,9 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import type { Json } from "@trainers/supabase/types";
+import { type FeatureFlag } from "@trainers/supabase";
 
 // --- Types ---
-
-interface FeatureFlag {
-  id: number;
-  key: string;
-  description: string | null;
-  enabled: boolean;
-  metadata: Json;
-  created_at: string;
-  updated_at: string;
-}
 
 interface FlagDialogProps {
   /** When provided, the dialog is in "edit" mode and pre-fills values. */

--- a/apps/web/src/app/(app)/admin/config/page.tsx
+++ b/apps/web/src/app/(app)/admin/config/page.tsx
@@ -52,18 +52,9 @@ import {
 import { FlagDialog } from "./flag-dialog";
 import { AnnouncementDialog } from "./announcement-dialog";
 import type { Json } from "@trainers/supabase/types";
+import { type FeatureFlag } from "@trainers/supabase";
 
 // --- Types ---
-
-interface FeatureFlag {
-  id: number;
-  key: string;
-  description: string | null;
-  enabled: boolean;
-  metadata: Json;
-  created_at: string;
-  updated_at: string;
-}
 
 interface Announcement {
   id: number;

--- a/apps/web/src/app/(dashboard)/dashboard/onboarding/__tests__/onboarding-form.test.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/onboarding/__tests__/onboarding-form.test.tsx
@@ -71,8 +71,14 @@ describe("OnboardingForm", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
-    mockCheckUsername.mockResolvedValue({ available: true });
-    mockCompleteOnboarding.mockResolvedValue({ success: true, error: null });
+    mockCheckUsername.mockResolvedValue({
+      success: true,
+      data: { available: true },
+    });
+    mockCompleteOnboarding.mockResolvedValue({
+      success: true,
+      data: undefined,
+    });
   });
 
   afterEach(() => {
@@ -185,7 +191,10 @@ describe("OnboardingForm", () => {
     });
 
     it("shows 'Username is available' after successful check", async () => {
-      mockCheckUsername.mockResolvedValue({ available: true });
+      mockCheckUsername.mockResolvedValue({
+        success: true,
+        data: { available: true },
+      });
       render(<OnboardingForm />);
       changeInput(screen.getByLabelText("Username"), "cooltrainer");
       await act(async () => {
@@ -198,8 +207,8 @@ describe("OnboardingForm", () => {
 
     it("shows taken error when username is not available", async () => {
       mockCheckUsername.mockResolvedValue({
-        available: false,
-        error: "Username is taken",
+        success: true,
+        data: { available: false, reason: "Username is taken" },
       });
       render(<OnboardingForm />);
       changeInput(screen.getByLabelText("Username"), "takenname");
@@ -212,7 +221,10 @@ describe("OnboardingForm", () => {
     });
 
     it("shows fallback error when taken but no error message provided", async () => {
-      mockCheckUsername.mockResolvedValue({ available: false });
+      mockCheckUsername.mockResolvedValue({
+        success: true,
+        data: { available: false },
+      });
       render(<OnboardingForm />);
       changeInput(screen.getByLabelText("Username"), "takenname");
       await act(async () => {
@@ -289,8 +301,8 @@ describe("OnboardingForm", () => {
 
     it("is disabled when username is taken", async () => {
       mockCheckUsername.mockResolvedValue({
-        available: false,
-        error: "Username is taken",
+        success: true,
+        data: { available: false, reason: "Username is taken" },
       });
       render(<OnboardingForm />);
       changeInput(screen.getByLabelText("Username"), "takenname");

--- a/apps/web/src/app/(dashboard)/dashboard/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/onboarding/onboarding-form.tsx
@@ -69,12 +69,15 @@ export function OnboardingForm() {
     const timer = setTimeout(async () => {
       const result = await checkUsernameAvailability(username);
       if (cancelled) return;
-      if (result.available) {
+      if (!result.success) {
+        setUsernameStatus("error");
+        setUsernameError(result.error);
+      } else if (result.data.available) {
         setUsernameStatus("available");
         setUsernameError(null);
       } else {
         setUsernameStatus("taken");
-        setUsernameError(result.error ?? "Username is not available");
+        setUsernameError(result.data.reason ?? "Username is not available");
       }
     }, 500);
 

--- a/apps/web/src/app/(dashboard)/dashboard/settings/profile/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/profile/page.tsx
@@ -119,7 +119,7 @@ export default function ProfileSettingsPage() {
       setUsernameError(null);
     } else {
       setUsernameStatus("taken");
-      setUsernameError(result.data.reason ?? null);
+      setUsernameError(result.data.reason ?? "Username is not available");
     }
   };
 

--- a/apps/web/src/app/(dashboard)/dashboard/settings/profile/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/profile/page.tsx
@@ -59,8 +59,9 @@ export default function ProfileSettingsPage() {
   // Load current profile data
   useEffect(() => {
     async function loadProfile() {
-      const profile = await getCurrentUserProfile();
-      if (profile) {
+      const result = await getCurrentUserProfile();
+      if (result.success && result.data) {
+        const profile = result.data;
         setUsername(profile.username ?? "");
         setOriginalUsername(profile.username ?? "");
         setBio(profile.bio ?? "");
@@ -110,12 +111,15 @@ export default function ProfileSettingsPage() {
 
     const result = await checkUsernameAvailability(value);
 
-    if (result.available) {
+    if (!result.success) {
+      setUsernameStatus("error");
+      setUsernameError(result.error);
+    } else if (result.data.available) {
       setUsernameStatus("available");
       setUsernameError(null);
     } else {
       setUsernameStatus("taken");
-      setUsernameError(result.error ?? "Username is not available");
+      setUsernameError(result.data.reason ?? null);
     }
   };
 

--- a/apps/web/src/components/auth/__tests__/username-required-modal.test.tsx
+++ b/apps/web/src/components/auth/__tests__/username-required-modal.test.tsx
@@ -245,7 +245,10 @@ describe("UsernameRequiredModal", () => {
     });
 
     it("shows available state when username is available", async () => {
-      mockCheckUsernameAvailability.mockResolvedValue({ available: true });
+      mockCheckUsernameAvailability.mockResolvedValue({
+        success: true,
+        data: { available: true },
+      });
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       render(<UsernameRequiredModal />);
 
@@ -260,8 +263,8 @@ describe("UsernameRequiredModal", () => {
 
     it("shows taken state when username is not available", async () => {
       mockCheckUsernameAvailability.mockResolvedValue({
-        available: false,
-        error: "Username is already taken",
+        success: true,
+        data: { available: false, reason: "Username is already taken" },
       });
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       render(<UsernameRequiredModal />);
@@ -303,7 +306,10 @@ describe("UsernameRequiredModal", () => {
     });
 
     it("button remains disabled when username is available but no country selected", async () => {
-      mockCheckUsernameAvailability.mockResolvedValue({ available: true });
+      mockCheckUsernameAvailability.mockResolvedValue({
+        success: true,
+        data: { available: true },
+      });
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       render(<UsernameRequiredModal />);
 
@@ -319,7 +325,10 @@ describe("UsernameRequiredModal", () => {
     });
 
     it("button is enabled when both username is available and country selected", async () => {
-      mockCheckUsernameAvailability.mockResolvedValue({ available: true });
+      mockCheckUsernameAvailability.mockResolvedValue({
+        success: true,
+        data: { available: true },
+      });
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       render(<UsernameRequiredModal />);
 
@@ -342,7 +351,10 @@ describe("UsernameRequiredModal", () => {
   describe("form submission", () => {
     async function setupReadyToSubmit() {
       setAuthUser("temp_abc123");
-      mockCheckUsernameAvailability.mockResolvedValue({ available: true });
+      mockCheckUsernameAvailability.mockResolvedValue({
+        success: true,
+        data: { available: true },
+      });
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       render(<UsernameRequiredModal />);
 

--- a/apps/web/src/components/auth/username-required-modal.tsx
+++ b/apps/web/src/components/auth/username-required-modal.tsx
@@ -87,12 +87,15 @@ export function UsernameRequiredModal() {
     const timer = setTimeout(async () => {
       const result = await checkUsernameAvailability(username);
       if (cancelled) return;
-      if (result.available) {
+      if (!result.success) {
+        setUsernameStatus("error");
+        setUsernameError(result.error);
+      } else if (result.data.available) {
         setUsernameStatus("available");
         setUsernameError(null);
       } else {
         setUsernameStatus("taken");
-        setUsernameError(result.error ?? "Username is not available");
+        setUsernameError(result.data.reason ?? "Username is not available");
       }
     }, 500);
 

--- a/packages/pokemon/src/__tests__/showdown-format.test.ts
+++ b/packages/pokemon/src/__tests__/showdown-format.test.ts
@@ -95,20 +95,18 @@ describe("parsePokemon", () => {
 
   it("parses EVs correctly", () => {
     const result = parsePokemon(PIKACHU_TEXT);
-    expect(result!.evs!.spa).toBe(252);
-    expect(result!.evs!.spe).toBe(252);
-    expect(result!.evs!.hp).toBe(4);
+    expect(result!.evs.spa).toBe(252);
+    expect(result!.evs.spe).toBe(252);
+    expect(result!.evs.hp).toBe(4);
   });
 
   it("parses IVs correctly", () => {
     const result = parsePokemon(PIKACHU_TEXT);
-    // Note: parsePokemon uses `if (!pokemon.ivs!.atk)` to default IVs,
-    // so 0 is treated as falsy and overwritten to 31.
-    // This is a known limitation of the parser when IVs are explicitly 0.
-    expect(result!.ivs!.atk).toBe(31);
-    // Non-specified IVs default to 31
-    expect(result!.ivs!.hp).toBe(31);
-    expect(result!.ivs!.def).toBe(31);
+    // Explicitly set to 0 in PIKACHU_TEXT ("IVs: 0 Atk")
+    expect(result!.ivs.atk).toBe(0);
+    // Non-specified IVs default to 31 (initialized that way)
+    expect(result!.ivs.hp).toBe(31);
+    expect(result!.ivs.def).toBe(31);
   });
 
   it("parses moves correctly", () => {
@@ -584,6 +582,8 @@ describe("convertShowdownToPokemonSet", () => {
       ability: "Static",
       nature: "Hardy",
       moves: ["Thunderbolt"],
+      evs: { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0 },
+      ivs: { hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31 },
     };
     const result = convertShowdownToPokemonSet(showdown);
     expect(result.gender).toBe("Female");
@@ -596,6 +596,8 @@ describe("convertShowdownToPokemonSet", () => {
       ability: "Static",
       nature: "Hardy",
       moves: ["Thunderbolt"],
+      evs: { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0 },
+      ivs: { hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31 },
     };
     const result = convertShowdownToPokemonSet(showdown);
     expect(result.gender).toBeUndefined();
@@ -608,18 +610,22 @@ describe("convertShowdownToPokemonSet", () => {
       ability: "Static",
       nature: "Hardy",
       moves: ["Thunderbolt"],
+      evs: { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0 },
+      ivs: { hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31 },
     };
     const result = convertShowdownToPokemonSet(showdown);
     expect(result.level).toBe(50);
   });
 
-  it("defaults EVs to 0 when not set", () => {
+  it("maps EVs correctly", () => {
     const showdown: ShowdownPokemon = {
       species: "Pikachu",
       gender: "",
       ability: "Static",
       nature: "Hardy",
       moves: ["Thunderbolt"],
+      evs: { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0 },
+      ivs: { hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31 },
     };
     const result = convertShowdownToPokemonSet(showdown);
     expect(result.evs.hp).toBe(0);
@@ -627,13 +633,15 @@ describe("convertShowdownToPokemonSet", () => {
     expect(result.evs.speed).toBe(0);
   });
 
-  it("defaults IVs to 31 when not set", () => {
+  it("maps IVs correctly", () => {
     const showdown: ShowdownPokemon = {
       species: "Pikachu",
       gender: "",
       ability: "Static",
       nature: "Hardy",
       moves: ["Thunderbolt"],
+      evs: { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0 },
+      ivs: { hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31 },
     };
     const result = convertShowdownToPokemonSet(showdown);
     expect(result.ivs.hp).toBe(31);
@@ -652,7 +660,8 @@ describe("convertShowdownToDbFormat", () => {
       level: 50,
       nature: "Timid",
       moves: ["Thunderbolt", "Protect"],
-      evs: { spa: 252, spe: 252 },
+      evs: { hp: 0, atk: 0, def: 0, spa: 252, spd: 0, spe: 252 },
+      ivs: { hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31 },
     };
 
     const result = convertShowdownToDbFormat(showdown);

--- a/packages/pokemon/src/index.ts
+++ b/packages/pokemon/src/index.ts
@@ -79,6 +79,7 @@ export {
 
 // Showdown format (advanced parser/exporter)
 export {
+  type ShowdownStats,
   type ShowdownPokemon,
   parsePokemon,
   parseTeam,

--- a/packages/pokemon/src/showdown-format.ts
+++ b/packages/pokemon/src/showdown-format.ts
@@ -6,6 +6,16 @@
 import type { PokemonSet, PokemonSetFlat } from "./types";
 import { toFlat } from "./types";
 
+/** Showdown-format stat block using abbreviated stat keys */
+export interface ShowdownStats {
+  hp: number;
+  atk: number;
+  def: number;
+  spa: number;
+  spd: number;
+  spe: number;
+}
+
 export interface ShowdownPokemon {
   species: string;
   nickname?: string;
@@ -14,22 +24,8 @@ export interface ShowdownPokemon {
   ability: string;
   level?: number;
   shiny?: boolean;
-  evs?: {
-    hp?: number;
-    atk?: number;
-    def?: number;
-    spa?: number;
-    spd?: number;
-    spe?: number;
-  };
-  ivs?: {
-    hp?: number;
-    atk?: number;
-    def?: number;
-    spa?: number;
-    spd?: number;
-    spe?: number;
-  };
+  evs: ShowdownStats;
+  ivs: ShowdownStats;
   nature: string;
   moves: string[];
   teraType?: string;
@@ -87,8 +83,8 @@ export function parsePokemon(text: string): ShowdownPokemon | null {
     ability: "",
     nature: "Hardy",
     moves: [],
-    evs: {},
-    ivs: {},
+    evs: { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0 },
+    ivs: { hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31 },
   };
 
   // Parse remaining lines
@@ -117,24 +113,23 @@ export function parsePokemon(text: string): ShowdownPokemon | null {
         if (match && match[1] && match[2]) {
           const value = parseInt(match[1]);
           const stat = match[2].toLowerCase();
-          if (stat === "hp") pokemon.evs!.hp = value;
-          else if (stat === "atk" || stat === "attack")
-            pokemon.evs!.atk = value;
+          if (stat === "hp") pokemon.evs.hp = value;
+          else if (stat === "atk" || stat === "attack") pokemon.evs.atk = value;
           else if (stat === "def" || stat === "defense")
-            pokemon.evs!.def = value;
+            pokemon.evs.def = value;
           else if (
             stat === "spa" ||
             stat === "spatk" ||
             stat === "special attack"
           )
-            pokemon.evs!.spa = value;
+            pokemon.evs.spa = value;
           else if (
             stat === "spd" ||
             stat === "spdef" ||
             stat === "special defense"
           )
-            pokemon.evs!.spd = value;
-          else if (stat === "spe" || stat === "speed") pokemon.evs!.spe = value;
+            pokemon.evs.spd = value;
+          else if (stat === "spe" || stat === "speed") pokemon.evs.spe = value;
         }
       }
     }
@@ -147,24 +142,23 @@ export function parsePokemon(text: string): ShowdownPokemon | null {
         if (match && match[1] && match[2]) {
           const value = parseInt(match[1]);
           const stat = match[2].toLowerCase();
-          if (stat === "hp") pokemon.ivs!.hp = value;
-          else if (stat === "atk" || stat === "attack")
-            pokemon.ivs!.atk = value;
+          if (stat === "hp") pokemon.ivs.hp = value;
+          else if (stat === "atk" || stat === "attack") pokemon.ivs.atk = value;
           else if (stat === "def" || stat === "defense")
-            pokemon.ivs!.def = value;
+            pokemon.ivs.def = value;
           else if (
             stat === "spa" ||
             stat === "spatk" ||
             stat === "special attack"
           )
-            pokemon.ivs!.spa = value;
+            pokemon.ivs.spa = value;
           else if (
             stat === "spd" ||
             stat === "spdef" ||
             stat === "special defense"
           )
-            pokemon.ivs!.spd = value;
-          else if (stat === "spe" || stat === "speed") pokemon.ivs!.spe = value;
+            pokemon.ivs.spd = value;
+          else if (stat === "spe" || stat === "speed") pokemon.ivs.spe = value;
         }
       }
     }
@@ -181,14 +175,6 @@ export function parsePokemon(text: string): ShowdownPokemon | null {
       pokemon.moves.push(line.substring(2).trim());
     }
   }
-
-  // Set default IVs if not specified
-  if (!pokemon.ivs!.hp) pokemon.ivs!.hp = 31;
-  if (!pokemon.ivs!.atk) pokemon.ivs!.atk = 31;
-  if (!pokemon.ivs!.def) pokemon.ivs!.def = 31;
-  if (!pokemon.ivs!.spa) pokemon.ivs!.spa = 31;
-  if (!pokemon.ivs!.spd) pokemon.ivs!.spd = 31;
-  if (!pokemon.ivs!.spe) pokemon.ivs!.spe = 31;
 
   return pokemon;
 }
@@ -350,20 +336,20 @@ export function convertShowdownToPokemonSet(
       move4: showdownPokemon.moves[3],
     },
     evs: {
-      hp: showdownPokemon.evs?.hp || 0,
-      attack: showdownPokemon.evs?.atk || 0,
-      defense: showdownPokemon.evs?.def || 0,
-      specialAttack: showdownPokemon.evs?.spa || 0,
-      specialDefense: showdownPokemon.evs?.spd || 0,
-      speed: showdownPokemon.evs?.spe || 0,
+      hp: showdownPokemon.evs.hp,
+      attack: showdownPokemon.evs.atk,
+      defense: showdownPokemon.evs.def,
+      specialAttack: showdownPokemon.evs.spa,
+      specialDefense: showdownPokemon.evs.spd,
+      speed: showdownPokemon.evs.spe,
     },
     ivs: {
-      hp: showdownPokemon.ivs?.hp || 31,
-      attack: showdownPokemon.ivs?.atk || 31,
-      defense: showdownPokemon.ivs?.def || 31,
-      specialAttack: showdownPokemon.ivs?.spa || 31,
-      specialDefense: showdownPokemon.ivs?.spd || 31,
-      speed: showdownPokemon.ivs?.spe || 31,
+      hp: showdownPokemon.ivs.hp,
+      attack: showdownPokemon.ivs.atk,
+      defense: showdownPokemon.ivs.def,
+      specialAttack: showdownPokemon.ivs.spa,
+      specialDefense: showdownPokemon.ivs.spd,
+      speed: showdownPokemon.ivs.spe,
     },
   };
 }

--- a/packages/supabase/src/queries/audit-log.ts
+++ b/packages/supabase/src/queries/audit-log.ts
@@ -3,6 +3,11 @@ import type { TypedClient } from "../client";
 
 type AuditAction = Database["public"]["Enums"]["audit_action"];
 
+/** Single audit log row with joined actor user, as returned by getAuditLog. */
+export type AuditLogEntry = NonNullable<
+  Awaited<ReturnType<typeof getAuditLog>>["data"]
+>[number];
+
 /**
  * Get audit log entries for a tournament, ordered by newest first.
  * RLS ensures only community staff with tournament.manage or site admins can read.

--- a/packages/supabase/src/queries/feature-flags.ts
+++ b/packages/supabase/src/queries/feature-flags.ts
@@ -1,5 +1,8 @@
-import type { Json } from "../types";
+import type { Json, Tables } from "../types";
 import type { TypedClient } from "../client";
+
+/** A feature flag row from the database. */
+export type FeatureFlag = Tables<"feature_flags">;
 
 /**
  * List all feature flags, ordered alphabetically by key.

--- a/packages/supabase/src/queries/index.ts
+++ b/packages/supabase/src/queries/index.ts
@@ -223,6 +223,8 @@ export {
   deleteFeatureFlag,
 } from "./feature-flags";
 
+export type { FeatureFlag } from "./feature-flags";
+
 // Player directory queries
 export {
   searchPlayers,

--- a/packages/supabase/src/queries/index.ts
+++ b/packages/supabase/src/queries/index.ts
@@ -154,6 +154,7 @@ export {
   getAuditLog,
   getAuditLogStats,
 } from "./audit-log";
+export type { AuditLogEntry } from "./audit-log";
 
 // Sudo mode queries
 export {


### PR DESCRIPTION
## Summary

Phase 1 fixes from the [TypeScript type audit](.audit-reports/2026-04-07-typescript-type-audit.md) — all critical and quick-win items.

- **Convert `profile.ts` to `ActionResult<T>` pattern** — the only server action file with non-standard return shapes. All 3 functions (`checkUsernameAvailability`, `getCurrentUserProfile`, `updateProfile`) now return `ActionResult<T>`. All callers and tests updated.
- **Fix bare `ActionResult` generic** — `submitGameSelectionAction` now specifies `ActionResult<void>` instead of implicitly `unknown`
- **Export `AuditLogEntry` from `@trainers/supabase`** — derived from query return type, replaces manually-defined duplicate in `columns.tsx`
- **Export `FeatureFlag` from `@trainers/supabase`** — uses `Tables<"feature_flags">`, replaces manual duplicate in `flag-dialog.tsx` and `page.tsx`
- **Make `ShowdownPokemon` evs/ivs required with defaults** — eliminates 18 non-null assertions in the parser. Also fixes a latent bug where `0 Atk` IVs were silently overwritten to 31.

## Test plan

- [x] `pnpm typecheck` — 11/11 pass
- [x] `pnpm --filter @trainers/web test` — all pass (profile: 75 tests, onboarding: 64 tests)
- [x] `pnpm --filter @trainers/pokemon test` — all pass
- [x] Pre-commit hooks pass (typecheck + prettier + eslint)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)