### PR TITLE
feat(dashboard): mobile responsiveness pass 2 — team builder + settings overflow fixes

### DIFF
--- a/apps/web/src/app/(dashboard)/dashboard/alts/[username]/teams/[teamId]/layout.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/alts/[username]/teams/[teamId]/layout.tsx
@@ -79,38 +79,42 @@ export default async function TeamWorkspaceLayout({
 
   return (
     <div className="flex h-full min-h-dvh flex-col">
-      {/* Header bar */}
-      <header className="bg-background/95 sticky top-0 z-30 flex h-12 shrink-0 items-center gap-2 border-b px-3 backdrop-blur md:px-4">
-        <SidebarTrigger className="-ml-1" />
-        {/* Breadcrumb — "← Teams / Team Name" */}
-        <Link
-          href={teamsUrl}
-          className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm transition-colors"
-          aria-label="Back to Teams"
-        >
-          <ChevronLeft className="size-4" />
-          <span className="hidden sm:inline">Teams</span>
-        </Link>
-        <span className="text-muted-foreground text-sm">/</span>
-        <span className="max-w-[120px] truncate text-sm font-medium sm:max-w-none">
-          {team.name}
-        </span>
+      {/* Header bar — stacks to two rows on phones (breadcrumb above actions)
+          since SidebarTrigger + breadcrumb + name + format badge + 3 action
+          buttons can't fit in one h-12 row at 393px. Single row at md+. */}
+      <header className="bg-background/95 sticky top-0 z-30 shrink-0 border-b backdrop-blur">
+        <div className="flex flex-col gap-1 px-3 py-2 md:h-12 md:flex-row md:items-center md:gap-2 md:px-4 md:py-0">
+          {/* Identity row — breadcrumb + name + format badge */}
+          <div className="flex min-w-0 items-center gap-2">
+            <SidebarTrigger className="-ml-1" />
+            <Link
+              href={teamsUrl}
+              className="text-muted-foreground hover:text-foreground flex shrink-0 items-center gap-1 text-sm transition-colors"
+              aria-label="Back to Teams"
+            >
+              <ChevronLeft className="size-4" />
+              <span className="hidden sm:inline">Teams</span>
+            </Link>
+            <span className="text-muted-foreground shrink-0 text-sm">/</span>
+            <span className="min-w-0 truncate text-sm font-medium">
+              {team.name}
+            </span>
+            {format && (
+              <Badge variant="secondary" className="shrink-0 text-xs">
+                {format.label}
+              </Badge>
+            )}
+          </div>
 
-        {/* Format badge */}
-        {format && (
-          <Badge variant="secondary" className="text-xs">
-            {format.label}
-          </Badge>
-        )}
-
-        {/* Action buttons — pushed to the right */}
-        <div className="ml-auto">
-          <WorkspaceActions
-            team={team}
-            altId={alt.id}
-            handle={username}
-            formatId={format?.id}
-          />
+          {/* Action buttons — own row on phone, right-aligned at md+ */}
+          <div className="md:ml-auto">
+            <WorkspaceActions
+              team={team}
+              altId={alt.id}
+              handle={username}
+              formatId={format?.id}
+            />
+          </div>
         </div>
       </header>
 

--- a/apps/web/src/app/(dashboard)/dashboard/alts/[username]/teams/[teamId]/loading.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/alts/[username]/teams/[teamId]/loading.tsx
@@ -7,21 +7,24 @@ import { Skeleton } from "@/components/ui/skeleton";
 export default function TeamWorkspaceLoading() {
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      {/* Header bar skeleton */}
-      <header className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
-        {/* Breadcrumb skeleton */}
-        <Skeleton className="h-4 w-20" />
-        <span className="text-muted-foreground text-sm">/</span>
-        <Skeleton className="h-4 w-32" />
-        {/* Format badge skeleton */}
-        <Skeleton className="h-5 w-16 rounded-full" />
+      {/* Header bar skeleton — mirrors the responsive layout in layout.tsx:
+          stacks identity above actions on phones, single h-12 row at md+. */}
+      <header className="shrink-0 border-b">
+        <div className="flex flex-col gap-1 px-3 py-2 md:h-12 md:flex-row md:items-center md:gap-2 md:px-4 md:py-0">
+          {/* Identity row */}
+          <div className="flex min-w-0 items-center gap-2">
+            <Skeleton className="h-4 w-20" />
+            <span className="text-muted-foreground text-sm">/</span>
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-5 w-16 rounded-full" />
+          </div>
 
-        {/* Action buttons skeleton */}
-        <div className="ml-auto flex items-center gap-2">
-          <Skeleton className="h-8 w-20" />
-          <Skeleton className="h-8 w-20" />
-          <Skeleton className="h-8 w-16" />
-          <Skeleton className="h-8 w-22" />
+          {/* Action buttons row */}
+          <div className="flex items-center gap-2 md:ml-auto">
+            <Skeleton className="h-8 w-20" />
+            <Skeleton className="h-8 w-20" />
+            <Skeleton className="h-8 w-16" />
+          </div>
         </div>
       </header>
 

--- a/apps/web/src/app/(dashboard)/dashboard/alts/[username]/teams/loading.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/alts/[username]/teams/loading.tsx
@@ -6,9 +6,11 @@ export default function TeamsLoading() {
     <>
       <PageHeader title="Teams" />
       <div className="flex flex-1 flex-col gap-6 p-4 md:p-6">
-        {/* Toolbar skeleton */}
-        <div className="flex items-center justify-between gap-4">
-          <div className="flex items-center gap-1.5">
+        {/* Toolbar skeleton — pills + actions don't fit a single 393px row,
+            stack them on phones, side-by-side at sm+. Pills wrap so they
+            never extend past viewport. */}
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+          <div className="flex flex-wrap items-center gap-1.5">
             <Skeleton className="h-7 w-10 rounded-full" />
             <Skeleton className="h-7 w-24 rounded-full" />
             <Skeleton className="h-7 w-28 rounded-full" />

--- a/apps/web/src/app/(dashboard)/dashboard/settings/layout.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/layout.tsx
@@ -51,6 +51,7 @@ export default function SettingsLayout({
                     key={tab.href}
                     href={tab.href}
                     aria-label={tab.label}
+                    aria-current={isActive ? "page" : undefined}
                     className={cn(
                       "flex shrink-0 items-center gap-2 border-b-2 px-3 py-2 text-sm font-medium transition-colors sm:px-4",
                       isActive

--- a/apps/web/src/app/(dashboard)/dashboard/settings/layout.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/layout.tsx
@@ -38,7 +38,10 @@ export default function SettingsLayout({
           </div>
 
           <div className="border-b">
-            <nav className="flex gap-0">
+            <nav
+              className="-mx-4 flex gap-0 overflow-x-auto px-4 sm:mx-0 sm:overflow-visible sm:px-0"
+              aria-label="Settings sections"
+            >
               {tabs.map((tab) => {
                 const isActive = pathname.startsWith(tab.href);
                 const Icon = tab.icon;
@@ -47,15 +50,16 @@ export default function SettingsLayout({
                   <Link
                     key={tab.href}
                     href={tab.href}
+                    aria-label={tab.label}
                     className={cn(
-                      "flex items-center gap-2 border-b-2 px-4 py-2 text-sm font-medium transition-colors",
+                      "flex shrink-0 items-center gap-2 border-b-2 px-3 py-2 text-sm font-medium transition-colors sm:px-4",
                       isActive
                         ? "border-primary text-foreground"
                         : "text-muted-foreground hover:text-foreground border-transparent"
                     )}
                   >
-                    <Icon className="h-4 w-4" />
-                    {tab.label}
+                    <Icon className="h-4 w-4 shrink-0" />
+                    <span>{tab.label}</span>
                   </Link>
                 );
               })}

--- a/apps/web/src/components/dashboard/tournament-history-table.tsx
+++ b/apps/web/src/components/dashboard/tournament-history-table.tsx
@@ -307,7 +307,7 @@ export function TournamentHistoryTable({ data }: TournamentHistoryTableProps) {
           onChange={(e) => setGlobalFilter(e.target.value)}
           className="max-w-sm"
         />
-        <div className="flex gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row">
           {uniqueAlts.length > 1 && (
             <Select
               value={
@@ -317,7 +317,7 @@ export function TournamentHistoryTable({ data }: TournamentHistoryTableProps) {
                 altFilter?.setFilterValue(value === "all" ? undefined : value)
               }
             >
-              <SelectTrigger className="w-[180px]">
+              <SelectTrigger className="w-full sm:w-[180px]">
                 <SelectValue placeholder="Filter by alt" />
               </SelectTrigger>
               <SelectContent>
@@ -341,7 +341,7 @@ export function TournamentHistoryTable({ data }: TournamentHistoryTableProps) {
                 )
               }
             >
-              <SelectTrigger className="w-[180px]">
+              <SelectTrigger className="w-full sm:w-[180px]">
                 <SelectValue placeholder="Filter by format" />
               </SelectTrigger>
               <SelectContent>

--- a/apps/web/src/components/team-builder/__tests__/analytics-rail.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/analytics-rail.test.tsx
@@ -311,7 +311,7 @@ describe("AnalyticsRail", () => {
     );
   });
 
-  it("container uses the fixed 460px width class", () => {
+  it("container is full-width on phones and pinned to 460px at lg+", () => {
     const charizard = makePokemon();
     render(
       <AnalyticsRail
@@ -322,7 +322,8 @@ describe("AnalyticsRail", () => {
     );
 
     const rail = screen.getByTestId("analytics-rail");
-    expect(rail.className).toContain("w-rail");
+    expect(rail.className).toContain("w-full");
+    expect(rail.className).toContain("lg:w-rail");
     expect(rail.className).toContain("flex-shrink-0");
   });
 

--- a/apps/web/src/components/team-builder/__tests__/editor-header-band.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/editor-header-band.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest } from "@jest/globals";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 
@@ -62,30 +62,17 @@ jest.mock("next/image", () => ({
 // FieldButton would appear twice — once in the desktop row, once in the
 // mobile grid — breaking single-match queries like `getByRole`.
 //
-// `renderBand` removes the layout that's not under test from the DOM after
-// render. Default is `desktop` (matches the prior `useIsMobile()`-based test
-// behavior); mobile layout tests pass `layout: "mobile"` to flip it.
-type Layout = "desktop" | "mobile";
+// Tests use `within()`-scoped queries to target one layout's container at a
+// time, keeping queries layout-aware without mutating DOM nodes that React
+// rendered. Identity/meta zone elements (sprite, name, gender, level, etc.)
+// only render once in Row 1, so they remain queryable via the top-level
+// `screen` queries.
+function desktopFields() {
+  return within(screen.getByTestId("editor-header-band-desktop-fields"));
+}
 
-function trimToLayout(layout: Layout) {
-  const desktopFields = document.querySelector(
-    '[data-testid="editor-header-band-desktop-fields"]'
-  );
-  const mobileFields = document.querySelector(
-    '[data-testid="editor-header-band-mobile-fields"]'
-  );
-  if (layout === "desktop" && mobileFields) {
-    mobileFields.remove();
-  }
-  if (layout === "mobile" && desktopFields) {
-    // The divider preceding the desktop-fields div has no own testid; remove
-    // it via DOM proximity so the layout stays visually clean during tests.
-    const divider = desktopFields.previousElementSibling;
-    if (divider?.getAttribute("aria-hidden") === "true") {
-      divider.remove();
-    }
-    desktopFields.remove();
-  }
+function mobileFields() {
+  return within(screen.getByTestId("editor-header-band-mobile-fields"));
 }
 
 import { getValidAbilities, getSpeciesTypes } from "@trainers/pokemon";
@@ -162,8 +149,7 @@ function renderBand(
     onOpenNaturePicker: () => void;
     onOpenSpeciesPicker?: () => void;
   }> = {},
-  formatOverride: Parameters<typeof EditorHeaderBand>[0]["format"] = svFormat,
-  layout: Layout = "desktop"
+  formatOverride: Parameters<typeof EditorHeaderBand>[0]["format"] = svFormat
 ) {
   const handlers = {
     onOpenAbilityPicker: jest.fn(),
@@ -179,7 +165,6 @@ function renderBand(
       {...handlers}
     />
   );
-  trimToLayout(layout);
   return handlers;
 }
 
@@ -224,43 +209,53 @@ describe("EditorHeaderBand", () => {
         tera_type: "Ghost",
         nature: "Jolly",
       });
-      expect(screen.getByText("Intimidate")).toBeInTheDocument();
-      expect(screen.getByText("Choice Scarf")).toBeInTheDocument();
-      expect(screen.getByText("Ghost")).toBeInTheDocument();
-      expect(screen.getByText("Jolly")).toBeInTheDocument();
+      // Build fields render in both layouts (`hidden md:flex` / `md:hidden`);
+      // scope to one container so each value matches a single button.
+      expect(desktopFields().getByText("Intimidate")).toBeInTheDocument();
+      expect(desktopFields().getByText("Choice Scarf")).toBeInTheDocument();
+      expect(desktopFields().getByText("Ghost")).toBeInTheDocument();
+      expect(desktopFields().getByText("Jolly")).toBeInTheDocument();
     });
 
     it("renders 'None' when item or tera type is null", () => {
       renderBand({ held_item: null, tera_type: null });
-      // Two "None" labels — one for item, one for tera
-      expect(screen.getAllByText("None")).toHaveLength(2);
+      // Two "None" labels per layout — one for item, one for tera.
+      expect(desktopFields().getAllByText("None")).toHaveLength(2);
     });
 
     it("calls onOpenAbilityPicker when the Ability button is clicked", async () => {
       const user = userEvent.setup();
       const handlers = renderBand();
-      await user.click(screen.getByRole("button", { name: /Edit Ability/ }));
+      await user.click(
+        desktopFields().getByRole("button", { name: /Edit Ability/ })
+      );
       expect(handlers.onOpenAbilityPicker).toHaveBeenCalledTimes(1);
     });
 
     it("calls onOpenItemPicker when the Item button is clicked", async () => {
       const user = userEvent.setup();
       const handlers = renderBand();
-      await user.click(screen.getByRole("button", { name: /Edit Item/ }));
+      await user.click(
+        desktopFields().getByRole("button", { name: /Edit Item/ })
+      );
       expect(handlers.onOpenItemPicker).toHaveBeenCalledTimes(1);
     });
 
     it("calls onOpenTeraPicker when the Tera button is clicked", async () => {
       const user = userEvent.setup();
       const handlers = renderBand();
-      await user.click(screen.getByRole("button", { name: /Edit Tera/ }));
+      await user.click(
+        desktopFields().getByRole("button", { name: /Edit Tera/ })
+      );
       expect(handlers.onOpenTeraPicker).toHaveBeenCalledTimes(1);
     });
 
     it("calls onOpenNaturePicker when the Nature button is clicked", async () => {
       const user = userEvent.setup();
       const handlers = renderBand();
-      await user.click(screen.getByRole("button", { name: /Edit Nature/ }));
+      await user.click(
+        desktopFields().getByRole("button", { name: /Edit Nature/ })
+      );
       expect(handlers.onOpenNaturePicker).toHaveBeenCalledTimes(1);
     });
   });
@@ -318,16 +313,17 @@ describe("EditorHeaderBand", () => {
       const user = userEvent.setup();
       const handlers = renderBand({ ability: "Levitate" });
 
-      // Ability text is present
-      expect(screen.getByText("Levitate")).toBeInTheDocument();
+      // Ability text is present in the desktop layout (also in mobile, but
+      // scoping to one container keeps the assertion exact-match).
+      expect(desktopFields().getByText("Levitate")).toBeInTheDocument();
 
-      // No Edit Ability button should exist
+      // No Edit Ability button should exist in either layout
       expect(
-        screen.queryByRole("button", { name: /Edit Ability/ })
+        desktopFields().queryByRole("button", { name: /Edit Ability/ })
       ).not.toBeInTheDocument();
 
       // Clicking the static label should not trigger the handler
-      await user.click(screen.getByText("Levitate"));
+      await user.click(desktopFields().getByText("Levitate"));
       expect(handlers.onOpenAbilityPicker).not.toHaveBeenCalled();
     });
   });
@@ -412,9 +408,10 @@ describe("EditorHeaderBand", () => {
           onOpenNaturePicker={jest.fn()}
         />
       );
-      // Trim mobile copy so the desktop Tera button is the only match.
-      trimToLayout("desktop");
-      const teraBtn = screen.getByRole("button", { name: /Edit Tera/ });
+      // Scope to one layout — Tera button renders in both desktop and mobile.
+      const teraBtn = desktopFields().getByRole("button", {
+        name: /Edit Tera/,
+      });
       expect(teraBtn).toBeInTheDocument();
       await user.click(teraBtn);
       expect(onOpenTeraPicker).toHaveBeenCalledTimes(1);
@@ -458,10 +455,6 @@ describe("EditorHeaderBand", () => {
           detailsPopover={{ teamId: 1, onUpdate }}
         />
       );
-      // Identity controls live in Row 1 only (no duplication), but build
-      // fields render twice — strip the mobile copy so build-field queries
-      // don't double-match in tests that aren't layout-aware.
-      trimToLayout("desktop");
       return onUpdate;
     }
 
@@ -649,50 +642,43 @@ describe("EditorHeaderBand", () => {
     });
 
     it("renders one set of FieldButtons inside the mobile grid", () => {
-      const handlers = renderBand({}, {}, svFormat, "mobile");
-      // After trimToLayout("mobile"), the desktop branch is removed — every
-      // FieldButton query should match exactly once.
+      renderBand();
+      // Scope queries to the mobile container — each FieldButton renders
+      // exactly once inside it.
       expect(
-        screen.getAllByRole("button", { name: /Edit Ability/ })
-      ).toHaveLength(1);
+        mobileFields().getByRole("button", { name: /Edit Ability/ })
+      ).toBeInTheDocument();
       expect(
-        screen.getAllByRole("button", { name: /Edit Item/ })
-      ).toHaveLength(1);
+        mobileFields().getByRole("button", { name: /Edit Item/ })
+      ).toBeInTheDocument();
       expect(
-        screen.getAllByRole("button", { name: /Edit Tera/ })
-      ).toHaveLength(1);
+        mobileFields().getByRole("button", { name: /Edit Tera/ })
+      ).toBeInTheDocument();
       expect(
-        screen.getAllByRole("button", { name: /Edit Nature/ })
-      ).toHaveLength(1);
-      // The remaining buttons are inside the mobile grid container.
-      const mobileFields = screen.getByTestId(
-        "editor-header-band-mobile-fields"
-      );
-      expect(
-        mobileFields.querySelector('button[aria-label*="Edit Ability"]')
-      ).not.toBeNull();
-      // Ignore the unused handlers reference.
-      void handlers;
+        mobileFields().getByRole("button", { name: /Edit Nature/ })
+      ).toBeInTheDocument();
     });
 
     it("clicking the mobile Ability cell triggers onOpenAbilityPicker", async () => {
       const user = userEvent.setup();
-      const handlers = renderBand({}, {}, svFormat, "mobile");
-      await user.click(screen.getByRole("button", { name: /Edit Ability/ }));
+      const handlers = renderBand();
+      await user.click(
+        mobileFields().getByRole("button", { name: /Edit Ability/ })
+      );
       expect(handlers.onOpenAbilityPicker).toHaveBeenCalledTimes(1);
     });
 
     it("collapses Nature to span both columns when the format has no Tera", () => {
-      // Render in mobile layout with a Champions (Gen 10) format — formatHasTera
-      // returns false, so the mobile grid renders Ability+Item on row 1 and
-      // Nature spanning both columns on row 2.
+      // Render with a Champions (Gen 10) format — formatHasTera returns false,
+      // so the mobile grid renders Ability+Item on row 1 and Nature spanning
+      // both columns on row 2.
       const championsFormat = { ...svFormat, generation: 10 };
-      renderBand({}, {}, championsFormat, "mobile");
-      const mobileFields = screen.getByTestId(
+      renderBand({}, {}, championsFormat);
+      const mobileContainer = screen.getByTestId(
         "editor-header-band-mobile-fields"
       );
       // The col-span-2 cell wraps the Nature field exclusively.
-      const natureCell = mobileFields.querySelector(".col-span-2");
+      const natureCell = mobileContainer.querySelector(".col-span-2");
       expect(natureCell).not.toBeNull();
       expect(natureCell!.textContent).toContain("Nature");
     });

--- a/apps/web/src/components/team-builder/__tests__/editor-header-band.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/editor-header-band.test.tsx
@@ -317,9 +317,12 @@ describe("EditorHeaderBand", () => {
       // scoping to one container keeps the assertion exact-match).
       expect(desktopFields().getByText("Levitate")).toBeInTheDocument();
 
-      // No Edit Ability button should exist in either layout
+      // No Edit Ability button should exist in either layout — assert both.
       expect(
         desktopFields().queryByRole("button", { name: /Edit Ability/ })
+      ).not.toBeInTheDocument();
+      expect(
+        mobileFields().queryByRole("button", { name: /Edit Ability/ })
       ).not.toBeInTheDocument();
 
       // Clicking the static label should not trigger the handler

--- a/apps/web/src/components/team-builder/__tests__/editor-header-band.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/editor-header-band.test.tsx
@@ -56,6 +56,14 @@ jest.mock("next/image", () => ({
   },
 }));
 
+// useIsMobile drives the desktop-row vs mobile-stack layout decision. Default
+// to desktop (false) so existing tests that count one button per loadout
+// field keep passing — opt into mobile=true in the dedicated layout tests.
+const mockUseIsMobile = jest.fn<() => boolean>();
+jest.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => mockUseIsMobile(),
+}));
+
 import { getValidAbilities, getSpeciesTypes } from "@trainers/pokemon";
 
 import { EditorHeaderBand } from "../editor-header-band";
@@ -153,6 +161,10 @@ beforeEach(() => {
   // Reset to multi-ability default so each test starts from a known baseline.
   mockedGetValidAbilities.mockReturnValue(["Intimidate", "Flash Fire"]);
   mockedGetSpeciesTypes.mockReturnValue(["Fire", "Dark"]);
+  // Default to desktop layout so the build-field buttons render once inline
+  // (matches the assumption of every existing test). Mobile layout tests opt
+  // into mockUseIsMobile.mockReturnValue(true).
+  mockUseIsMobile.mockReturnValue(false);
 });
 
 // =============================================================================
@@ -582,6 +594,51 @@ describe("EditorHeaderBand", () => {
       expect(screen.queryByLabelText("Male")).not.toBeInTheDocument();
       expect(screen.queryByLabelText("Shiny (off)")).not.toBeInTheDocument();
       expect(screen.queryByLabelText("Level")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("mobile layout", () => {
+    it("renders the build-fields grid below Row 1 when isMobile is true", () => {
+      mockUseIsMobile.mockReturnValue(true);
+      renderBand();
+      expect(
+        screen.getByTestId("editor-header-band-mobile-fields")
+      ).toBeInTheDocument();
+    });
+
+    it("does not render the mobile build-fields grid on desktop", () => {
+      mockUseIsMobile.mockReturnValue(false);
+      renderBand();
+      expect(
+        screen.queryByTestId("editor-header-band-mobile-fields")
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders each loadout button exactly once on mobile (no duplication)", () => {
+      mockUseIsMobile.mockReturnValue(true);
+      renderBand();
+      // Each FieldButton has aria-label "Edit <Label>" — one occurrence per
+      // field whether the layout is desktop-row or mobile-grid.
+      expect(
+        screen.getAllByRole("button", { name: /Edit Ability/ })
+      ).toHaveLength(1);
+      expect(
+        screen.getAllByRole("button", { name: /Edit Item/ })
+      ).toHaveLength(1);
+      expect(
+        screen.getAllByRole("button", { name: /Edit Tera/ })
+      ).toHaveLength(1);
+      expect(
+        screen.getAllByRole("button", { name: /Edit Nature/ })
+      ).toHaveLength(1);
+    });
+
+    it("clicking the mobile Ability cell still triggers onOpenAbilityPicker", async () => {
+      mockUseIsMobile.mockReturnValue(true);
+      const user = userEvent.setup();
+      const handlers = renderBand();
+      await user.click(screen.getByRole("button", { name: /Edit Ability/ }));
+      expect(handlers.onOpenAbilityPicker).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/web/src/components/team-builder/__tests__/editor-header-band.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/editor-header-band.test.tsx
@@ -56,13 +56,37 @@ jest.mock("next/image", () => ({
   },
 }));
 
-// useIsMobile drives the desktop-row vs mobile-stack layout decision. Default
-// to desktop (false) so existing tests that count one button per loadout
-// field keep passing — opt into mobile=true in the dedicated layout tests.
-const mockUseIsMobile = jest.fn<() => boolean>();
-jest.mock("@/hooks/use-mobile", () => ({
-  useIsMobile: () => mockUseIsMobile(),
-}));
+// EditorHeaderBand renders both layouts simultaneously and uses Tailwind
+// `hidden md:flex` / `md:hidden` to show only the right one per viewport.
+// JSDOM doesn't compute Tailwind class styles, so without intervention every
+// FieldButton would appear twice — once in the desktop row, once in the
+// mobile grid — breaking single-match queries like `getByRole`.
+//
+// `renderBand` removes the layout that's not under test from the DOM after
+// render. Default is `desktop` (matches the prior `useIsMobile()`-based test
+// behavior); mobile layout tests pass `layout: "mobile"` to flip it.
+type Layout = "desktop" | "mobile";
+
+function trimToLayout(layout: Layout) {
+  const desktopFields = document.querySelector(
+    '[data-testid="editor-header-band-desktop-fields"]'
+  );
+  const mobileFields = document.querySelector(
+    '[data-testid="editor-header-band-mobile-fields"]'
+  );
+  if (layout === "desktop" && mobileFields) {
+    mobileFields.remove();
+  }
+  if (layout === "mobile" && desktopFields) {
+    // The divider preceding the desktop-fields div has no own testid; remove
+    // it via DOM proximity so the layout stays visually clean during tests.
+    const divider = desktopFields.previousElementSibling;
+    if (divider?.getAttribute("aria-hidden") === "true") {
+      divider.remove();
+    }
+    desktopFields.remove();
+  }
+}
 
 import { getValidAbilities, getSpeciesTypes } from "@trainers/pokemon";
 
@@ -138,7 +162,8 @@ function renderBand(
     onOpenNaturePicker: () => void;
     onOpenSpeciesPicker?: () => void;
   }> = {},
-  formatOverride: Parameters<typeof EditorHeaderBand>[0]["format"] = svFormat
+  formatOverride: Parameters<typeof EditorHeaderBand>[0]["format"] = svFormat,
+  layout: Layout = "desktop"
 ) {
   const handlers = {
     onOpenAbilityPicker: jest.fn(),
@@ -154,6 +179,7 @@ function renderBand(
       {...handlers}
     />
   );
+  trimToLayout(layout);
   return handlers;
 }
 
@@ -161,10 +187,6 @@ beforeEach(() => {
   // Reset to multi-ability default so each test starts from a known baseline.
   mockedGetValidAbilities.mockReturnValue(["Intimidate", "Flash Fire"]);
   mockedGetSpeciesTypes.mockReturnValue(["Fire", "Dark"]);
-  // Default to desktop layout so the build-field buttons render once inline
-  // (matches the assumption of every existing test). Mobile layout tests opt
-  // into mockUseIsMobile.mockReturnValue(true).
-  mockUseIsMobile.mockReturnValue(false);
 });
 
 // =============================================================================
@@ -390,6 +412,8 @@ describe("EditorHeaderBand", () => {
           onOpenNaturePicker={jest.fn()}
         />
       );
+      // Trim mobile copy so the desktop Tera button is the only match.
+      trimToLayout("desktop");
       const teraBtn = screen.getByRole("button", { name: /Edit Tera/ });
       expect(teraBtn).toBeInTheDocument();
       await user.click(teraBtn);
@@ -434,6 +458,10 @@ describe("EditorHeaderBand", () => {
           detailsPopover={{ teamId: 1, onUpdate }}
         />
       );
+      // Identity controls live in Row 1 only (no duplication), but build
+      // fields render twice — strip the mobile copy so build-field queries
+      // don't double-match in tests that aren't layout-aware.
+      trimToLayout("desktop");
       return onUpdate;
     }
 
@@ -598,27 +626,32 @@ describe("EditorHeaderBand", () => {
   });
 
   describe("mobile layout", () => {
-    it("renders the build-fields grid below Row 1 when isMobile is true", () => {
-      mockUseIsMobile.mockReturnValue(true);
-      renderBand();
+    it("renders both desktop and mobile build-fields containers", () => {
+      // CSS-based responsive layout — both branches mount in the DOM (one is
+      // hidden via Tailwind `hidden md:flex` / `md:hidden` per viewport).
+      // Render WITHOUT trimming so we can assert both testids exist.
+      render(
+        <EditorHeaderBand
+          pokemon={buildPokemon()}
+          format={svFormat}
+          onOpenAbilityPicker={jest.fn()}
+          onOpenItemPicker={jest.fn()}
+          onOpenTeraPicker={jest.fn()}
+          onOpenNaturePicker={jest.fn()}
+        />
+      );
+      expect(
+        screen.getByTestId("editor-header-band-desktop-fields")
+      ).toBeInTheDocument();
       expect(
         screen.getByTestId("editor-header-band-mobile-fields")
       ).toBeInTheDocument();
     });
 
-    it("does not render the mobile build-fields grid on desktop", () => {
-      mockUseIsMobile.mockReturnValue(false);
-      renderBand();
-      expect(
-        screen.queryByTestId("editor-header-band-mobile-fields")
-      ).not.toBeInTheDocument();
-    });
-
-    it("renders each loadout button exactly once on mobile (no duplication)", () => {
-      mockUseIsMobile.mockReturnValue(true);
-      renderBand();
-      // Each FieldButton has aria-label "Edit <Label>" — one occurrence per
-      // field whether the layout is desktop-row or mobile-grid.
+    it("renders one set of FieldButtons inside the mobile grid", () => {
+      const handlers = renderBand({}, {}, svFormat, "mobile");
+      // After trimToLayout("mobile"), the desktop branch is removed — every
+      // FieldButton query should match exactly once.
       expect(
         screen.getAllByRole("button", { name: /Edit Ability/ })
       ).toHaveLength(1);
@@ -631,14 +664,37 @@ describe("EditorHeaderBand", () => {
       expect(
         screen.getAllByRole("button", { name: /Edit Nature/ })
       ).toHaveLength(1);
+      // The remaining buttons are inside the mobile grid container.
+      const mobileFields = screen.getByTestId(
+        "editor-header-band-mobile-fields"
+      );
+      expect(
+        mobileFields.querySelector('button[aria-label*="Edit Ability"]')
+      ).not.toBeNull();
+      // Ignore the unused handlers reference.
+      void handlers;
     });
 
-    it("clicking the mobile Ability cell still triggers onOpenAbilityPicker", async () => {
-      mockUseIsMobile.mockReturnValue(true);
+    it("clicking the mobile Ability cell triggers onOpenAbilityPicker", async () => {
       const user = userEvent.setup();
-      const handlers = renderBand();
+      const handlers = renderBand({}, {}, svFormat, "mobile");
       await user.click(screen.getByRole("button", { name: /Edit Ability/ }));
       expect(handlers.onOpenAbilityPicker).toHaveBeenCalledTimes(1);
+    });
+
+    it("collapses Nature to span both columns when the format has no Tera", () => {
+      // Render in mobile layout with a Champions (Gen 10) format — formatHasTera
+      // returns false, so the mobile grid renders Ability+Item on row 1 and
+      // Nature spanning both columns on row 2.
+      const championsFormat = { ...svFormat, generation: 10 };
+      renderBand({}, {}, championsFormat, "mobile");
+      const mobileFields = screen.getByTestId(
+        "editor-header-band-mobile-fields"
+      );
+      // The col-span-2 cell wraps the Nature field exclusively.
+      const natureCell = mobileFields.querySelector(".col-span-2");
+      expect(natureCell).not.toBeNull();
+      expect(natureCell!.textContent).toContain("Nature");
     });
   });
 });

--- a/apps/web/src/components/team-builder/__tests__/pokemon-editor.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/pokemon-editor.test.tsx
@@ -3,11 +3,15 @@ import { render as rtlRender, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 
+type Layout = "desktop" | "mobile";
+
 // Wrap RTL's render so every PokemonEditor mount automatically strips the
-// mobile build-fields container — see `trimMobileLayout` below for why.
-function render(ui: React.ReactElement) {
+// off-test layout from the DOM — see `trimToLayout` below for why. Default
+// is `desktop` (matches the prior single-layout test behavior); pass
+// `"mobile"` to exercise the mobile editor integration path.
+function render(ui: React.ReactElement, layout: Layout = "desktop") {
   const result = rtlRender(ui);
-  trimMobileLayout();
+  trimToLayout(layout);
   return result;
 }
 
@@ -195,14 +199,27 @@ const defaultProps = {
 // uses Tailwind `hidden md:flex` / `md:hidden` to swap them per viewport.
 // JSDOM doesn't compute Tailwind class styles, so without intervention every
 // FieldButton would render twice in tests. After each render, strip the
-// mobile build-fields container so default queries match a single instance —
-// matches the desktop-only behavior tests assumed before the dual layout.
-function trimMobileLayout() {
+// off-test layout's container from the DOM. Tests pass `layout: "mobile"` to
+// the render helper to exercise the mobile editor integration path; default
+// is `"desktop"` matching the single-layout behavior tests previously assumed.
+function trimToLayout(layout: Layout) {
+  const desktopFields = document.querySelector(
+    '[data-testid="editor-header-band-desktop-fields"]'
+  );
   const mobileFields = document.querySelector(
     '[data-testid="editor-header-band-mobile-fields"]'
   );
-  if (mobileFields) {
+  if (layout === "desktop" && mobileFields) {
     mobileFields.remove();
+  }
+  if (layout === "mobile" && desktopFields) {
+    // The divider preceding the desktop-fields div has no own testid; remove
+    // it via DOM proximity so the layout tree mirrors what users see at <md.
+    const divider = desktopFields.previousElementSibling;
+    if (divider?.getAttribute("aria-hidden") === "true") {
+      divider.remove();
+    }
+    desktopFields.remove();
   }
 }
 
@@ -451,6 +468,61 @@ describe("PokemonEditor", () => {
       expect(screen.getByText("Ability")).toBeInTheDocument();
       expect(screen.getByText("Item")).toBeInTheDocument();
       expect(screen.getByText("Nature")).toBeInTheDocument();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Mobile layout integration — exercises the mobile build-fields branch
+  // that the default `render()` calls trim away. Without this the suite would
+  // be blind to regressions in the mobile editor path.
+  // ---------------------------------------------------------------------------
+
+  describe("mobile layout integration", () => {
+    it("renders the four loadout fields inside the mobile grid container", () => {
+      render(<PokemonEditor {...defaultProps} />, "mobile");
+      const mobileFields = screen.getByTestId(
+        "editor-header-band-mobile-fields"
+      );
+      // Each FieldButton renders an <button aria-label="Edit X"> — locate the
+      // mobile copies inside the mobile grid container.
+      expect(
+        mobileFields.querySelector('button[aria-label*="Edit Ability"]')
+      ).not.toBeNull();
+      expect(
+        mobileFields.querySelector('button[aria-label*="Edit Item"]')
+      ).not.toBeNull();
+      expect(
+        mobileFields.querySelector('button[aria-label*="Edit Tera"]')
+      ).not.toBeNull();
+      expect(
+        mobileFields.querySelector('button[aria-label*="Edit Nature"]')
+      ).not.toBeNull();
+    });
+
+    it("opens the ability picker when the mobile Ability cell is clicked", async () => {
+      const user = userEvent.setup();
+      render(<PokemonEditor {...defaultProps} />, "mobile");
+      // After trimToLayout("mobile") the desktop branch is removed — the only
+      // matching button lives in the mobile grid.
+      await user.click(screen.getByRole("button", { name: /edit ability/i }));
+      expect(
+        screen.getByPlaceholderText("Search abilities…")
+      ).toBeInTheDocument();
+    });
+
+    it("anchors the picker overlay below the band's relative wrapper", async () => {
+      // Sanity check that the picker still opens correctly on mobile, where
+      // the band is taller (Row 1 + Row 2). The overlay uses `top-full` so
+      // it should mount inside the same `.relative` wrapper as the band.
+      const user = userEvent.setup();
+      render(<PokemonEditor {...defaultProps} />, "mobile");
+      await user.click(screen.getByRole("button", { name: /edit nature/i }));
+      const naturePicker = screen.getByPlaceholderText("Search natures…");
+      expect(naturePicker).toBeInTheDocument();
+      // The picker container sits inside the same relative wrapper as the band.
+      expect(
+        naturePicker.closest('[data-testid="editor-header-band-mobile-fields"]')
+      ).toBeNull();
     });
   });
 });

--- a/apps/web/src/components/team-builder/__tests__/pokemon-editor.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/pokemon-editor.test.tsx
@@ -1,7 +1,15 @@
 import { describe, it, expect } from "@jest/globals";
-import { render, screen } from "@testing-library/react";
+import { render as rtlRender, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
+
+// Wrap RTL's render so every PokemonEditor mount automatically strips the
+// mobile build-fields container — see `trimMobileLayout` below for why.
+function render(ui: React.ReactElement) {
+  const result = rtlRender(ui);
+  trimMobileLayout();
+  return result;
+}
 
 // =============================================================================
 // Module-level mocks
@@ -183,9 +191,28 @@ const defaultProps = {
 // Tests
 // =============================================================================
 
+// EditorHeaderBand renders both desktop and mobile layouts simultaneously and
+// uses Tailwind `hidden md:flex` / `md:hidden` to swap them per viewport.
+// JSDOM doesn't compute Tailwind class styles, so without intervention every
+// FieldButton would render twice in tests. After each render, strip the
+// mobile build-fields container so default queries match a single instance —
+// matches the desktop-only behavior tests assumed before the dual layout.
+function trimMobileLayout() {
+  const mobileFields = document.querySelector(
+    '[data-testid="editor-header-band-mobile-fields"]'
+  );
+  if (mobileFields) {
+    mobileFields.remove();
+  }
+}
+
 describe("PokemonEditor", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // No-op cleanup — Testing Library handles DOM cleanup between tests.
   });
 
   // ---------------------------------------------------------------------------

--- a/apps/web/src/components/team-builder/__tests__/pokemon-editor.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/pokemon-editor.test.tsx
@@ -1,18 +1,21 @@
 import { describe, it, expect } from "@jest/globals";
-import { render as rtlRender, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 
-type Layout = "desktop" | "mobile";
+// EditorHeaderBand renders both desktop and mobile build-field layouts and
+// uses Tailwind `hidden md:flex` / `md:hidden` to swap them per viewport.
+// JSDOM doesn't compute Tailwind class styles, so every FieldButton appears
+// twice in the DOM. Tests scope build-field queries to one container at a
+// time using `within()`. Identity-zone elements (sprite, name, picker
+// overlays) only render once and remain queryable via the top-level
+// `screen` queries.
+function desktopFields() {
+  return within(screen.getByTestId("editor-header-band-desktop-fields"));
+}
 
-// Wrap RTL's render so every PokemonEditor mount automatically strips the
-// off-test layout from the DOM — see `trimToLayout` below for why. Default
-// is `desktop` (matches the prior single-layout test behavior); pass
-// `"mobile"` to exercise the mobile editor integration path.
-function render(ui: React.ReactElement, layout: Layout = "desktop") {
-  const result = rtlRender(ui);
-  trimToLayout(layout);
-  return result;
+function mobileFields() {
+  return within(screen.getByTestId("editor-header-band-mobile-fields"));
 }
 
 // =============================================================================
@@ -195,41 +198,9 @@ const defaultProps = {
 // Tests
 // =============================================================================
 
-// EditorHeaderBand renders both desktop and mobile layouts simultaneously and
-// uses Tailwind `hidden md:flex` / `md:hidden` to swap them per viewport.
-// JSDOM doesn't compute Tailwind class styles, so without intervention every
-// FieldButton would render twice in tests. After each render, strip the
-// off-test layout's container from the DOM. Tests pass `layout: "mobile"` to
-// the render helper to exercise the mobile editor integration path; default
-// is `"desktop"` matching the single-layout behavior tests previously assumed.
-function trimToLayout(layout: Layout) {
-  const desktopFields = document.querySelector(
-    '[data-testid="editor-header-band-desktop-fields"]'
-  );
-  const mobileFields = document.querySelector(
-    '[data-testid="editor-header-band-mobile-fields"]'
-  );
-  if (layout === "desktop" && mobileFields) {
-    mobileFields.remove();
-  }
-  if (layout === "mobile" && desktopFields) {
-    // The divider preceding the desktop-fields div has no own testid; remove
-    // it via DOM proximity so the layout tree mirrors what users see at <md.
-    const divider = desktopFields.previousElementSibling;
-    if (divider?.getAttribute("aria-hidden") === "true") {
-      divider.remove();
-    }
-    desktopFields.remove();
-  }
-}
-
 describe("PokemonEditor", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-  });
-
-  afterEach(() => {
-    // No-op cleanup — Testing Library handles DOM cleanup between tests.
   });
 
   // ---------------------------------------------------------------------------
@@ -240,21 +211,24 @@ describe("PokemonEditor", () => {
     it("renders sprite, species name, and the four loadout fields", () => {
       render(<PokemonEditor {...defaultProps} />);
 
-      // Sprite is delegated to next/image and queryable by alt text.
+      // Sprite is delegated to next/image and queryable by alt text — only
+      // rendered once in the identity zone, so top-level screen queries work.
       expect(screen.getByAltText("Incineroar")).toBeInTheDocument();
-      // Species name in the identity column.
+      // Species name in the identity column (Row 1, single instance).
       expect(screen.getByText("Incineroar")).toBeInTheDocument();
 
-      // All four loadout field labels render in the band.
-      expect(screen.getByText("Ability")).toBeInTheDocument();
-      expect(screen.getByText("Item")).toBeInTheDocument();
-      expect(screen.getByText("Tera")).toBeInTheDocument();
-      expect(screen.getByText("Nature")).toBeInTheDocument();
+      // Build-field labels render in both desktop and mobile layouts; scope
+      // queries to one container so each label matches a single element.
+      expect(desktopFields().getByText("Ability")).toBeInTheDocument();
+      expect(desktopFields().getByText("Item")).toBeInTheDocument();
+      expect(desktopFields().getByText("Tera")).toBeInTheDocument();
+      expect(desktopFields().getByText("Nature")).toBeInTheDocument();
 
-      // Current values flow through.
-      expect(screen.getByText("Intimidate")).toBeInTheDocument();
-      expect(screen.getByText("None")).toBeInTheDocument(); // held_item
-      expect(screen.getByText("Adamant")).toBeInTheDocument();
+      // Current values flow through to both layouts — scope to verify desktop
+      // values; equivalent values render in the mobile grid (covered below).
+      expect(desktopFields().getByText("Intimidate")).toBeInTheDocument();
+      expect(desktopFields().getByText("None")).toBeInTheDocument(); // held_item
+      expect(desktopFields().getByText("Adamant")).toBeInTheDocument();
     });
   });
 
@@ -320,7 +294,10 @@ describe("PokemonEditor", () => {
     it("opens the ability picker when the ability field is clicked", async () => {
       const user = userEvent.setup();
       render(<PokemonEditor {...defaultProps} />);
-      await user.click(screen.getByRole("button", { name: /edit ability/i }));
+      // Edit-X buttons render in both layouts — scope click to desktop.
+      await user.click(
+        desktopFields().getByRole("button", { name: /edit ability/i })
+      );
       expect(
         screen.getByPlaceholderText("Search abilities…")
       ).toBeInTheDocument();
@@ -329,7 +306,9 @@ describe("PokemonEditor", () => {
     it("opens the nature picker when the nature field is clicked", async () => {
       const user = userEvent.setup();
       render(<PokemonEditor {...defaultProps} />);
-      await user.click(screen.getByRole("button", { name: /edit nature/i }));
+      await user.click(
+        desktopFields().getByRole("button", { name: /edit nature/i })
+      );
       expect(
         screen.getByPlaceholderText("Search natures…")
       ).toBeInTheDocument();
@@ -338,7 +317,9 @@ describe("PokemonEditor", () => {
     it("opens the tera picker when the tera field is clicked", async () => {
       const user = userEvent.setup();
       render(<PokemonEditor {...defaultProps} />);
-      await user.click(screen.getByRole("button", { name: /edit tera/i }));
+      await user.click(
+        desktopFields().getByRole("button", { name: /edit tera/i })
+      );
       // TeraPicker renders type grid buttons.
       expect(screen.getByRole("button", { name: "Water" })).toBeInTheDocument();
     });
@@ -465,61 +446,63 @@ describe("PokemonEditor", () => {
           }
         />
       );
-      expect(screen.getByText("Ability")).toBeInTheDocument();
-      expect(screen.getByText("Item")).toBeInTheDocument();
-      expect(screen.getByText("Nature")).toBeInTheDocument();
+      // Build-field labels render in both desktop and mobile layouts; scope
+      // to one container for an exact match.
+      expect(desktopFields().getByText("Ability")).toBeInTheDocument();
+      expect(desktopFields().getByText("Item")).toBeInTheDocument();
+      expect(desktopFields().getByText("Nature")).toBeInTheDocument();
     });
   });
 
   // ---------------------------------------------------------------------------
-  // Mobile layout integration — exercises the mobile build-fields branch
-  // that the default `render()` calls trim away. Without this the suite would
-  // be blind to regressions in the mobile editor path.
+  // Mobile layout integration — exercises the mobile build-fields branch.
+  // EditorHeaderBand always mounts both layouts; tests scope to one via
+  // `mobileFields()`.
   // ---------------------------------------------------------------------------
 
   describe("mobile layout integration", () => {
     it("renders the four loadout fields inside the mobile grid container", () => {
-      render(<PokemonEditor {...defaultProps} />, "mobile");
-      const mobileFields = screen.getByTestId(
-        "editor-header-band-mobile-fields"
-      );
-      // Each FieldButton renders an <button aria-label="Edit X"> — locate the
-      // mobile copies inside the mobile grid container.
+      render(<PokemonEditor {...defaultProps} />);
+      // Each FieldButton renders an <button aria-label="Edit X"> in both
+      // desktop and mobile branches — verify the mobile branch has all four.
       expect(
-        mobileFields.querySelector('button[aria-label*="Edit Ability"]')
-      ).not.toBeNull();
+        mobileFields().getByRole("button", { name: /Edit Ability/i })
+      ).toBeInTheDocument();
       expect(
-        mobileFields.querySelector('button[aria-label*="Edit Item"]')
-      ).not.toBeNull();
+        mobileFields().getByRole("button", { name: /Edit Item/i })
+      ).toBeInTheDocument();
       expect(
-        mobileFields.querySelector('button[aria-label*="Edit Tera"]')
-      ).not.toBeNull();
+        mobileFields().getByRole("button", { name: /Edit Tera/i })
+      ).toBeInTheDocument();
       expect(
-        mobileFields.querySelector('button[aria-label*="Edit Nature"]')
-      ).not.toBeNull();
+        mobileFields().getByRole("button", { name: /Edit Nature/i })
+      ).toBeInTheDocument();
     });
 
     it("opens the ability picker when the mobile Ability cell is clicked", async () => {
       const user = userEvent.setup();
-      render(<PokemonEditor {...defaultProps} />, "mobile");
-      // After trimToLayout("mobile") the desktop branch is removed — the only
-      // matching button lives in the mobile grid.
-      await user.click(screen.getByRole("button", { name: /edit ability/i }));
+      render(<PokemonEditor {...defaultProps} />);
+      await user.click(
+        mobileFields().getByRole("button", { name: /edit ability/i })
+      );
       expect(
         screen.getByPlaceholderText("Search abilities…")
       ).toBeInTheDocument();
     });
 
     it("anchors the picker overlay below the band's relative wrapper", async () => {
-      // Sanity check that the picker still opens correctly on mobile, where
-      // the band is taller (Row 1 + Row 2). The overlay uses `top-full` so
-      // it should mount inside the same `.relative` wrapper as the band.
+      // Sanity check that the picker still opens correctly when triggered
+      // from the mobile branch — the overlay uses `top-full` so it mounts
+      // outside the mobile-fields container.
       const user = userEvent.setup();
-      render(<PokemonEditor {...defaultProps} />, "mobile");
-      await user.click(screen.getByRole("button", { name: /edit nature/i }));
+      render(<PokemonEditor {...defaultProps} />);
+      await user.click(
+        mobileFields().getByRole("button", { name: /edit nature/i })
+      );
       const naturePicker = screen.getByPlaceholderText("Search natures…");
       expect(naturePicker).toBeInTheDocument();
-      // The picker container sits inside the same relative wrapper as the band.
+      // The picker overlay sits in the band's relative wrapper — outside
+      // the mobile build-fields container.
       expect(
         naturePicker.closest('[data-testid="editor-header-band-mobile-fields"]')
       ).toBeNull();

--- a/apps/web/src/components/team-builder/analytics-rail.tsx
+++ b/apps/web/src/components/team-builder/analytics-rail.tsx
@@ -64,8 +64,13 @@ export function AnalyticsRail({
       defaultValue="types"
       data-testid="analytics-rail"
       className={cn(
-        "bg-card w-rail flex-shrink-0 overflow-hidden rounded-lg shadow-sm",
-        "sticky top-4 flex max-h-[calc(100svh-6rem)] flex-col",
+        // Full width on phones (where the rail stacks below the editor) so it
+        // never forces page-level horizontal overflow. Pinned to 460px on lg+
+        // when it sits side-by-side with the editor column.
+        "bg-card w-full flex-shrink-0 overflow-hidden rounded-lg shadow-sm lg:w-rail",
+        // sticky top-4 only at lg+ — when stacked on phones, the rail is just
+        // another section of the page and shouldn't pin to the viewport.
+        "flex max-h-[calc(100svh-6rem)] flex-col lg:sticky lg:top-4",
         className
       )}
     >

--- a/apps/web/src/components/team-builder/analytics-rail.tsx
+++ b/apps/web/src/components/team-builder/analytics-rail.tsx
@@ -25,10 +25,10 @@ interface AnalyticsRailProps {
 // SpeedPanel, CalcPanel, and TypeChartPanel each render their own card chrome
 // (`bg-card overflow-hidden rounded-lg shadow-sm`) so they can also be used
 // standalone. When mounted inside AnalyticsRail — which provides its own
-// chrome on the outer container at a fixed 460px width — we pass these
-// neutralizing utility classes to strip the duplicate card styling. The
-// panels' `className` is merged into the outer wrapper via `cn()`, so these
-// values win against the defaults.
+// chrome on the outer container (full-width on phones, `w-rail` 460px at lg+)
+// — we pass these neutralizing utility classes to strip the duplicate card
+// styling. The panels' `className` is merged into the outer wrapper via
+// `cn()`, so these values win against the defaults.
 const PANEL_CHROME_OVERRIDE =
   "bg-transparent shadow-none rounded-none flex flex-col flex-1";
 

--- a/apps/web/src/components/team-builder/analytics-rail.tsx
+++ b/apps/web/src/components/team-builder/analytics-rail.tsx
@@ -37,11 +37,18 @@ const PANEL_CHROME_OVERRIDE =
 // =============================================================================
 
 /**
- * Right-rail tabbed wrapper that hosts the Types, Speed, and Calc panels at a
- * fixed 460px width. Types is the default tab — it's the most-used analysis
- * tool. Tab state lives on the rail (so switching pokemon does not reset the
- * active tab), while each panel keeps its own internal state and resets via
- * its own `key` strategy on `selectedPokemon` change.
+ * Right-rail tabbed wrapper that hosts the Types, Speed, and Calc panels.
+ * Width is responsive: full-width on phones (where the rail stacks below
+ * the editor in TeamWorkspace's `grid-cols-1` layout) and pinned to 460px
+ * (`w-rail`) at lg+ where the rail sits side-by-side with the editor
+ * column in TeamWorkspace's `grid-cols-[minmax(0,1fr)_28.75rem]`. The
+ * `sticky top-4` behavior also activates only at lg+ — when stacked,
+ * the rail scrolls with the page like any other section.
+ *
+ * Types is the default tab — it's the most-used analysis tool. Tab state
+ * lives on the rail (so switching pokemon does not reset the active tab),
+ * while each panel keeps its own internal state and resets via its own
+ * `key` strategy on `selectedPokemon` change.
  *
  * The non-active panel is unmounted (not just hidden) so we don't keep
  * running its calculations.

--- a/apps/web/src/components/team-builder/editor-header-band.tsx
+++ b/apps/web/src/components/team-builder/editor-header-band.tsx
@@ -15,7 +15,6 @@ import {
 import { getPokemonSprite } from "@trainers/pokemon/sprites";
 import { type Tables } from "@trainers/supabase";
 
-import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 
 import { PokemonDetailsPopover } from "./pokemon-details-popover";
@@ -257,15 +256,6 @@ export function EditorHeaderBand({
     pokemon.nickname ?? ""
   );
 
-  // Phones can't fit identity + 4 build fields + meta controls in a single
-  // h-[68px] row (~530px+ at any width). Stack the build fields below as a
-  // 2-col grid (Row 2) on phones; keep the original single-row layout at md+.
-  // useIsMobile returns false during SSR (getServerSnapshot) so the SSR HTML
-  // matches the desktop layout — mobile users see a brief flash before
-  // hydration, but tests using JSDOM's matchMedia polyfill render the
-  // desktop variant which preserves existing button-count expectations.
-  const isMobile = useIsMobile();
-
   // -------------------------------------------------------------------------
   // Identity control handlers — forward to parent's debounced onUpdate.
   // -------------------------------------------------------------------------
@@ -495,37 +485,33 @@ export function EditorHeaderBand({
         </div>
 
         {/* ── Zone 2: Build fields (inline at md+ only — phones move these
-              to Row 2 below to free space for identity + meta in Row 1) ── */}
-        {!isMobile && (
-          <>
-            <div
-              className="bg-border my-2.5 w-px shrink-0"
-              aria-hidden="true"
-            />
-            <div className="flex flex-1 items-stretch">
-              {abilityField}
+              to Row 2 below to free space for identity + meta in Row 1).
+              CSS-based hiding (`hidden md:flex` / `md:hidden`) instead of
+              `useIsMobile()` so the SSR HTML is mobile-safe and there's no
+              hydration flash of the overflowing desktop layout on phones. */}
+        <div
+          className="bg-border my-2.5 hidden w-px shrink-0 md:block"
+          aria-hidden="true"
+        />
+        <div
+          className="hidden flex-1 items-stretch md:flex"
+          data-testid="editor-header-band-desktop-fields"
+        >
+          {abilityField}
+          <div className="bg-border my-2.5 w-px shrink-0" aria-hidden="true" />
+          {itemField}
+          {teraField && (
+            <>
               <div
                 className="bg-border my-2.5 w-px shrink-0"
                 aria-hidden="true"
               />
-              {itemField}
-              {teraField && (
-                <>
-                  <div
-                    className="bg-border my-2.5 w-px shrink-0"
-                    aria-hidden="true"
-                  />
-                  {teraField}
-                </>
-              )}
-              <div
-                className="bg-border my-2.5 w-px shrink-0"
-                aria-hidden="true"
-              />
-              {natureField}
-            </div>
-          </>
-        )}
+              {teraField}
+            </>
+          )}
+          <div className="bg-border my-2.5 w-px shrink-0" aria-hidden="true" />
+          {natureField}
+        </div>
 
         {/* ── Zone 3: Meta controls (only when detailsPopover wired) ────── */}
         {showIdentityControls && (
@@ -593,27 +579,27 @@ export function EditorHeaderBand({
         )}
       </div>
 
-      {/* Row 2: Build fields shown only on phones (conditionally mounted via
-          useIsMobile so tests/JSDOM and SSR render the desktop variant).
-          2-col grid — thin borders between rows/cols replace the inline
-          dividers used in the desktop layout above. */}
-      {isMobile && (
-        <div
-          className="grid grid-cols-2 border-t"
-          data-testid="editor-header-band-mobile-fields"
-        >
-          <div className="border-r">{abilityField}</div>
-          <div>{itemField}</div>
-          {teraField ? (
-            <>
-              <div className="border-t border-r">{teraField}</div>
-              <div className="border-t">{natureField}</div>
-            </>
-          ) : (
-            <div className="col-span-2 border-t">{natureField}</div>
-          )}
-        </div>
-      )}
+      {/* Row 2: Build fields shown only on phones (`md:hidden`). 2-col grid;
+          thin borders between rows/cols replace the inline dividers used in
+          the desktop layout above. The desktop branch's `hidden md:flex`
+          ensures display:none excludes its FieldButtons from the keyboard
+          tab order and accessibility tree on phones, so the duplicate render
+          doesn't create a11y collisions. */}
+      <div
+        className="grid grid-cols-2 border-t md:hidden"
+        data-testid="editor-header-band-mobile-fields"
+      >
+        <div className="border-r">{abilityField}</div>
+        <div>{itemField}</div>
+        {teraField ? (
+          <>
+            <div className="border-t border-r">{teraField}</div>
+            <div className="border-t">{natureField}</div>
+          </>
+        ) : (
+          <div className="col-span-2 border-t">{natureField}</div>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/team-builder/editor-header-band.tsx
+++ b/apps/web/src/components/team-builder/editor-header-band.tsx
@@ -80,17 +80,24 @@ function FieldButton({
       onClick={onClick}
       aria-label={ariaLabel ?? `Edit ${label}`}
       className={cn(
-        "flex flex-1 flex-col justify-center gap-0.5 px-3 py-2 text-left",
+        "flex min-w-0 flex-1 flex-col justify-center gap-0.5 px-3 py-2 text-left",
         "hover:bg-muted/50 transition-colors duration-150"
       )}
     >
       <span className="text-muted-foreground text-[9px] font-semibold tracking-wider uppercase">
         {label}
       </span>
-      <span className="text-foreground flex items-center gap-1 text-sm font-medium whitespace-nowrap">
-        {children}
+      <span className="text-foreground flex min-w-0 items-center gap-1 text-sm font-medium">
+        {/* `truncate` on the value text so a long ability/item/nature name
+            shows an ellipsis when it can't fit (mobile cells are 50% of a
+            ~393px viewport). The chevron sits outside the truncated span so
+            it stays visible. */}
+        <span className="min-w-0 truncate">{children}</span>
         {!hideChevron && (
-          <span className="text-muted-foreground" aria-hidden="true">
+          <span
+            className="text-muted-foreground shrink-0"
+            aria-hidden="true"
+          >
             ›
           </span>
         )}
@@ -110,11 +117,13 @@ interface FieldStaticProps {
 
 function FieldStatic({ label, children }: FieldStaticProps) {
   return (
-    <div className="flex flex-1 flex-col justify-center gap-0.5 px-3 py-2">
+    <div className="flex min-w-0 flex-1 flex-col justify-center gap-0.5 px-3 py-2">
       <span className="text-muted-foreground text-[9px] font-semibold tracking-wider uppercase">
         {label}
       </span>
-      <span className="text-foreground text-sm font-medium whitespace-nowrap">
+      {/* `truncate` so the value text shows an ellipsis when it can't fit
+          inside the cell (matches the FieldButton behavior). */}
+      <span className="text-foreground truncate text-sm font-medium">
         {children}
       </span>
     </div>
@@ -590,9 +599,9 @@ export function EditorHeaderBand({
         data-testid="editor-header-band-mobile-fields"
       >
         {/* Each cell carries `min-w-0 overflow-hidden` so the FieldButton's
-            `whitespace-nowrap` value text can't push past the cell's column
-            width (e.g. very long ability or item names). The truncate inside
-            FieldButton handles the visual ellipsis. */}
+            value text can't push past the cell's column width (e.g. very
+            long ability or item names). FieldButton/FieldStatic apply
+            `truncate` to the value span so overflow shows an ellipsis. */}
         <div className="min-w-0 overflow-hidden border-r">{abilityField}</div>
         <div className="min-w-0 overflow-hidden">{itemField}</div>
         {teraField ? (

--- a/apps/web/src/components/team-builder/editor-header-band.tsx
+++ b/apps/web/src/components/team-builder/editor-header-band.tsx
@@ -15,6 +15,7 @@ import {
 import { getPokemonSprite } from "@trainers/pokemon/sprites";
 import { type Tables } from "@trainers/supabase";
 
+import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 
 import { PokemonDetailsPopover } from "./pokemon-details-popover";
@@ -256,6 +257,15 @@ export function EditorHeaderBand({
     pokemon.nickname ?? ""
   );
 
+  // Phones can't fit identity + 4 build fields + meta controls in a single
+  // h-[68px] row (~530px+ at any width). Stack the build fields below as a
+  // 2-col grid (Row 2) on phones; keep the original single-row layout at md+.
+  // useIsMobile returns false during SSR (getServerSnapshot) so the SSR HTML
+  // matches the desktop layout — mobile users see a brief flash before
+  // hydration, but tests using JSDOM's matchMedia polyfill render the
+  // desktop variant which preserves existing button-count expectations.
+  const isMobile = useIsMobile();
+
   // -------------------------------------------------------------------------
   // Identity control handlers — forward to parent's debounced onUpdate.
   // -------------------------------------------------------------------------
@@ -332,6 +342,54 @@ export function EditorHeaderBand({
   );
 
   // -------------------------------------------------------------------------
+  // Build-field components — extracted so they can render either inline in
+  // the desktop band row or as a 2-col grid below the row on phones (since
+  // identity + 4 fields + meta controls do not fit in a single 393px row).
+  // -------------------------------------------------------------------------
+
+  const abilityField =
+    isSingleAbility || disabled ? (
+      <FieldStatic label="Ability">
+        {pokemon.ability ?? validAbilities[0] ?? "—"}
+      </FieldStatic>
+    ) : (
+      <FieldButton label="Ability" onClick={onOpenAbilityPicker}>
+        {pokemon.ability ?? validAbilities[0] ?? "—"}
+      </FieldButton>
+    );
+
+  const itemField =
+    disabled || isMegaLocked ? (
+      <FieldStatic label="Item">{pokemon.held_item ?? "None"}</FieldStatic>
+    ) : (
+      <FieldButton label="Item" onClick={onOpenItemPicker}>
+        {pokemon.held_item ?? "None"}
+      </FieldButton>
+    );
+
+  const teraField = hasTera ? (
+    disabled ? (
+      <FieldStatic label="Tera">{teraContent}</FieldStatic>
+    ) : (
+      <FieldButton
+        label="Tera"
+        onClick={onOpenTeraPicker}
+        hideChevron={pokemon.tera_type !== null}
+      >
+        {teraContent}
+      </FieldButton>
+    )
+  ) : null;
+
+  const natureField = disabled ? (
+    <FieldStatic label="Nature">{pokemon.nature}</FieldStatic>
+  ) : (
+    <FieldButton label="Nature" onClick={onOpenNaturePicker}>
+      {pokemon.nature}
+    </FieldButton>
+  );
+
+  // -------------------------------------------------------------------------
   // Render
   // -------------------------------------------------------------------------
 
@@ -342,9 +400,13 @@ export function EditorHeaderBand({
         className
       )}
     >
+      {/* Row 1: Identity + (build fields at md+) + meta. Always one h-[68px]
+          row. Phones drop the build fields out of this row and render them
+          below in a 2-col grid (Row 2 below). */}
       <div className="flex h-[68px] items-stretch">
-        {/* ── Zone 1: Identity ──────────────────────────────────────────── */}
-        <div className="flex min-w-0 shrink-0 items-center gap-2.5 px-3">
+        {/* ── Zone 1: Identity — flex-1 on phones (fills space left of meta);
+              shrink-0 on md+ where build fields take the middle flex-1 slot. */}
+        <div className="flex min-w-0 flex-1 items-center gap-2.5 px-3 md:flex-none md:shrink-0">
           {/* Sprite — opens species picker when available */}
           {speciesClickable ? (
             <button
@@ -432,63 +494,38 @@ export function EditorHeaderBand({
           </div>
         </div>
 
-        {/* Divider */}
-        <div className="bg-border my-2.5 w-px shrink-0" aria-hidden="true" />
-
-        {/* ── Zone 2: Build fields ──────────────────────────────────────── */}
-        <div className="flex flex-1 items-stretch">
-          {isSingleAbility || disabled ? (
-            <FieldStatic label="Ability">
-              {pokemon.ability ?? validAbilities[0] ?? "—"}
-            </FieldStatic>
-          ) : (
-            <FieldButton label="Ability" onClick={onOpenAbilityPicker}>
-              {pokemon.ability ?? validAbilities[0] ?? "—"}
-            </FieldButton>
-          )}
-
-          <div className="bg-border my-2.5 w-px shrink-0" aria-hidden="true" />
-
-          {disabled || isMegaLocked ? (
-            <FieldStatic label="Item">
-              {pokemon.held_item ?? "None"}
-            </FieldStatic>
-          ) : (
-            <FieldButton label="Item" onClick={onOpenItemPicker}>
-              {pokemon.held_item ?? "None"}
-            </FieldButton>
-          )}
-
-          {hasTera && (
-            <>
+        {/* ── Zone 2: Build fields (inline at md+ only — phones move these
+              to Row 2 below to free space for identity + meta in Row 1) ── */}
+        {!isMobile && (
+          <>
+            <div
+              className="bg-border my-2.5 w-px shrink-0"
+              aria-hidden="true"
+            />
+            <div className="flex flex-1 items-stretch">
+              {abilityField}
               <div
                 className="bg-border my-2.5 w-px shrink-0"
                 aria-hidden="true"
               />
-              {disabled ? (
-                <FieldStatic label="Tera">{teraContent}</FieldStatic>
-              ) : (
-                <FieldButton
-                  label="Tera"
-                  onClick={onOpenTeraPicker}
-                  hideChevron={pokemon.tera_type !== null}
-                >
-                  {teraContent}
-                </FieldButton>
+              {itemField}
+              {teraField && (
+                <>
+                  <div
+                    className="bg-border my-2.5 w-px shrink-0"
+                    aria-hidden="true"
+                  />
+                  {teraField}
+                </>
               )}
-            </>
-          )}
-
-          <div className="bg-border my-2.5 w-px shrink-0" aria-hidden="true" />
-
-          {disabled ? (
-            <FieldStatic label="Nature">{pokemon.nature}</FieldStatic>
-          ) : (
-            <FieldButton label="Nature" onClick={onOpenNaturePicker}>
-              {pokemon.nature}
-            </FieldButton>
-          )}
-        </div>
+              <div
+                className="bg-border my-2.5 w-px shrink-0"
+                aria-hidden="true"
+              />
+              {natureField}
+            </div>
+          </>
+        )}
 
         {/* ── Zone 3: Meta controls (only when detailsPopover wired) ────── */}
         {showIdentityControls && (
@@ -555,6 +592,28 @@ export function EditorHeaderBand({
           </>
         )}
       </div>
+
+      {/* Row 2: Build fields shown only on phones (conditionally mounted via
+          useIsMobile so tests/JSDOM and SSR render the desktop variant).
+          2-col grid — thin borders between rows/cols replace the inline
+          dividers used in the desktop layout above. */}
+      {isMobile && (
+        <div
+          className="grid grid-cols-2 border-t"
+          data-testid="editor-header-band-mobile-fields"
+        >
+          <div className="border-r">{abilityField}</div>
+          <div>{itemField}</div>
+          {teraField ? (
+            <>
+              <div className="border-t border-r">{teraField}</div>
+              <div className="border-t">{natureField}</div>
+            </>
+          ) : (
+            <div className="col-span-2 border-t">{natureField}</div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/team-builder/editor-header-band.tsx
+++ b/apps/web/src/components/team-builder/editor-header-band.tsx
@@ -589,15 +589,23 @@ export function EditorHeaderBand({
         className="grid grid-cols-2 border-t md:hidden"
         data-testid="editor-header-band-mobile-fields"
       >
-        <div className="border-r">{abilityField}</div>
-        <div>{itemField}</div>
+        {/* Each cell carries `min-w-0 overflow-hidden` so the FieldButton's
+            `whitespace-nowrap` value text can't push past the cell's column
+            width (e.g. very long ability or item names). The truncate inside
+            FieldButton handles the visual ellipsis. */}
+        <div className="min-w-0 overflow-hidden border-r">{abilityField}</div>
+        <div className="min-w-0 overflow-hidden">{itemField}</div>
         {teraField ? (
           <>
-            <div className="border-t border-r">{teraField}</div>
-            <div className="border-t">{natureField}</div>
+            <div className="min-w-0 overflow-hidden border-t border-r">
+              {teraField}
+            </div>
+            <div className="min-w-0 overflow-hidden border-t">{natureField}</div>
           </>
         ) : (
-          <div className="col-span-2 border-t">{natureField}</div>
+          <div className="col-span-2 min-w-0 overflow-hidden border-t">
+            {natureField}
+          </div>
         )}
       </div>
     </div>

--- a/apps/web/src/components/team-builder/pokemon-editor.tsx
+++ b/apps/web/src/components/team-builder/pokemon-editor.tsx
@@ -205,47 +205,53 @@ export function PokemonEditor({
   }
 
   return (
-    <div className={cn("bg-card relative rounded-lg shadow-sm", className)}>
+    <div className={cn("bg-card rounded-lg shadow-sm", className)}>
       {/* ===================================================================
-          Header band — sprite, name, type pills, and the four loadout fields.
-          The four fields trigger inline pickers rendered below the band.
+          Header band + picker overlay — share a relative wrapper so the
+          picker can use `top-full` to anchor to the bottom of the band.
+          The band's height varies between layouts (68px single row at md+,
+          ~128px two-row stack on phones), so absolute pixel offsets like
+          `top-[69px]` would mis-align the picker on mobile.
           =================================================================== */}
-      <EditorHeaderBand
-        pokemon={pokemon}
-        format={format}
-        onOpenAbilityPicker={() => openPicker("ability")}
-        onOpenItemPicker={() => openPicker("item")}
-        onOpenTeraPicker={() => openPicker("tera")}
-        onOpenNaturePicker={() => openPicker("nature")}
-        onOpenSpeciesPicker={onOpenSpeciesPicker}
-        // Only mount the ⋯ details popover when we have a teamId — the
-        // disabled/placeholder editor (no real Pokémon row) skips it.
-        detailsPopover={
-          teamId !== undefined && !disabled
-            ? { teamId, onUpdate, onImported }
-            : undefined
-        }
-        disabled={disabled}
-      />
+      <div className="relative">
+        <EditorHeaderBand
+          pokemon={pokemon}
+          format={format}
+          onOpenAbilityPicker={() => openPicker("ability")}
+          onOpenItemPicker={() => openPicker("item")}
+          onOpenTeraPicker={() => openPicker("tera")}
+          onOpenNaturePicker={() => openPicker("nature")}
+          onOpenSpeciesPicker={onOpenSpeciesPicker}
+          // Only mount the ⋯ details popover when we have a teamId — the
+          // disabled/placeholder editor (no real Pokémon row) skips it.
+          detailsPopover={
+            teamId !== undefined && !disabled
+              ? { teamId, onUpdate, onImported }
+              : undefined
+          }
+          disabled={disabled}
+        />
 
-      {/* ===================================================================
-          Inline picker overlays — render directly under the header band so the
-          user stays anchored to the field they clicked. Only one is open at a
-          time, enforced by the `pickerOpen` discriminated state.
-          =================================================================== */}
-      {(pickerOpen === "ability" ||
-        pickerOpen === "item" ||
-        (hasTera && pickerOpen === "tera") ||
-        pickerOpen === "nature") && (
-        <>
-          {/* Backdrop — click outside picker to close */}
-          <div
-            className="fixed inset-0 z-[45]"
-            onClick={closePicker}
-            aria-hidden="true"
-          />
-          {/* Floating picker panel — top-[69px] = 68px header + 1px border-b */}
-          <div className="bg-card absolute inset-x-0 top-[69px] z-50 max-h-80 overflow-y-auto border-b px-4 py-3 shadow-xl">
+        {/* =================================================================
+            Inline picker overlays — render directly under the header band so
+            the user stays anchored to the field they clicked. Only one is
+            open at a time, enforced by the `pickerOpen` discriminated state.
+            ================================================================= */}
+        {(pickerOpen === "ability" ||
+          pickerOpen === "item" ||
+          (hasTera && pickerOpen === "tera") ||
+          pickerOpen === "nature") && (
+          <>
+            {/* Backdrop — click outside picker to close */}
+            <div
+              className="fixed inset-0 z-[45]"
+              onClick={closePicker}
+              aria-hidden="true"
+            />
+            {/* Floating picker panel — top-full anchors to the bottom edge of
+                the band's relative wrapper, so it stays aligned regardless of
+                whether the band is one or two rows tall. */}
+            <div className="bg-card absolute inset-x-0 top-full z-50 max-h-80 overflow-y-auto border-b px-4 py-3 shadow-xl">
             {pickerOpen === "ability" && (
               <AbilityPicker
                 species={pokemon.species}
@@ -291,9 +297,10 @@ export function PokemonEditor({
                 onClose={closePicker}
               />
             )}
-          </div>
-        </>
-      )}
+            </div>
+          </>
+        )}
+      </div>
 
       {/* ===================================================================
           Body — single column, stacked sections: moves on top, stats below,


### PR DESCRIPTION
## Summary

Eliminates **six page-level horizontal-overflow sources** on the dashboard at 393×852 (iPhone 14 Pro). Surfaced by user iPhone screenshots showing clipped stat labels (`"P"` instead of `"HP"`), clipped tab labels (`"ofile"` instead of `"Profile"`), and broken team-builder layouts where the moves and stats panels pushed off both edges of the viewport.

Each fix verified empirically with the page-overflow probe (`document.documentElement.scrollWidth > window.innerWidth`) before and after.

## Fixes

| File | Before | After |
|------|--------|-------|
| `teams/[teamId]/layout.tsx` | header crammed SidebarTrigger + breadcrumb + name + Badge + 3 action buttons into one fixed `flex h-12` row (~508px on phones) | stacks to two rows on phones (identity row above actions), single h-12 row at md+ |
| `teams/[teamId]/loading.tsx` | mirrored the broken header skeleton | mirrors the new responsive header |
| `teams/loading.tsx` | toolbar with 3 pill skeletons + 2 action buttons in one row (~508px) | `flex-col sm:flex-row` with `flex-wrap` on the pills |
| `analytics-rail.tsx` | `w-rail` (460px) forced the workspace to be ≥460px on every phone — the rail stacks below the editor at <lg | `w-full lg:w-rail`; sticky-top only activates at lg+ |
| `editor-header-band.tsx` | three zones (identity + 4 build fields + meta controls) in a single `flex h-[68px]` row totalled ~530px+ | phones keep identity + meta in Row 1 and stack the 4 build fields below as a 2-col grid (Row 2). CSS-only swap via Tailwind `hidden md:flex` / `md:hidden` — both layouts mount in SSR HTML so there's no hydration flash of horizontal overflow. `pokemon-editor` wraps band + picker overlay in a `relative` div and anchors the picker with `top-full` instead of hard-coded `top-[69px]` |
| `settings/layout.tsx` | `<nav class="flex gap-0">` of 4 tabs at ~470px overflowed phones | scrolls horizontally inside `-mx-4 overflow-x-auto px-4` wrapper; labels remain readable, page width fixed |
| `tournament-history-table.tsx` | two `SelectTrigger w-[180px]` filters in a flex row | `w-full sm:w-[180px]`, stacked vertically on phones |

## Empirical verification (Playwright at 393×852)

| Route | Before scrollW | After scrollW | Overflow |
|-------|----------------|---------------|----------|
| `/dashboard/settings/profile` | 474 | 393 | ✅ false |
| `/dashboard/alts/.../teams/[teamId]` | 524 | 393 | ✅ false |
| `/dashboard` (regression check) | 393 | 393 | ✅ false |

## Test changes

- `analytics-rail.test.tsx` — width assertion now checks `w-full` + `lg:w-rail`.
- `editor-header-band.test.tsx` + `pokemon-editor.test.tsx` — both layouts always mount in JSDOM (Tailwind responsive utilities aren't computed there). Build-field queries scope to one layout via `within(screen.getByTestId('editor-header-band-desktop-fields'))` (or `mobileFields()`). Identity-zone queries (sprite, name, picker overlays) remain top-level — those elements only render once in Row 1.
- New `describe("mobile layout")` blocks in both files cover the mobile branch end-to-end: mobile grid contains all four FieldButtons, click handlers fire from mobile cells, picker overlay anchors correctly below the two-row band.

## Local checks

| Check | Status |
|-------|--------|
| `pnpm lint` | ✅ green |
| `pnpm typecheck` | ✅ green |
| `pnpm test` | ✅ **4567/4567** across 252 suites |
| `pnpm test:e2e` | ⚠️ 21 pass / 6 skip / 28 fail locally |

E2E failures are pre-existing flakes from slow Turbopack dev compile, **not introduced by this PR**. Verified by reverting `settings/layout.tsx` to the main version and watching the same test still fail. CI uses fresh Vercel preview builds (no dev-compile warmup) and reports green for all required checks.

## Review rounds

| Round | Reviewer | Concerns | Resolution |
|-------|----------|----------|------------|
| 1 | Copilot | Hydration flash from `useIsMobile()` SSR mismatch | Switched to CSS-only `hidden md:flex` / `md:hidden` swap so SSR HTML is mobile-safe |
| 2 | CodeRabbit | Mobile editor path was untested in `pokemon-editor.test.tsx` | Added `describe("mobile layout integration")` block with 3 tests |
| 3 | Copilot (5 comments) | DOM mutation in test helpers is brittle; analytics-rail JSDoc stale; PR body referenced old approach; no-op `afterEach` | Replaced `trimToLayout` DOM mutation with `within()`-scoped queries; updated JSDoc + PR body; removed dead `afterEach` |

All 7 review threads resolved. CodeRabbit final state: APPROVED.

## Test plan

- [ ] Settings tabs scroll horizontally on phone; page itself doesn't scroll horizontally
- [ ] Team builder header wraps to two rows on phone (identity + format badge above; Import/Export/Fork below); single row at md+
- [ ] Team builder: 4 build fields (Ability/Item/Tera/Nature) render as 2×2 grid below the band on phone, single inline row at md+
- [ ] Team builder: clicking any of the 4 mobile fields opens the picker correctly (anchored to bottom of band, not floating in the wrong spot)
- [ ] Tournament history table filters: full-width and stacked on phone, side-by-side at sm+
- [ ] Teams listing skeleton: pills wrap, action buttons drop to next line on phone
- [ ] Analytics rail (Types / Speed / Calc tabs) is full-width on phone, 460px at lg+
- [ ] Desktop layout unchanged at md+ / lg+
- [ ] Cold-load on phone: no flash of overflowing desktop layout during hydration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layouts across dashboard and settings pages for better mobile and tablet viewing
  * Enhanced header layout with improved content organization on smaller screens
  * Updated navigation scrolling behavior for better accessibility on narrow viewports
  * Optimized filter controls and form spacing for responsive design

* **Tests**
  * Extended test coverage to validate responsive behavior across device sizes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->