### PR TITLE
feat(dashboard): render alt list as cards on mobile

### DIFF
--- a/apps/web/src/app/(dashboard)/dashboard/__tests__/home-client.test.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/__tests__/home-client.test.tsx
@@ -16,6 +16,14 @@ jest.mock("@/lib/supabase", () => ({
   })),
 }));
 
+// --- @/hooks/use-mobile ---
+// Default to desktop (false) so AltsTable renders; tests that want the
+// mobile view can override via mockUseIsMobile.mockReturnValue(true).
+const mockUseIsMobile = jest.fn(() => false);
+jest.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => mockUseIsMobile(),
+}));
+
 // --- @/components/dashboard/sidebar-helpers ---
 jest.mock("@/components/dashboard/sidebar-helpers", () => ({
   DASHBOARD_ALT_COOKIE: "dashboard-alt",
@@ -174,6 +182,8 @@ function setupMockSupabase() {
 describe("HomeClient", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Re-apply the desktop default — jest.clearAllMocks() wipes implementations
+    mockUseIsMobile.mockReturnValue(false);
     setupMockSupabase();
   });
 
@@ -182,9 +192,18 @@ describe("HomeClient", () => {
   // ---------------------------------------------------------------------------
 
   describe("alts table", () => {
-    it("renders AltsTable component when alts exist", () => {
+    it("renders AltsTable component on desktop", () => {
+      mockUseIsMobile.mockReturnValue(false);
       render(<HomeClient {...getDefaultProps()} />);
       expect(screen.getByTestId("alts-table")).toBeInTheDocument();
+      expect(screen.queryByTestId("alts-cards")).not.toBeInTheDocument();
+    });
+
+    it("renders AltsCards (not AltsTable) on mobile", () => {
+      mockUseIsMobile.mockReturnValue(true);
+      render(<HomeClient {...getDefaultProps()} />);
+      expect(screen.getByTestId("alts-cards")).toBeInTheDocument();
+      expect(screen.queryByTestId("alts-table")).not.toBeInTheDocument();
     });
 
     it("renders 'Your Alts' heading", () => {

--- a/apps/web/src/app/(dashboard)/dashboard/__tests__/home-client.test.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/__tests__/home-client.test.tsx
@@ -24,6 +24,15 @@ jest.mock("@/hooks/use-mobile", () => ({
   useIsMobile: () => mockUseIsMobile(),
 }));
 
+// --- @/hooks/use-is-client ---
+// Default to true (post-hydration) so the real layout renders in tests.
+// The production code renders a skeleton until hydration; tests skip that
+// path by asserting directly against the hydrated output.
+const mockUseIsClient = jest.fn(() => true);
+jest.mock("@/hooks/use-is-client", () => ({
+  useIsClient: () => mockUseIsClient(),
+}));
+
 // --- @/components/dashboard/sidebar-helpers ---
 jest.mock("@/components/dashboard/sidebar-helpers", () => ({
   DASHBOARD_ALT_COOKIE: "dashboard-alt",
@@ -182,8 +191,10 @@ function setupMockSupabase() {
 describe("HomeClient", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // Re-apply the desktop default — jest.clearAllMocks() wipes implementations
+    // clearAllMocks only wipes call history — re-apply defaults so each
+    // test starts from a known return value.
     mockUseIsMobile.mockReturnValue(false);
+    mockUseIsClient.mockReturnValue(true);
     setupMockSupabase();
   });
 
@@ -214,6 +225,13 @@ describe("HomeClient", () => {
     it("renders empty state when no alts", () => {
       render(<HomeClient {...getDefaultProps({ alts: [] })} />);
       expect(screen.getByText("No alts yet")).toBeInTheDocument();
+    });
+
+    it("renders skeleton (neither AltsTable nor AltsCards) during SSR", () => {
+      mockUseIsClient.mockReturnValue(false);
+      render(<HomeClient {...getDefaultProps()} />);
+      expect(screen.queryByTestId("alts-table")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("alts-cards")).not.toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/app/(dashboard)/dashboard/__tests__/home-client.test.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/__tests__/home-client.test.tsx
@@ -30,6 +30,12 @@ jest.mock("../components/alts-table", () => ({
   ),
 }));
 
+jest.mock("../components/alts-cards", () => ({
+  AltsCards: (props: { alts: unknown[] }) => (
+    <div data-testid="alts-cards" data-count={props.alts?.length ?? 0} />
+  ),
+}));
+
 jest.mock("../components/live-match-bar", () => ({
   LiveMatchBar: (props: { match: { tournamentName: string } }) => (
     <div data-testid="live-match-bar">{props.match.tournamentName}</div>

--- a/apps/web/src/app/(dashboard)/dashboard/components/__tests__/alt-avatar-picker.test.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/__tests__/alt-avatar-picker.test.tsx
@@ -1,0 +1,143 @@
+// --- Mock modules before imports ---
+
+jest.mock("@/components/profile/sprite-picker", () => ({
+  SpritePicker: () => <div data-testid="sprite-picker" />,
+}));
+
+jest.mock("lucide-react", () => ({
+  Pencil: () => <svg data-testid="icon-pencil" />,
+}));
+
+jest.mock("@/components/ui/avatar", () => ({
+  Avatar: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <div data-testid="avatar" className={className}>
+      {children}
+    </div>
+  ),
+  AvatarImage: ({ src, alt }: { src: string; alt: string }) => (
+    <img data-testid="avatar-image" src={src} alt={alt} />
+  ),
+  AvatarFallback: ({ children }: { children: React.ReactNode }) => (
+    <span data-testid="avatar-fallback">{children}</span>
+  ),
+}));
+
+jest.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popover">{children}</div>
+  ),
+  PopoverTrigger: ({
+    children,
+    ...props
+  }: {
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <button data-testid="popover-trigger" {...props}>
+      {children}
+    </button>
+  ),
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popover-content">{children}</div>
+  ),
+}));
+
+jest.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) =>
+    args
+      .filter((a) => typeof a === "string")
+      .join(" ")
+      .trim(),
+}));
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+import { AltAvatarPicker } from "../alt-avatar-picker";
+
+describe("AltAvatarPicker", () => {
+  it("renders avatar fallback with the first character of username", () => {
+    render(
+      <AltAvatarPicker
+        altId={1}
+        username="ash"
+        avatarUrl={null}
+        onAvatarChange={jest.fn()}
+        refreshKey={0}
+      />
+    );
+    expect(screen.getByTestId("avatar-fallback")).toHaveTextContent("A");
+  });
+
+  it("renders avatar image when avatarUrl is provided", () => {
+    render(
+      <AltAvatarPicker
+        altId={1}
+        username="ash"
+        avatarUrl="https://example.com/a.png"
+        onAvatarChange={jest.fn()}
+        refreshKey={0}
+      />
+    );
+    const img = screen.getByTestId("avatar-image");
+    expect(img).toHaveAttribute("src", "https://example.com/a.png");
+  });
+
+  it("stops click propagation so parent row handlers don't fire", () => {
+    const parentClick = jest.fn();
+    render(
+      <div onClick={parentClick}>
+        <AltAvatarPicker
+          altId={1}
+          username="ash"
+          avatarUrl={null}
+          onAvatarChange={jest.fn()}
+          refreshKey={0}
+        />
+      </div>
+    );
+
+    fireEvent.click(screen.getByTestId("popover-trigger"));
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["Enter", "Enter"],
+    ["Space", " "],
+  ])("stops %s keydown propagation to parent", (_label, key) => {
+    const parentKeyDown = jest.fn();
+    render(
+      <div onKeyDown={parentKeyDown}>
+        <AltAvatarPicker
+          altId={1}
+          username="ash"
+          avatarUrl={null}
+          onAvatarChange={jest.fn()}
+          refreshKey={0}
+        />
+      </div>
+    );
+
+    fireEvent.keyDown(screen.getByTestId("popover-trigger"), { key });
+    expect(parentKeyDown).not.toHaveBeenCalled();
+  });
+
+  it("includes the SpritePicker inside the popover content", () => {
+    render(
+      <AltAvatarPicker
+        altId={1}
+        username="ash"
+        avatarUrl={null}
+        onAvatarChange={jest.fn()}
+        refreshKey={0}
+      />
+    );
+    expect(screen.getByTestId("sprite-picker")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(dashboard)/dashboard/components/__tests__/alt-visibility-toggle.test.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/__tests__/alt-visibility-toggle.test.tsx
@@ -1,0 +1,132 @@
+// --- Mock modules before imports ---
+
+const mockUpdateAltVisibilityAction = jest.fn();
+jest.mock("@/actions/profile", () => ({
+  updateAltVisibilityAction: (...args: unknown[]) =>
+    mockUpdateAltVisibilityAction(...args),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) =>
+    args
+      .filter((a) => typeof a === "string")
+      .join(" ")
+      .trim(),
+}));
+
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import React from "react";
+import { toast } from "sonner";
+
+import { AltVisibilityToggle } from "../alt-visibility-toggle";
+
+describe("AltVisibilityToggle", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUpdateAltVisibilityAction.mockResolvedValue({ success: true });
+  });
+
+  it("renders with a 'Make private' label when public", () => {
+    render(
+      <AltVisibilityToggle altId={1} isPublic={true} onRefresh={jest.fn()} />
+    );
+    expect(screen.getByLabelText("Make private")).toBeInTheDocument();
+  });
+
+  it("renders with a 'Make public' label when private", () => {
+    render(
+      <AltVisibilityToggle altId={1} isPublic={false} onRefresh={jest.fn()} />
+    );
+    expect(screen.getByLabelText("Make public")).toBeInTheDocument();
+  });
+
+  it("calls updateAltVisibilityAction with the flipped value on click", async () => {
+    render(
+      <AltVisibilityToggle altId={42} isPublic={true} onRefresh={jest.fn()} />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Make private"));
+    });
+
+    expect(mockUpdateAltVisibilityAction).toHaveBeenCalledWith(42, false);
+  });
+
+  it("calls onRefresh on success", async () => {
+    const onRefresh = jest.fn();
+    render(
+      <AltVisibilityToggle altId={1} isPublic={true} onRefresh={onRefresh} />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Make private"));
+    });
+
+    expect(onRefresh).toHaveBeenCalled();
+  });
+
+  it("shows a toast when the action fails", async () => {
+    mockUpdateAltVisibilityAction.mockResolvedValue({
+      success: false,
+      error: "Nope",
+    });
+    render(
+      <AltVisibilityToggle altId={1} isPublic={true} onRefresh={jest.fn()} />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Make private"));
+    });
+
+    expect(toast.error).toHaveBeenCalledWith("Nope");
+  });
+
+  it("stops click propagation so parent row handlers don't fire", () => {
+    const parentClick = jest.fn();
+    render(
+      <div onClick={parentClick}>
+        <AltVisibilityToggle altId={1} isPublic={true} onRefresh={jest.fn()} />
+      </div>
+    );
+
+    fireEvent.click(screen.getByLabelText("Make private"));
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["Enter", "Enter"],
+    ["Space", " "],
+  ])("stops %s keydown propagation to parent", (_label, key) => {
+    const parentKeyDown = jest.fn();
+    render(
+      <div onKeyDown={parentKeyDown}>
+        <AltVisibilityToggle altId={1} isPublic={true} onRefresh={jest.fn()} />
+      </div>
+    );
+
+    fireEvent.keyDown(screen.getByLabelText("Make private"), { key });
+    expect(parentKeyDown).not.toHaveBeenCalled();
+  });
+
+  it("does not fire a second request while a visibility update is pending", () => {
+    // Never-resolving promise keeps the transition pending for the test
+    mockUpdateAltVisibilityAction.mockReturnValue(new Promise(() => {}));
+
+    render(
+      <AltVisibilityToggle altId={1} isPublic={true} onRefresh={jest.fn()} />
+    );
+
+    const button = screen.getByLabelText("Make private");
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    // Initial click starts the request; subsequent clicks are ignored
+    // because the button is disabled during the pending transition.
+    expect(mockUpdateAltVisibilityAction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/app/(dashboard)/dashboard/components/__tests__/alts-cards.test.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/__tests__/alts-cards.test.tsx
@@ -172,7 +172,10 @@ function getDefaultProps(
 
 describe("AltsCards", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
+    // Safe defaults for async action mocks — tests can override per case
+    mockUpdateAltVisibilityAction.mockResolvedValue({ success: true });
+    mockDeleteAltAction.mockResolvedValue({ success: true });
     window.confirm = jest.fn(() => true);
   });
 
@@ -418,6 +421,40 @@ describe("AltsCards", () => {
     // Clicking the toggle should not bubble up to the header's onClick
     expect(props.onAltSelect).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ["Enter", "Enter"],
+    ["Space", " "],
+  ])(
+    "does not toggle expansion when %s is pressed on the visibility toggle",
+    (_name, key) => {
+      const props = getDefaultProps();
+      render(<AltsCards {...props} />);
+
+      // Keydown bubbles from the button to the header; the header guard
+      // should ignore events where currentTarget !== target.
+      fireEvent.keyDown(screen.getByLabelText("Make private"), { key });
+
+      expect(props.onAltSelect).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    ["Enter", "Enter"],
+    ["Space", " "],
+  ])(
+    "does not toggle expansion when %s is pressed on the avatar trigger",
+    (_name, key) => {
+      const props = getDefaultProps();
+      render(<AltsCards {...props} />);
+
+      // First popover-trigger belongs to the first card's avatar
+      const triggers = screen.getAllByTestId("popover-trigger");
+      fireEvent.keyDown(triggers[0]!, { key });
+
+      expect(props.onAltSelect).not.toHaveBeenCalled();
+    }
+  );
 
   // ── Avatar display ──────────────────────────────────────────────────────
 

--- a/apps/web/src/app/(dashboard)/dashboard/components/__tests__/alts-cards.test.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/__tests__/alts-cards.test.tsx
@@ -129,6 +129,8 @@ import { render, screen, fireEvent, act } from "@testing-library/react";
 import React from "react";
 import { toast } from "sonner";
 
+import { type PlayerRating } from "@trainers/supabase";
+
 import { AltsCards, type AltsCardsProps } from "../alts-cards";
 
 // ---------------------------------------------------------------------------
@@ -231,11 +233,9 @@ describe("AltsCards", () => {
       <AltsCards
         {...getDefaultProps({
           bulkRatings: {
-            1: { rating: 1500 } as AltsCardsProps["bulkRatings"] extends
-              | Record<number, infer R>
-              | undefined
-              ? R
-              : never,
+            // The component only reads `.rating`; stub the rest so tests
+            // stay readable without a full PlayerRating factory.
+            1: { rating: 1500 } as unknown as PlayerRating,
           },
         })}
       />

--- a/apps/web/src/app/(dashboard)/dashboard/components/__tests__/alts-cards.test.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/__tests__/alts-cards.test.tsx
@@ -1,0 +1,448 @@
+// --- Mock modules before imports ---
+
+// --- Mock deep dependency chains ---
+jest.mock("../teams-sub-table", () => ({
+  TeamsSubTable: (props: {
+    altId: number;
+    altUsername: string;
+    onDeleteAlt: () => void;
+    isMain: boolean;
+  }) => (
+    <div data-testid={`teams-sub-table-${props.altId}`}>
+      {props.altUsername}
+      {!props.isMain && (
+        <button data-testid="delete-alt-btn" onClick={props.onDeleteAlt}>
+          Delete alt
+        </button>
+      )}
+    </div>
+  ),
+}));
+
+// --- @/components/profile/sprite-picker ---
+jest.mock("@/components/profile/sprite-picker", () => ({
+  SpritePicker: () => <div data-testid="sprite-picker" />,
+}));
+
+// --- @/actions/profile ---
+const mockUpdateAltVisibilityAction = jest.fn();
+jest.mock("@/actions/profile", () => ({
+  updateAltVisibilityAction: (...args: unknown[]) =>
+    mockUpdateAltVisibilityAction(...args),
+}));
+
+// --- @/actions/alts ---
+const mockDeleteAltAction = jest.fn();
+jest.mock("@/actions/alts", () => ({
+  deleteAltAction: (...args: unknown[]) => mockDeleteAltAction(...args),
+}));
+
+// --- sonner ---
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn(), info: jest.fn() },
+}));
+
+// --- lucide-react ---
+jest.mock("lucide-react", () => ({
+  Pencil: () => <svg data-testid="icon-pencil" />,
+  Star: () => <svg data-testid="icon-star" />,
+  ChevronDown: () => <svg data-testid="icon-chevron-down" />,
+  ChevronRight: () => <svg data-testid="icon-chevron-right" />,
+}));
+
+// --- @/components/ui/avatar ---
+jest.mock("@/components/ui/avatar", () => ({
+  Avatar: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <div data-testid="avatar" className={className}>
+      {children}
+    </div>
+  ),
+  AvatarImage: ({ src, alt }: { src: string; alt: string }) => (
+    <img data-testid="avatar-image" src={src} alt={alt} />
+  ),
+  AvatarFallback: ({ children }: { children: React.ReactNode }) => (
+    <span data-testid="avatar-fallback">{children}</span>
+  ),
+}));
+
+// --- @/components/ui/badge ---
+jest.mock("@/components/ui/badge", () => ({
+  Badge: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <span data-testid="badge" className={className}>
+      {children}
+    </span>
+  ),
+}));
+
+// --- @/components/ui/popover ---
+jest.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popover">{children}</div>
+  ),
+  PopoverTrigger: ({
+    children,
+    ...props
+  }: {
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <button data-testid="popover-trigger" {...props}>
+      {children}
+    </button>
+  ),
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popover-content">{children}</div>
+  ),
+}));
+
+// --- @/lib/utils ---
+jest.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) =>
+    args
+      .filter((a) => typeof a === "string")
+      .join(" ")
+      .trim(),
+}));
+
+// --- tournament-helpers ---
+jest.mock("../../tournaments/tournament-helpers", () => ({
+  formatWinRate: (wins: number, losses: number) => {
+    const total = wins + losses;
+    if (total === 0) return "—";
+    return `${((wins / total) * 100).toFixed(1)}%`;
+  },
+}));
+
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import React from "react";
+import { toast } from "sonner";
+
+import { AltsCards, type AltsCardsProps } from "../alts-cards";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Alt = AltsCardsProps["alts"][number];
+
+function buildAlt(overrides: Partial<Alt> = {}): Alt {
+  return {
+    id: 1,
+    username: "ash_main",
+    avatar_url: null,
+    is_public: true,
+    ...overrides,
+  };
+}
+
+function getDefaultProps(
+  overrides: Partial<AltsCardsProps> = {}
+): AltsCardsProps {
+  return {
+    alts: [
+      buildAlt({ id: 1, username: "ash_main" }),
+      buildAlt({ id: 2, username: "ash_alt", is_public: false }),
+    ],
+    mainAltId: 1,
+    bulkStats: undefined,
+    bulkRatings: undefined,
+    selectedAltUsername: null,
+    onAltSelect: jest.fn(),
+    onRefresh: jest.fn(),
+    refreshKey: 0,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AltsCards", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.confirm = jest.fn(() => true);
+  });
+
+  // ── Rendering ───────────────────────────────────────────────────────────
+
+  it("renders a card for each alt", () => {
+    render(<AltsCards {...getDefaultProps()} />);
+    expect(screen.getByText("ash_main")).toBeInTheDocument();
+    expect(screen.getByText("ash_alt")).toBeInTheDocument();
+  });
+
+  it("renders stat labels on each card", () => {
+    render(<AltsCards {...getDefaultProps()} />);
+    // 2 alts → 2 of each stat label
+    expect(screen.getAllByText("Record")).toHaveLength(2);
+    expect(screen.getAllByText("Win %")).toHaveLength(2);
+    expect(screen.getAllByText("ELO")).toHaveLength(2);
+    expect(screen.getAllByText("Events")).toHaveLength(2);
+  });
+
+  it("shows Main badge on the main alt only", () => {
+    render(<AltsCards {...getDefaultProps()} />);
+    expect(screen.getAllByText("Main")).toHaveLength(1);
+  });
+
+  // ── Stats display ──────────────────────────────────────────────────────
+
+  it("displays zero values when no stats are provided", () => {
+    render(<AltsCards {...getDefaultProps()} />);
+    // Both cards show "0-0" for record
+    expect(screen.getAllByText("0-0")).toHaveLength(2);
+  });
+
+  it("displays stats when bulkStats are provided", () => {
+    render(
+      <AltsCards
+        {...getDefaultProps({
+          bulkStats: {
+            1: { matchWins: 10, matchLosses: 5, tournamentCount: 3 },
+            2: { matchWins: 2, matchLosses: 8, tournamentCount: 1 },
+          },
+        })}
+      />
+    );
+    expect(screen.getByText("10-5")).toBeInTheDocument();
+    expect(screen.getByText("66.7%")).toBeInTheDocument();
+    expect(screen.getByText("2-8")).toBeInTheDocument();
+    expect(screen.getByText("20.0%")).toBeInTheDocument();
+  });
+
+  it("displays rating when bulkRatings are provided", () => {
+    render(
+      <AltsCards
+        {...getDefaultProps({
+          bulkRatings: {
+            1: { rating: 1500 } as AltsCardsProps["bulkRatings"] extends
+              | Record<number, infer R>
+              | undefined
+              ? R
+              : never,
+          },
+        })}
+      />
+    );
+    expect(screen.getByText("1500")).toBeInTheDocument();
+  });
+
+  it("displays em-dash for missing rating", () => {
+    render(<AltsCards {...getDefaultProps()} />);
+    // Each alt with no rating + no record contributes two em-dashes
+    // (ELO and Win %). 2 alts × 2 em-dashes each = 4.
+    expect(screen.getAllByText("—")).toHaveLength(4);
+  });
+
+  // ── Expand/collapse ────────────────────────────────────────────────────
+
+  it("calls onAltSelect when a card header is clicked", () => {
+    const props = getDefaultProps();
+    render(<AltsCards {...props} />);
+    const header = screen.getByText("ash_alt").closest('[role="button"]')!;
+    fireEvent.click(header);
+    expect(props.onAltSelect).toHaveBeenCalledWith("ash_alt");
+  });
+
+  it("calls onAltSelect(null) when already-selected card header is clicked", () => {
+    const props = getDefaultProps({ selectedAltUsername: "ash_main" });
+    render(<AltsCards {...props} />);
+    // When expanded, TeamsSubTable mock also renders the username
+    const header = screen
+      .getAllByText("ash_main")[0]!
+      .closest('[role="button"]')!;
+    fireEvent.click(header);
+    expect(props.onAltSelect).toHaveBeenCalledWith(null);
+  });
+
+  it("renders TeamsSubTable when a card is expanded", () => {
+    render(
+      <AltsCards {...getDefaultProps({ selectedAltUsername: "ash_alt" })} />
+    );
+    expect(screen.getByTestId("teams-sub-table-2")).toBeInTheDocument();
+  });
+
+  it("does not render TeamsSubTable when no card is expanded", () => {
+    render(<AltsCards {...getDefaultProps()} />);
+    expect(screen.queryByTestId("teams-sub-table-1")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("teams-sub-table-2")).not.toBeInTheDocument();
+  });
+
+  // ── Keyboard navigation ────────────────────────────────────────────────
+
+  it("toggles expand on Enter key", () => {
+    const props = getDefaultProps();
+    render(<AltsCards {...props} />);
+    const header = screen.getByText("ash_alt").closest('[role="button"]')!;
+    fireEvent.keyDown(header, { key: "Enter" });
+    expect(props.onAltSelect).toHaveBeenCalledWith("ash_alt");
+  });
+
+  it("toggles expand on Space key", () => {
+    const props = getDefaultProps();
+    render(<AltsCards {...props} />);
+    const header = screen.getByText("ash_alt").closest('[role="button"]')!;
+    fireEvent.keyDown(header, { key: " " });
+    expect(props.onAltSelect).toHaveBeenCalledWith("ash_alt");
+  });
+
+  // ── Delete ──────────────────────────────────────────────────────────────
+
+  it("does not render delete button for main alt in TeamsSubTable", () => {
+    render(
+      <AltsCards {...getDefaultProps({ selectedAltUsername: "ash_main" })} />
+    );
+    expect(screen.queryByTestId("delete-alt-btn")).not.toBeInTheDocument();
+  });
+
+  it("calls deleteAltAction when delete button is clicked on a non-main alt", async () => {
+    mockDeleteAltAction.mockResolvedValue({ success: true });
+    const props = getDefaultProps({ selectedAltUsername: "ash_alt" });
+    render(<AltsCards {...props} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("delete-alt-btn"));
+    });
+
+    expect(mockDeleteAltAction).toHaveBeenCalledWith(2);
+    expect(toast.success).toHaveBeenCalledWith("Alt deleted");
+    expect(props.onRefresh).toHaveBeenCalled();
+  });
+
+  it("shows error toast when delete fails", async () => {
+    mockDeleteAltAction.mockResolvedValue({
+      success: false,
+      error: "Network error",
+    });
+    render(
+      <AltsCards {...getDefaultProps({ selectedAltUsername: "ash_alt" })} />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("delete-alt-btn"));
+    });
+
+    expect(toast.error).toHaveBeenCalledWith("Network error");
+  });
+
+  it("skips delete when user cancels the confirm prompt", async () => {
+    window.confirm = jest.fn(() => false);
+    render(
+      <AltsCards {...getDefaultProps({ selectedAltUsername: "ash_alt" })} />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("delete-alt-btn"));
+    });
+
+    expect(mockDeleteAltAction).not.toHaveBeenCalled();
+  });
+
+  // ── Visibility toggle ──────────────────────────────────────────────────
+
+  it("renders public/private toggle for each alt", () => {
+    render(<AltsCards {...getDefaultProps()} />);
+    expect(screen.getByLabelText("Make private")).toBeInTheDocument();
+    expect(screen.getByLabelText("Make public")).toBeInTheDocument();
+  });
+
+  it("calls updateAltVisibilityAction when toggle is clicked", async () => {
+    mockUpdateAltVisibilityAction.mockResolvedValue({ success: true });
+    const props = getDefaultProps();
+    render(<AltsCards {...props} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Make private"));
+    });
+
+    // ash_main is id=1, is_public=true → clicking toggles to false
+    expect(mockUpdateAltVisibilityAction).toHaveBeenCalledWith(1, false);
+  });
+
+  it("calls onRefresh after successful visibility toggle", async () => {
+    mockUpdateAltVisibilityAction.mockResolvedValue({ success: true });
+    const props = getDefaultProps();
+    render(<AltsCards {...props} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Make private"));
+    });
+
+    expect(props.onRefresh).toHaveBeenCalled();
+  });
+
+  it("shows error toast when visibility toggle fails", async () => {
+    mockUpdateAltVisibilityAction.mockResolvedValue({
+      success: false,
+      error: "Permission denied",
+    });
+    render(<AltsCards {...getDefaultProps()} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Make private"));
+    });
+
+    expect(toast.error).toHaveBeenCalledWith("Permission denied");
+  });
+
+  it("shows default error when visibility toggle fails without error message", async () => {
+    mockUpdateAltVisibilityAction.mockResolvedValue({ success: false });
+    render(<AltsCards {...getDefaultProps()} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Make private"));
+    });
+
+    expect(toast.error).toHaveBeenCalledWith("Failed to update visibility");
+  });
+
+  it("does not toggle expansion when the visibility toggle is clicked", () => {
+    const props = getDefaultProps();
+    render(<AltsCards {...props} />);
+
+    fireEvent.click(screen.getByLabelText("Make private"));
+
+    // Clicking the toggle should not bubble up to the header's onClick
+    expect(props.onAltSelect).not.toHaveBeenCalled();
+  });
+
+  // ── Avatar display ──────────────────────────────────────────────────────
+
+  it("shows avatar fallback with first character uppercase", () => {
+    render(<AltsCards {...getDefaultProps()} />);
+    const fallbacks = screen.getAllByTestId("avatar-fallback");
+    expect(fallbacks[0]).toHaveTextContent("A");
+    expect(fallbacks[1]).toHaveTextContent("A");
+  });
+
+  it("renders avatar image when avatar_url is provided", () => {
+    render(
+      <AltsCards
+        {...getDefaultProps({
+          alts: [
+            buildAlt({
+              id: 1,
+              username: "ash_main",
+              avatar_url: "https://example.com/avatar.png",
+            }),
+          ],
+        })}
+      />
+    );
+    const img = screen.getByTestId("avatar-image");
+    expect(img).toHaveAttribute("src", "https://example.com/avatar.png");
+  });
+});

