### PR TITLE
fix(tournaments): remove BotID gate from registration

### DIFF
--- a/apps/web/src/actions/tournaments.ts
+++ b/apps/web/src/actions/tournaments.ts
@@ -483,7 +483,6 @@ export async function registerForTournament(
   }
 ): Promise<ActionResult<{ registrationId: number; status: string }>> {
   try {
-    await rejectBots();
     const supabase = await createClient();
     const result = await registerForTournamentMutation(
       supabase,


### PR DESCRIPTION
Vercel BotID is in basic mode (no <BotIdClient/> mounted, no protect config) and false-positives real users on registration. Other actions keep rejectBots() — registration has natural throttles (one per user, capacity caps) so dropping the gate here is low risk.