--- a/apps/web/src/app/(dashboard)/dashboard/components/__tests__/alts-table.test.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/__tests__/alts-table.test.tsx
@@ -132,6 +132,8 @@ import { render, screen, fireEvent, act } from "@testing-library/react";
 import React from "react";
 import { toast } from "sonner";
 
+import { type PlayerRating } from "@trainers/supabase";
+
 import { AltsTable, type AltsTableProps } from "../alts-table";
 
 // ---------------------------------------------------------------------------
@@ -237,11 +239,9 @@ describe("AltsTable", () => {
       <AltsTable
         {...getDefaultProps({
           bulkRatings: {
-            1: { rating: 1500 } as AltsTableProps["bulkRatings"] extends
-              | Record<number, infer R>
-              | undefined
-              ? R
-              : never,
+            // The component only reads `.rating`; stub the rest so tests
+            // stay readable without a full PlayerRating factory.
+            1: { rating: 1500 } as unknown as PlayerRating,
           },
         })}
       />

--- a/apps/web/src/app/(dashboard)/dashboard/components/alt-avatar-picker.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/alt-avatar-picker.tsx
@@ -40,7 +40,12 @@ export function AltAvatarPicker({
     size === "md" ? "text-xs font-bold" : "text-[10px] font-bold";
 
   return (
-    <span onClick={(e) => e.stopPropagation()} className="shrink-0">
+    <span
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
+      onKeyUp={(e) => e.stopPropagation()}
+      className="shrink-0"
+    >
       <Popover key={`${altId}-${refreshKey}`}>
         <PopoverTrigger
           title="Change avatar"

--- a/apps/web/src/app/(dashboard)/dashboard/components/alt-avatar-picker.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/alt-avatar-picker.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { Pencil } from "lucide-react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover";
+import { SpritePicker } from "@/components/profile/sprite-picker";
+import { cn } from "@/lib/utils";
+
+interface AltAvatarPickerProps {
+  altId: number;
+  username: string;
+  avatarUrl: string | null;
+  onAvatarChange: () => void;
+  refreshKey: number;
+  size?: "sm" | "md";
+}
+
+/**
+ * Avatar + popover sprite-picker trigger used in both the desktop alts
+ * table and the mobile alts cards. The outer `<span>` stops click
+ * propagation so the row/card header doesn't toggle when the user opens
+ * the picker.
+ */
+export function AltAvatarPicker({
+  altId,
+  username,
+  avatarUrl,
+  onAvatarChange,
+  refreshKey,
+  size = "sm",
+}: AltAvatarPickerProps) {
+  const avatarClass = size === "md" ? "size-9" : "size-7";
+  const pencilClass = size === "md" ? "size-3" : "size-2.5";
+  const fallbackClass =
+    size === "md" ? "text-xs font-bold" : "text-[10px] font-bold";
+
+  return (
+    <span onClick={(e) => e.stopPropagation()} className="shrink-0">
+      <Popover key={`${altId}-${refreshKey}`}>
+        <PopoverTrigger
+          title="Change avatar"
+          className="group/avatar relative shrink-0 cursor-pointer"
+        >
+          <div className="relative overflow-hidden rounded-full">
+            <Avatar className={cn("ring-primary/10 ring-1", avatarClass)}>
+              {avatarUrl && <AvatarImage src={avatarUrl} alt={username} />}
+              <AvatarFallback
+                className={cn("bg-primary/10 text-primary", fallbackClass)}
+              >
+                {username.charAt(0).toUpperCase()}
+              </AvatarFallback>
+            </Avatar>
+            <div className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover/avatar:bg-black/40">
+              <Pencil
+                className={cn(
+                  "text-white opacity-0 drop-shadow-md transition-opacity group-hover/avatar:opacity-100",
+                  pencilClass
+                )}
+              />
+            </div>
+          </div>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-auto p-2">
+          <SpritePicker
+            altId={altId}
+            currentAvatarUrl={avatarUrl}
+            onAvatarChange={onAvatarChange}
+          />
+        </PopoverContent>
+      </Popover>
+    </span>
+  );
+}

--- a/apps/web/src/app/(dashboard)/dashboard/components/alt-row-helpers.ts
+++ b/apps/web/src/app/(dashboard)/dashboard/components/alt-row-helpers.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared helpers for the dashboard alt list rendering — used by both the
+ * desktop `AltsTable` and mobile `AltsCards` layouts.
+ */
+
+export function isHighWinRate(wins: number, losses: number): boolean {
+  const total = wins + losses;
+  if (total === 0) return false;
+  return wins / total >= 0.55;
+}

--- a/apps/web/src/app/(dashboard)/dashboard/components/alt-visibility-toggle.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/alt-visibility-toggle.tsx
@@ -20,9 +20,11 @@ interface AltVisibilityToggleProps {
 
 /**
  * Visibility toggle (public/private) dot used in both the desktop alts
- * table and the mobile alts cards. Stops click + keyboard event
- * propagation so the row/card header expand toggle doesn't fire when
- * the user changes visibility.
+ * table and the mobile alts cards. Stops click AND keyboard event
+ * propagation on the button so the row/card header expand toggle
+ * doesn't fire when the user changes visibility. The button is
+ * disabled while a visibility update is in flight to prevent
+ * rapid-click double submissions against a stale `isPublic` prop.
  */
 export function AltVisibilityToggle({
   altId,
@@ -30,7 +32,7 @@ export function AltVisibilityToggle({
   onRefresh,
   layout = "button",
 }: AltVisibilityToggleProps) {
-  const [, startVisibilityTransition] = useTransition();
+  const [isPending, startVisibilityTransition] = useTransition();
 
   const handleToggle = () => {
     startVisibilityTransition(async () => {
@@ -43,34 +45,38 @@ export function AltVisibilityToggle({
     });
   };
 
-  const dot = (
-    <span
-      className={cn(
-        "block size-2.5 rounded-full",
-        isPublic ? "bg-emerald-500" : "bg-neutral-300"
-      )}
-    />
-  );
+  const stopKeyboardPropagation = (e: React.KeyboardEvent) => {
+    e.stopPropagation();
+  };
 
-  const button = (
+  return (
     <button
       onClick={(e) => {
         e.stopPropagation();
+        if (isPending) return;
         handleToggle();
       }}
-      className={cn(layout === "button" ? "shrink-0 p-1" : "mx-auto block")}
+      onKeyDown={stopKeyboardPropagation}
+      onKeyUp={stopKeyboardPropagation}
+      disabled={isPending}
+      className={cn(
+        layout === "button" ? "shrink-0 p-1" : "mx-auto block",
+        isPending && "cursor-wait opacity-60"
+      )}
       aria-label={isPublic ? "Make private" : "Make public"}
+      aria-busy={isPending || undefined}
       title={
         isPublic
           ? "Public — click to make private"
           : "Private — click to make public"
       }
     >
-      {dot}
+      <span
+        className={cn(
+          "block size-2.5 rounded-full",
+          isPublic ? "bg-emerald-500" : "bg-neutral-300"
+        )}
+      />
     </button>
   );
-
-  // In the table layout the button lives inside a <td> that handles
-  // propagation; keep the button styled for a centered cell.
-  return button;
 }

--- a/apps/web/src/app/(dashboard)/dashboard/components/alt-visibility-toggle.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/alt-visibility-toggle.tsx
@@ -51,6 +51,7 @@ export function AltVisibilityToggle({
 
   return (
     <button
+      type="button"
       onClick={(e) => {
         e.stopPropagation();
         if (isPending) return;

--- a/apps/web/src/app/(dashboard)/dashboard/components/alt-visibility-toggle.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/alt-visibility-toggle.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useTransition } from "react";
+import { toast } from "sonner";
+
+import { cn } from "@/lib/utils";
+import { updateAltVisibilityAction } from "@/actions/profile";
+
+interface AltVisibilityToggleProps {
+  altId: number;
+  isPublic: boolean;
+  onRefresh: () => void;
+  /**
+   * How the toggle is laid out in the parent row. `"cell"` is the desktop
+   * table — a centered dot in a table cell. `"button"` is the mobile card
+   * header — a tappable button aligned with surrounding icons.
+   */
+  layout?: "cell" | "button";
+}
+
+/**
+ * Visibility toggle (public/private) dot used in both the desktop alts
+ * table and the mobile alts cards. Stops click + keyboard event
+ * propagation so the row/card header expand toggle doesn't fire when
+ * the user changes visibility.
+ */
+export function AltVisibilityToggle({
+  altId,
+  isPublic,
+  onRefresh,
+  layout = "button",
+}: AltVisibilityToggleProps) {
+  const [, startVisibilityTransition] = useTransition();
+
+  const handleToggle = () => {
+    startVisibilityTransition(async () => {
+      const result = await updateAltVisibilityAction(altId, !isPublic);
+      if (result.success) {
+        onRefresh();
+      } else {
+        toast.error(result.error ?? "Failed to update visibility");
+      }
+    });
+  };
+
+  const dot = (
+    <span
+      className={cn(
+        "block size-2.5 rounded-full",
+        isPublic ? "bg-emerald-500" : "bg-neutral-300"
+      )}
+    />
+  );
+
+  const button = (
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        handleToggle();
+      }}
+      className={cn(layout === "button" ? "shrink-0 p-1" : "mx-auto block")}
+      aria-label={isPublic ? "Make private" : "Make public"}
+      title={
+        isPublic
+          ? "Public — click to make private"
+          : "Private — click to make public"
+      }
+    >
+      {dot}
+    </button>
+  );
+
+  // In the table layout the button lives inside a <td> that handles
+  // propagation; keep the button styled for a centered cell.
+  return button;
+}

--- a/apps/web/src/app/(dashboard)/dashboard/components/alts-cards.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/alts-cards.tsx
@@ -248,7 +248,7 @@ export function AltsCards({
         onAltSelect(null);
         onRefresh();
       } else {
-        toast.error(result.error);
+        toast.error(result.error ?? "Failed to delete alt");
       }
     });
   };

--- a/apps/web/src/app/(dashboard)/dashboard/components/alts-cards.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/alts-cards.tsx
@@ -1,24 +1,19 @@
 "use client";
 
 import { useTransition } from "react";
-import { Pencil, Star, ChevronDown, ChevronRight } from "lucide-react";
+import { Star, ChevronDown, ChevronRight } from "lucide-react";
 import { toast } from "sonner";
 
 import { type AltStats, type PlayerRating } from "@trainers/supabase";
 
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
-import {
-  Popover,
-  PopoverTrigger,
-  PopoverContent,
-} from "@/components/ui/popover";
-import { SpritePicker } from "@/components/profile/sprite-picker";
 import { cn } from "@/lib/utils";
-import { updateAltVisibilityAction } from "@/actions/profile";
 import { deleteAltAction } from "@/actions/alts";
 import { formatWinRate } from "../tournaments/tournament-helpers";
 
+import { AltAvatarPicker } from "./alt-avatar-picker";
+import { AltVisibilityToggle } from "./alt-visibility-toggle";
+import { isHighWinRate } from "./alt-row-helpers";
 import { TeamsSubTable } from "./teams-sub-table";
 
 // ---------------------------------------------------------------------------
@@ -45,16 +40,6 @@ export interface AltsCardsProps {
   onAltSelect: (username: string | null) => void;
   onRefresh: () => void;
   refreshKey: number;
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function isHighWinRate(wins: number, losses: number): boolean {
-  const total = wins + losses;
-  if (total === 0) return false;
-  return wins / total >= 0.55;
 }
 
 // ---------------------------------------------------------------------------
@@ -117,24 +102,11 @@ function AltCard({
   altStats: AltStats | undefined;
   altRating: PlayerRating | null;
 }) {
-  const [, startVisibilityTransition] = useTransition();
-
   const wins = altStats?.matchWins ?? 0;
   const losses = altStats?.matchLosses ?? 0;
   const events = altStats?.tournamentCount ?? 0;
   const rating = altRating?.rating ?? null;
   const noRecord = wins + losses === 0;
-
-  const handleVisibilityChange = (checked: boolean) => {
-    startVisibilityTransition(async () => {
-      const result = await updateAltVisibilityAction(alt.id, checked);
-      if (result.success) {
-        onRefresh();
-      } else {
-        toast.error(result.error ?? "Failed to update visibility");
-      }
-    });
-  };
 
   return (
     <div
@@ -162,36 +134,14 @@ function AltCard({
         aria-expanded={isExpanded}
         className="hover:bg-muted/40 flex cursor-pointer items-center gap-3 px-3 py-3"
       >
-        {/* Avatar with sprite picker — stop propagation so header tap doesn't fire */}
-        <span onClick={(e) => e.stopPropagation()} className="shrink-0">
-          <Popover key={`${alt.id}-${refreshKey}`}>
-            <PopoverTrigger
-              title="Change avatar"
-              className="group/avatar relative shrink-0 cursor-pointer"
-            >
-              <div className="relative overflow-hidden rounded-full">
-                <Avatar className="ring-primary/10 size-9 ring-1">
-                  {alt.avatar_url && (
-                    <AvatarImage src={alt.avatar_url} alt={alt.username} />
-                  )}
-                  <AvatarFallback className="bg-primary/10 text-primary text-xs font-bold">
-                    {alt.username.charAt(0).toUpperCase()}
-                  </AvatarFallback>
-                </Avatar>
-                <div className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover/avatar:bg-black/40">
-                  <Pencil className="size-3 text-white opacity-0 drop-shadow-md transition-opacity group-hover/avatar:opacity-100" />
-                </div>
-              </div>
-            </PopoverTrigger>
-            <PopoverContent align="start" className="w-auto p-2">
-              <SpritePicker
-                altId={alt.id}
-                currentAvatarUrl={alt.avatar_url}
-                onAvatarChange={onRefresh}
-              />
-            </PopoverContent>
-          </Popover>
-        </span>
+        <AltAvatarPicker
+          altId={alt.id}
+          username={alt.username}
+          avatarUrl={alt.avatar_url}
+          onAvatarChange={onRefresh}
+          refreshKey={refreshKey}
+          size="md"
+        />
 
         {/* Username + Main badge */}
         <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
@@ -211,27 +161,11 @@ function AltCard({
           )}
         </div>
 
-        {/* Public toggle — stop propagation */}
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            handleVisibilityChange(!alt.is_public);
-          }}
-          className="shrink-0 p-1"
-          aria-label={alt.is_public ? "Make private" : "Make public"}
-          title={
-            alt.is_public
-              ? "Public — tap to make private"
-              : "Private — tap to make public"
-          }
-        >
-          <span
-            className={cn(
-              "block size-2.5 rounded-full",
-              alt.is_public ? "bg-emerald-500" : "bg-neutral-300"
-            )}
-          />
-        </button>
+        <AltVisibilityToggle
+          altId={alt.id}
+          isPublic={alt.is_public}
+          onRefresh={onRefresh}
+        />
 
         {/* Chevron */}
         {isExpanded ? (

--- a/apps/web/src/app/(dashboard)/dashboard/components/alts-cards.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/alts-cards.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import { useTransition } from "react";
+import { Pencil, Star, ChevronDown, ChevronRight } from "lucide-react";
+import { toast } from "sonner";
+
+import type { AltStats, PlayerRating } from "@trainers/supabase";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover";
+import { SpritePicker } from "@/components/profile/sprite-picker";
+import { cn } from "@/lib/utils";
+import { updateAltVisibilityAction } from "@/actions/profile";
+import { deleteAltAction } from "@/actions/alts";
+import { formatWinRate } from "../tournaments/tournament-helpers";
+
+import { TeamsSubTable } from "./teams-sub-table";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type Alt = {
+  id: number;
+  username: string;
+  avatar_url: string | null;
+  is_public: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface AltsCardsProps {
+  alts: Alt[];
+  mainAltId: number | null;
+  bulkStats: Record<number, AltStats> | undefined;
+  bulkRatings: Record<number, PlayerRating> | undefined;
+  selectedAltUsername: string | null;
+  onAltSelect: (username: string | null) => void;
+  onRefresh: () => void;
+  refreshKey: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isHighWinRate(wins: number, losses: number): boolean {
+  const total = wins + losses;
+  if (total === 0) return false;
+  return wins / total >= 0.55;
+}
+
+// ---------------------------------------------------------------------------
+// StatCell — label + value pair inside the card stat grid
+// ---------------------------------------------------------------------------
+
+function StatCell({
+  label,
+  value,
+  muted = false,
+  accent = false,
+}: {
+  label: string;
+  value: string | number;
+  muted?: boolean;
+  accent?: boolean;
+}) {
+  return (
+    <div className="flex flex-col items-start">
+      <span className="text-muted-foreground text-[10px] font-medium tracking-wide uppercase">
+        {label}
+      </span>
+      <span
+        className={cn(
+          "font-mono text-sm font-semibold tabular-nums",
+          muted && "text-muted-foreground font-normal",
+          accent && "text-teal-600 dark:text-teal-400"
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AltCard
+// ---------------------------------------------------------------------------
+
+function AltCard({
+  alt,
+  isMain,
+  isExpanded,
+  onToggle,
+  onDelete,
+  isDeletePending,
+  onRefresh,
+  refreshKey,
+  altStats,
+  altRating,
+}: {
+  alt: Alt;
+  isMain: boolean;
+  isExpanded: boolean;
+  onToggle: () => void;
+  onDelete: () => void;
+  isDeletePending: boolean;
+  onRefresh: () => void;
+  refreshKey: number;
+  altStats: AltStats | undefined;
+  altRating: PlayerRating | null;
+}) {
+  const [, startVisibilityTransition] = useTransition();
+
+  const wins = altStats?.matchWins ?? 0;
+  const losses = altStats?.matchLosses ?? 0;
+  const events = altStats?.tournamentCount ?? 0;
+  const rating = altRating?.rating ?? null;
+  const noRecord = wins + losses === 0;
+
+  const handleVisibilityChange = (checked: boolean) => {
+    startVisibilityTransition(async () => {
+      const result = await updateAltVisibilityAction(alt.id, checked);
+      if (result.success) {
+        onRefresh();
+      } else {
+        toast.error(result.error ?? "Failed to update visibility");
+      }
+    });
+  };
+
+  return (
+    <div
+      className={cn(
+        "ring-foreground/10 bg-card overflow-hidden rounded-xl ring-1 transition-colors",
+        isExpanded && "bg-muted/20"
+      )}
+    >
+      {/* Header — tappable region toggles expansion */}
+      <div
+        onClick={onToggle}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onToggle();
+          }
+        }}
+        role="button"
+        tabIndex={0}
+        aria-expanded={isExpanded}
+        className="hover:bg-muted/40 flex cursor-pointer items-center gap-3 px-3 py-3"
+      >
+        {/* Avatar with sprite picker — stop propagation so header tap doesn't fire */}
+        <span onClick={(e) => e.stopPropagation()} className="shrink-0">
+          <Popover key={`${alt.id}-${refreshKey}`}>
+            <PopoverTrigger
+              title="Change avatar"
+              className="group/avatar relative shrink-0 cursor-pointer"
+            >
+              <div className="relative overflow-hidden rounded-full">
+                <Avatar className="ring-primary/10 size-9 ring-1">
+                  {alt.avatar_url && (
+                    <AvatarImage src={alt.avatar_url} alt={alt.username} />
+                  )}
+                  <AvatarFallback className="bg-primary/10 text-primary text-xs font-bold">
+                    {alt.username.charAt(0).toUpperCase()}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover/avatar:bg-black/40">
+                  <Pencil className="size-3 text-white opacity-0 drop-shadow-md transition-opacity group-hover/avatar:opacity-100" />
+                </div>
+              </div>
+            </PopoverTrigger>
+            <PopoverContent align="start" className="w-auto p-2">
+              <SpritePicker
+                altId={alt.id}
+                currentAvatarUrl={alt.avatar_url}
+                onAvatarChange={onRefresh}
+              />
+            </PopoverContent>
+          </Popover>
+        </span>
+
+        {/* Username + Main badge */}
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+          <span
+            className={cn(
+              "truncate text-sm font-semibold",
+              isExpanded && "font-bold"
+            )}
+          >
+            {alt.username}
+          </span>
+          {isMain && (
+            <Badge className="gap-0.5 border-amber-500/30 bg-amber-500/10 px-1.5 py-0 text-[10px] text-amber-600 dark:text-amber-400">
+              <Star className="size-2.5 fill-current" />
+              Main
+            </Badge>
+          )}
+        </div>
+
+        {/* Public toggle — stop propagation */}
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            handleVisibilityChange(!alt.is_public);
+          }}
+          className="shrink-0 p-1"
+          aria-label={alt.is_public ? "Make private" : "Make public"}
+          title={
+            alt.is_public
+              ? "Public — tap to make private"
+              : "Private — tap to make public"
+          }
+        >
+          <span
+            className={cn(
+              "block size-2.5 rounded-full",
+              alt.is_public ? "bg-emerald-500" : "bg-neutral-300"
+            )}
+          />
+        </button>
+
+        {/* Chevron */}
+        {isExpanded ? (
+          <ChevronDown className="text-muted-foreground size-4 shrink-0" />
+        ) : (
+          <ChevronRight className="text-muted-foreground size-4 shrink-0" />
+        )}
+      </div>
+
+      {/* Stats grid */}
+      <div className="grid grid-cols-4 gap-2 px-3 pb-3">
+        <StatCell label="Record" value={`${wins}-${losses}`} muted={noRecord} />
+        <StatCell
+          label="Win %"
+          value={formatWinRate(wins, losses)}
+          muted={noRecord}
+          accent={!noRecord && isHighWinRate(wins, losses)}
+        />
+        <StatCell label="ELO" value={rating ?? "—"} muted={rating === null} />
+        <StatCell label="Events" value={events} muted={events === 0} />
+      </div>
+
+      {/* Expanded detail */}
+      {isExpanded && (
+        <div className="bg-muted/20 border-t">
+          <TeamsSubTable
+            altId={alt.id}
+            altUsername={alt.username}
+            isMain={isMain}
+            onDeleteAlt={onDelete}
+            isDeletePending={isDeletePending}
+            refreshKey={refreshKey}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AltsCards
+// ---------------------------------------------------------------------------
+
+export function AltsCards({
+  alts,
+  mainAltId,
+  bulkStats,
+  bulkRatings,
+  selectedAltUsername,
+  onAltSelect,
+  onRefresh,
+  refreshKey,
+}: AltsCardsProps) {
+  const [isPending, startTransition] = useTransition();
+
+  const expandedAlt = selectedAltUsername
+    ? alts.find((a) => a.username === selectedAltUsername)
+    : null;
+  const expandedAltId = expandedAlt?.id ?? null;
+
+  const handleToggleExpand = (alt: Alt) => {
+    if (selectedAltUsername === alt.username) {
+      onAltSelect(null);
+    } else {
+      onAltSelect(alt.username);
+    }
+  };
+
+  const handleDelete = (altId: number, altName: string) => {
+    if (mainAltId === altId) {
+      toast.error("Cannot delete your main alt.");
+      return;
+    }
+    if (!confirm(`Delete alt "${altName}"? This cannot be undone.`)) return;
+
+    startTransition(async () => {
+      const result = await deleteAltAction(altId);
+      if (result.success) {
+        toast.success("Alt deleted");
+        onAltSelect(null);
+        onRefresh();
+      } else {
+        toast.error(result.error);
+      }
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      {alts.map((alt) => (
+        <AltCard
+          key={alt.id}
+          alt={alt}
+          isMain={mainAltId === alt.id}
+          isExpanded={expandedAltId === alt.id}
+          onToggle={() => handleToggleExpand(alt)}
+          onDelete={() => handleDelete(alt.id, alt.username)}
+          isDeletePending={isPending}
+          onRefresh={onRefresh}
+          refreshKey={refreshKey}
+          altStats={bulkStats?.[alt.id]}
+          altRating={bulkRatings?.[alt.id] ?? null}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/dashboard/components/alts-cards.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/alts-cards.tsx
@@ -4,7 +4,7 @@ import { useTransition } from "react";
 import { Pencil, Star, ChevronDown, ChevronRight } from "lucide-react";
 import { toast } from "sonner";
 
-import type { AltStats, PlayerRating } from "@trainers/supabase";
+import { type AltStats, type PlayerRating } from "@trainers/supabase";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
@@ -147,6 +147,11 @@ function AltCard({
       <div
         onClick={onToggle}
         onKeyDown={(e) => {
+          // Ignore keydowns that bubble from nested interactive controls
+          // (avatar popover trigger, visibility toggle) — keyboard users
+          // shouldn't accidentally expand/collapse by pressing Space/Enter
+          // on those inner buttons.
+          if (e.currentTarget !== e.target) return;
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
             onToggle();

--- a/apps/web/src/app/(dashboard)/dashboard/components/alts-table.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/alts-table.tsx
@@ -1,24 +1,19 @@
 "use client";
 
 import { useTransition } from "react";
-import { Pencil, Star, ChevronDown, ChevronRight } from "lucide-react";
+import { Star, ChevronDown, ChevronRight } from "lucide-react";
 import { toast } from "sonner";
 
-import type { AltStats, PlayerRating } from "@trainers/supabase";
+import { type AltStats, type PlayerRating } from "@trainers/supabase";
 
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
-import {
-  Popover,
-  PopoverTrigger,
-  PopoverContent,
-} from "@/components/ui/popover";
-import { SpritePicker } from "@/components/profile/sprite-picker";
 import { cn } from "@/lib/utils";
-import { updateAltVisibilityAction } from "@/actions/profile";
 import { deleteAltAction } from "@/actions/alts";
 import { formatWinRate } from "../tournaments/tournament-helpers";
 
+import { AltAvatarPicker } from "./alt-avatar-picker";
+import { AltVisibilityToggle } from "./alt-visibility-toggle";
+import { isHighWinRate } from "./alt-row-helpers";
 import { TeamsSubTable } from "./teams-sub-table";
 
 // ---------------------------------------------------------------------------
@@ -48,32 +43,6 @@ export interface AltsTableProps {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function isHighWinRate(wins: number, losses: number): boolean {
-  const total = wins + losses;
-  if (total === 0) return false;
-  return wins / total >= 0.55;
-}
-
-// ---------------------------------------------------------------------------
-// PublicDot
-// ---------------------------------------------------------------------------
-
-function PublicDot({ isPublic }: { isPublic: boolean }) {
-  return (
-    <span
-      className={cn(
-        "mx-auto block size-2 rounded-full",
-        isPublic ? "bg-emerald-500" : "bg-neutral-300"
-      )}
-      title={isPublic ? "Public" : "Private"}
-    />
-  );
-}
-
-// ---------------------------------------------------------------------------
 // AltTableRow
 // ---------------------------------------------------------------------------
 
@@ -100,24 +69,11 @@ function AltTableRow({
   altStats: AltStats | undefined;
   altRating: PlayerRating | null;
 }) {
-  const [, startVisibilityTransition] = useTransition();
-
   const wins = altStats?.matchWins ?? 0;
   const losses = altStats?.matchLosses ?? 0;
   const events = altStats?.tournamentCount ?? 0;
 
   const rating = altRating?.rating ?? null;
-
-  const handleVisibilityChange = (checked: boolean) => {
-    startVisibilityTransition(async () => {
-      const result = await updateAltVisibilityAction(alt.id, checked);
-      if (result.success) {
-        onRefresh();
-      } else {
-        toast.error(result.error ?? "Failed to update visibility");
-      }
-    });
-  };
 
   return (
     <>
@@ -142,36 +98,14 @@ function AltTableRow({
         {/* Handle */}
         <td className="w-[200px] px-3 py-2.5">
           <div className="flex items-center gap-2">
-            {/* Avatar with sprite picker — stop propagation so row click doesn't fire */}
-            <span onClick={(e) => e.stopPropagation()}>
-              <Popover key={`${alt.id}-${refreshKey}`}>
-                <PopoverTrigger
-                  title="Change avatar"
-                  className="group/avatar relative shrink-0 cursor-pointer"
-                >
-                  <div className="relative overflow-hidden rounded-full">
-                    <Avatar className="ring-primary/10 size-7 ring-1">
-                      {alt.avatar_url && (
-                        <AvatarImage src={alt.avatar_url} alt={alt.username} />
-                      )}
-                      <AvatarFallback className="bg-primary/10 text-primary text-[10px] font-bold">
-                        {alt.username.charAt(0).toUpperCase()}
-                      </AvatarFallback>
-                    </Avatar>
-                    <div className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover/avatar:bg-black/40">
-                      <Pencil className="size-2.5 text-white opacity-0 drop-shadow-md transition-opacity group-hover/avatar:opacity-100" />
-                    </div>
-                  </div>
-                </PopoverTrigger>
-                <PopoverContent align="start" className="w-auto p-2">
-                  <SpritePicker
-                    altId={alt.id}
-                    currentAvatarUrl={alt.avatar_url}
-                    onAvatarChange={onRefresh}
-                  />
-                </PopoverContent>
-              </Popover>
-            </span>
+            <AltAvatarPicker
+              altId={alt.id}
+              username={alt.username}
+              avatarUrl={alt.avatar_url}
+              onAvatarChange={onRefresh}
+              refreshKey={refreshKey}
+              size="sm"
+            />
             <span className="flex min-w-0 items-center gap-1.5">
               <span
                 className={cn(
@@ -256,18 +190,12 @@ function AltTableRow({
           className="px-3 py-2.5 text-center"
           onClick={(e) => e.stopPropagation()}
         >
-          <button
-            onClick={() => handleVisibilityChange(!alt.is_public)}
-            className="mx-auto block"
-            aria-label={alt.is_public ? "Make private" : "Make public"}
-            title={
-              alt.is_public
-                ? "Public — click to make private"
-                : "Private — click to make public"
-            }
-          >
-            <PublicDot isPublic={alt.is_public} />
-          </button>
+          <AltVisibilityToggle
+            altId={alt.id}
+            isPublic={alt.is_public}
+            onRefresh={onRefresh}
+            layout="cell"
+          />
         </td>
 
         {/* Chevron */}

--- a/apps/web/src/app/(dashboard)/dashboard/components/alts-table.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/alts-table.tsx
@@ -81,6 +81,11 @@ function AltTableRow({
       <tr
         onClick={onToggle}
         onKeyDown={(e) => {
+          // Ignore keydowns that bubble from nested interactive controls
+          // (avatar popover trigger, visibility toggle) — keyboard users
+          // shouldn't accidentally expand/collapse by pressing Space/Enter
+          // on those inner buttons. Matches the card variant's guard.
+          if (e.currentTarget !== e.target) return;
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
             onToggle();

--- a/apps/web/src/app/(dashboard)/dashboard/components/alts-table.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/alts-table.tsx
@@ -277,7 +277,7 @@ export function AltsTable({
         onAltSelect(null);
         onRefresh();
       } else {
-        toast.error(result.error);
+        toast.error(result.error ?? "Failed to delete alt");
       }
     });
   };

--- a/apps/web/src/app/(dashboard)/dashboard/home-client.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/home-client.tsx
@@ -242,11 +242,15 @@ export function HomeClient({
           avoids mounting the desktop `AltsTable` for mobile users
           (which would briefly mount `TeamsSubTable` if a selected alt
           is restored from the cookie and cause a visible layout shift).
-          The skeleton keeps the viewport stable until the hook settles. */}
+          The skeleton's height is derived from `alts.length` (rows are
+          ~42px, cards are larger on mobile but we don't know the viewport
+          yet pre-hydration) so swapping it for the real layout avoids
+          CLS. */}
       {!isClient ? (
         <div
           aria-hidden
-          className="bg-muted/30 h-40 animate-pulse rounded-lg"
+          className="bg-muted/30 animate-pulse rounded-lg"
+          style={{ height: `${Math.max(alts.length, 1) * 42 + 32}px` }}
         />
       ) : isMobile ? (
         <AltsCards

--- a/apps/web/src/app/(dashboard)/dashboard/home-client.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/home-client.tsx
@@ -15,6 +15,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 
+import { AltsCards } from "./components/alts-cards";
 import { AltsTable } from "./components/alts-table";
 import { CreateAltForm } from "./components/create-alt-form";
 
@@ -232,17 +233,33 @@ export function HomeClient({
         </div>
       )}
 
-      {/* Alts table with inline stats and expand/collapse */}
-      <AltsTable
-        alts={alts}
-        mainAltId={mainAltId}
-        bulkStats={initialBulkStats}
-        bulkRatings={initialBulkRatings}
-        selectedAltUsername={selectedAlt}
-        onAltSelect={handleAltSelect}
-        onRefresh={handleRefresh}
-        refreshKey={refreshKey}
-      />
+      {/* Mobile: card list */}
+      <div className="md:hidden">
+        <AltsCards
+          alts={alts}
+          mainAltId={mainAltId}
+          bulkStats={initialBulkStats}
+          bulkRatings={initialBulkRatings}
+          selectedAltUsername={selectedAlt}
+          onAltSelect={handleAltSelect}
+          onRefresh={handleRefresh}
+          refreshKey={refreshKey}
+        />
+      </div>
+
+      {/* Desktop: table with inline stats and expand/collapse */}
+      <div className="hidden md:block">
+        <AltsTable
+          alts={alts}
+          mainAltId={mainAltId}
+          bulkStats={initialBulkStats}
+          bulkRatings={initialBulkRatings}
+          selectedAltUsername={selectedAlt}
+          onAltSelect={handleAltSelect}
+          onRefresh={handleRefresh}
+          refreshKey={refreshKey}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/home-client.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/home-client.tsx
@@ -5,9 +5,10 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Plus, Users } from "lucide-react";
 
-import type { AltStats, PlayerRating } from "@trainers/supabase";
+import { type AltStats, type PlayerRating } from "@trainers/supabase";
 
 import { useSupabase } from "@/lib/supabase";
+import { useIsMobile } from "@/hooks/use-mobile";
 import {
   DASHBOARD_ALT_COOKIE,
   COOKIE_MAX_AGE,
@@ -51,6 +52,7 @@ export function HomeClient({
 }: DashboardHomeClientProps) {
   const router = useRouter();
   const supabase = useSupabase();
+  const isMobile = useIsMobile();
   const toastShown = useRef(false);
   const refreshTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
   const [selectedAlt, setSelectedAlt] = useState<string | null>(
@@ -233,8 +235,10 @@ export function HomeClient({
         </div>
       )}
 
-      {/* Mobile: card list */}
-      <div className="md:hidden">
+      {/* Conditionally render one layout — mounting both would duplicate
+          useSupabaseQuery calls in the expanded TeamsSubTable and cause
+          scroll/layout conflicts on mobile. */}
+      {isMobile ? (
         <AltsCards
           alts={alts}
           mainAltId={mainAltId}
@@ -245,10 +249,7 @@ export function HomeClient({
           onRefresh={handleRefresh}
           refreshKey={refreshKey}
         />
-      </div>
-
-      {/* Desktop: table with inline stats and expand/collapse */}
-      <div className="hidden md:block">
+      ) : (
         <AltsTable
           alts={alts}
           mainAltId={mainAltId}
@@ -259,7 +260,7 @@ export function HomeClient({
           onRefresh={handleRefresh}
           refreshKey={refreshKey}
         />
-      </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/home-client.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/home-client.tsx
@@ -8,6 +8,7 @@ import { Plus, Users } from "lucide-react";
 import { type AltStats, type PlayerRating } from "@trainers/supabase";
 
 import { useSupabase } from "@/lib/supabase";
+import { useIsClient } from "@/hooks/use-is-client";
 import { useIsMobile } from "@/hooks/use-mobile";
 import {
   DASHBOARD_ALT_COOKIE,
@@ -52,6 +53,7 @@ export function HomeClient({
 }: DashboardHomeClientProps) {
   const router = useRouter();
   const supabase = useSupabase();
+  const isClient = useIsClient();
   const isMobile = useIsMobile();
   const toastShown = useRef(false);
   const refreshTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
@@ -235,10 +237,18 @@ export function HomeClient({
         </div>
       )}
 
-      {/* Conditionally render one layout — mounting both would duplicate
-          useSupabaseQuery calls in the expanded TeamsSubTable and cause
-          scroll/layout conflicts on mobile. */}
-      {isMobile ? (
+      {/* Render exactly one layout. `useIsMobile()` returns false during
+          SSR + initial hydration, so gating on `useIsClient()` first
+          avoids mounting the desktop `AltsTable` for mobile users
+          (which would briefly mount `TeamsSubTable` if a selected alt
+          is restored from the cookie and cause a visible layout shift).
+          The skeleton keeps the viewport stable until the hook settles. */}
+      {!isClient ? (
+        <div
+          aria-hidden
+          className="bg-muted/30 h-40 animate-pulse rounded-lg"
+        />
+      ) : isMobile ? (
         <AltsCards
           alts={alts}
           mainAltId={mainAltId}

--- a/apps/web/src/app/(dashboard)/dashboard/layout.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/layout.tsx
@@ -169,7 +169,7 @@ export default async function DashboardLayout({
   }));
 
   return (
-    <SidebarProvider className="max-h-svh overflow-hidden">
+    <SidebarProvider>
       <DashboardSidebar
         user={sidebarUser}
         communities={sidebarCommunities}
@@ -181,7 +181,7 @@ export default async function DashboardLayout({
         hasTeamBuilderAccess={teamBuilderAccess.access === true}
         variant="inset"
       />
-      <SidebarInset className="overflow-hidden">{children}</SidebarInset>
+      <SidebarInset>{children}</SidebarInset>
     </SidebarProvider>
   );
 }


### PR DESCRIPTION
## Summary

- The "Your Alts" table on the dashboard was awkward on small viewports — columns overflowed and the expanded detail got squeezed.
- On `<md` (mobile) viewports, the alt list now renders as a stacked card per alt: avatar + username + Main badge in the header, a 4-column stat strip (Record, Win %, ELO, Events), the public-visibility toggle dot, and the same expand chevron / `TeamsSubTable` detail below.
- On `md+` viewports, the existing `AltsTable` is unchanged.

## Implementation

- New `apps/web/src/app/(dashboard)/dashboard/components/alts-cards.tsx` — `AltsCards` with the same prop shape as `AltsTable` (alts, bulkStats, bulkRatings, selectedAltUsername, onAltSelect, onRefresh, refreshKey). Reuses `TeamsSubTable` for the expanded detail.
- `home-client.tsx` now renders both: `AltsCards` wrapped in `md:hidden` and `AltsTable` in `hidden md:block`.
- Interactive parity maintained: tap-to-expand, avatar sprite picker popover (with `stopPropagation` so the row doesn't toggle), public/private visibility toggle, delete alt in the footer of the expanded detail.

## Test plan

- [ ] Visit `/dashboard` at <768px viewport → alts render as cards with correct stats
- [ ] Tap an alt card header → expands to show teams + recent results + footer buttons
- [ ] Tap avatar → sprite picker opens without toggling expansion
- [ ] Tap public dot → toggles visibility without toggling expansion
- [ ] "Delete alt" (non-main) still works in the expanded footer
- [ ] ≥768px → desktop table renders unchanged

## Checks

- `pnpm --filter @trainers/web typecheck` ✅
- `pnpm --filter @trainers/web lint` ✅
- `pnpm format:check` ✅
- UI not verified in a running browser (dev server not started locally).

https://claude.ai/code/session_01Bt9b9FNk2TJmuP6Rm8vwjK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile dashboard now shows alternate accounts as expandable cards; desktop retains table view.
  * In-card avatar picker and a visibility toggle for each alt for quick avatar/visibility changes.

* **Bug Fixes**
  * Improved keyboard and click handling so interactions inside cards/buttons don’t accidentally toggle selection.
  * Prevents deleting the primary alt and surfaces clear success/error feedback.

* **Tests**
  * Added extensive UI tests covering cards, avatar picker, visibility toggle, expand/collapse, and delete flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->