### PR TITLE
perf(team-builder): optimistic UI for add and remove

### DIFF
--- a/apps/web/src/components/team-builder/v2/__tests__/team-workspace-v2.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/team-workspace-v2.test.tsx
@@ -13,7 +13,11 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 
-import { type Tables, type TeamWithPokemon } from "@trainers/supabase";
+import {
+  type Tables,
+  type TablesUpdate,
+  type TeamWithPokemon,
+} from "@trainers/supabase";
 
 // =============================================================================
 // Heavy module mocks — must be declared before any import that references them
@@ -76,7 +80,7 @@ jest.mock("../poke-row", () => ({
     onRemove: (idx: number) => void;
     onPokemonUpdate?: (
       pokemonId: number,
-      fields: Partial<Tables<"pokemon">>
+      fields: Partial<TablesUpdate<"pokemon">>
     ) => void;
   }) => (
     <div data-testid={`poke-row-${idx}`} data-sortable-id={sortableId}>

--- a/apps/web/src/components/team-builder/v2/__tests__/team-workspace-v2.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/team-workspace-v2.test.tsx
@@ -67,15 +67,21 @@ jest.mock("../poke-row", () => ({
     sortableId,
     onAdd,
     onRemove,
+    onPokemonUpdate,
   }: {
     idx: number;
     pokemon: Tables<"pokemon"> | null;
     sortableId: string;
     onAdd: (idx: number, speciesId: string) => void;
     onRemove: (idx: number) => void;
+    onPokemonUpdate?: (
+      pokemonId: number,
+      fields: Partial<Tables<"pokemon">>
+    ) => void;
   }) => (
     <div data-testid={`poke-row-${idx}`} data-sortable-id={sortableId}>
-      {pokemon?.species ?? "empty"}
+      <span data-testid={`species-${idx}`}>{pokemon?.species ?? "empty"}</span>
+      <span data-testid={`nickname-${idx}`}>{pokemon?.nickname ?? ""}</span>
       <button
         data-testid={`add-${idx}`}
         onClick={() => onAdd(idx, "Pikachu")}
@@ -84,6 +90,14 @@ jest.mock("../poke-row", () => ({
       </button>
       <button data-testid={`remove-${idx}`} onClick={() => onRemove(idx)}>
         Remove
+      </button>
+      <button
+        data-testid={`update-${idx}`}
+        onClick={() =>
+          pokemon && onPokemonUpdate?.(pokemon.id, { nickname: "Sparky" })
+        }
+      >
+        Update nickname
       </button>
     </div>
   ),
@@ -265,6 +279,19 @@ function renderWorkspace(
   );
 }
 
+/**
+ * Build a manually-resolvable promise for holding a server action open across
+ * an `await`. Lets a test assert what the UI looks like during the pending
+ * window — the optimistic-UI contract — before the action resolves.
+ */
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve: (value: T) => void = () => {};
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
 // =============================================================================
 // Setup
 // =============================================================================
@@ -385,30 +412,25 @@ describe("TeamWorkspaceV2 — add pokemon flow", () => {
   });
 
   it("renders the new pokemon in the slot optimistically before the server action resolves", async () => {
-    // Hold the action open — the user must see the species in the slot
-    // before the await ever returns.
-    let resolveAdd: (value: { success: true; data: { pokemonId: number } }) => void = () => {};
-    mockAddPokemonToTeamAction.mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          resolveAdd = resolve;
-        })
-    );
+    const { promise, resolve } = deferred<{
+      success: true;
+      data: { pokemonId: number };
+    }>();
+    mockAddPokemonToTeamAction.mockImplementationOnce(() => promise);
 
     const user = userEvent.setup();
     renderWorkspace(EMPTY_TEAM);
 
-    expect(screen.getByTestId("poke-row-0")).toHaveTextContent("empty");
+    expect(screen.getByTestId("species-0")).toHaveTextContent("empty");
 
     await user.click(screen.getByTestId("add-0"));
 
-    // Optimistic UI: species appears in the slot before the server resolves.
     await waitFor(() => {
-      expect(screen.getByTestId("poke-row-0")).toHaveTextContent("Pikachu");
+      expect(screen.getByTestId("species-0")).toHaveTextContent("Pikachu");
     });
     expect(mockRouterRefresh).not.toHaveBeenCalled();
 
-    resolveAdd({ success: true, data: { pokemonId: 99 } });
+    resolve({ success: true, data: { pokemonId: 99 } });
     await waitFor(() => {
       expect(mockRouterRefresh).toHaveBeenCalled();
     });
@@ -427,8 +449,6 @@ describe("TeamWorkspaceV2 — add pokemon flow", () => {
 
     await waitFor(() => {
       expect(mockToastError).toHaveBeenCalledWith("Slot is full.");
-      // refresh on failure rolls the UI back to the canonical server state,
-      // dropping the optimistic placeholder.
       expect(mockRouterRefresh).toHaveBeenCalled();
     });
   });
@@ -489,30 +509,26 @@ describe("TeamWorkspaceV2 — remove pokemon flow", () => {
   });
 
   it("empties the slot optimistically before the server action resolves", async () => {
-    let resolveRemove: (value: { success: true; data: undefined }) => void = () => {};
-    mockRemovePokemonFromTeamAction.mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          resolveRemove = resolve;
-        })
-    );
+    const { promise, resolve } = deferred<{
+      success: true;
+      data: undefined;
+    }>();
+    mockRemovePokemonFromTeamAction.mockImplementationOnce(() => promise);
 
     const user = userEvent.setup();
     renderWorkspace();
 
-    // Slot 0 holds the seeded pokemon before removal.
-    expect(screen.getByTestId("poke-row-0")).not.toHaveTextContent("empty");
+    expect(screen.getByTestId("species-0")).toHaveTextContent("Garchomp");
 
     await user.click(screen.getByTestId("remove-0"));
     await user.click(screen.getByRole("button", { name: /^remove$/i }));
 
-    // Optimistic UI: slot empties before the server resolves.
     await waitFor(() => {
-      expect(screen.getByTestId("poke-row-0")).toHaveTextContent("empty");
+      expect(screen.getByTestId("species-0")).toHaveTextContent("empty");
     });
     expect(mockRouterRefresh).not.toHaveBeenCalled();
 
-    resolveRemove({ success: true, data: undefined });
+    resolve({ success: true, data: undefined });
     await waitFor(() => {
       expect(mockRouterRefresh).toHaveBeenCalled();
     });
@@ -532,8 +548,6 @@ describe("TeamWorkspaceV2 — remove pokemon flow", () => {
 
     await waitFor(() => {
       expect(mockToastError).toHaveBeenCalledWith("Permission denied.");
-      // refresh on failure rolls the UI back to the canonical server state,
-      // restoring the pokemon that was optimistically removed.
       expect(mockRouterRefresh).toHaveBeenCalled();
     });
   });
@@ -586,26 +600,69 @@ describe("TeamWorkspaceV2 — remove pokemon flow", () => {
 // =============================================================================
 
 describe("TeamWorkspaceV2 — optimistic update flow", () => {
-  it("updatePokemonAction is wired and callable", () => {
-    // The component wires handlePokemonUpdate → updatePokemonAction.
-    // Since PokeRow is mocked we verify that the action is importable and
-    // injectable as expected (wiring test — not a shallow prop test).
+  it("calls updatePokemonAction with the team id, pokemon id, and patch fields", async () => {
+    const user = userEvent.setup();
     renderWorkspace();
-    expect(mockUpdatePokemonAction).toBeDefined();
-    expect(typeof mockUpdatePokemonAction).toBe("function");
+
+    await user.click(screen.getByTestId("update-0")); // updates pokemon id 10
+
+    await waitFor(() => {
+      expect(mockUpdatePokemonAction).toHaveBeenCalledWith(1, 10, {
+        nickname: "Sparky",
+      });
+    });
   });
 
-  it("action mock returns the configured failure shape", async () => {
-    // Verify the mock infrastructure works correctly for the error branch.
-    // The component uses this shape to decide whether to call toast.error + router.refresh.
-    mockUpdatePokemonAction.mockResolvedValue({
+  it("renders the patched field optimistically before the server action resolves", async () => {
+    const { promise, resolve } = deferred<{ success: true; data: undefined }>();
+    mockUpdatePokemonAction.mockImplementationOnce(() => promise);
+
+    const user = userEvent.setup();
+    renderWorkspace();
+
+    expect(screen.getByTestId("nickname-0")).toHaveTextContent("");
+
+    await user.click(screen.getByTestId("update-0"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("nickname-0")).toHaveTextContent("Sparky");
+    });
+    expect(mockRouterRefresh).not.toHaveBeenCalled();
+
+    resolve({ success: true, data: undefined });
+    await waitFor(() => {
+      expect(mockRouterRefresh).toHaveBeenCalled();
+    });
+  });
+
+  it("toasts and refreshes (rolling back the optimistic patch) on update failure", async () => {
+    mockUpdatePokemonAction.mockResolvedValueOnce({
       success: false,
       error: "Validation failed.",
     });
 
-    const result = await mockUpdatePokemonAction(1, 10, { ability: "Speed Boost" });
-    expect(result.success).toBe(false);
-    expect(result.error).toBe("Validation failed.");
+    const user = userEvent.setup();
+    renderWorkspace();
+
+    await user.click(screen.getByTestId("update-0"));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Validation failed.");
+      expect(mockRouterRefresh).toHaveBeenCalled();
+    });
+  });
+
+  it("falls back to a generic message when the failure shape omits an error string", async () => {
+    mockUpdatePokemonAction.mockResolvedValueOnce({ success: false });
+
+    const user = userEvent.setup();
+    renderWorkspace();
+
+    await user.click(screen.getByTestId("update-0"));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Failed to save changes.");
+    });
   });
 });
 

--- a/apps/web/src/components/team-builder/v2/__tests__/team-workspace-v2.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/team-workspace-v2.test.tsx
@@ -384,7 +384,37 @@ describe("TeamWorkspaceV2 — add pokemon flow", () => {
     });
   });
 
-  it("shows an error toast and does NOT refresh on add failure", async () => {
+  it("renders the new pokemon in the slot optimistically before the server action resolves", async () => {
+    // Hold the action open — the user must see the species in the slot
+    // before the await ever returns.
+    let resolveAdd: (value: { success: true; data: { pokemonId: number } }) => void = () => {};
+    mockAddPokemonToTeamAction.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveAdd = resolve;
+        })
+    );
+
+    const user = userEvent.setup();
+    renderWorkspace(EMPTY_TEAM);
+
+    expect(screen.getByTestId("poke-row-0")).toHaveTextContent("empty");
+
+    await user.click(screen.getByTestId("add-0"));
+
+    // Optimistic UI: species appears in the slot before the server resolves.
+    await waitFor(() => {
+      expect(screen.getByTestId("poke-row-0")).toHaveTextContent("Pikachu");
+    });
+    expect(mockRouterRefresh).not.toHaveBeenCalled();
+
+    resolveAdd({ success: true, data: { pokemonId: 99 } });
+    await waitFor(() => {
+      expect(mockRouterRefresh).toHaveBeenCalled();
+    });
+  });
+
+  it("shows an error toast and refreshes (rolling back the optimistic add) on add failure", async () => {
     mockAddPokemonToTeamAction.mockResolvedValueOnce({
       success: false,
       error: "Slot is full.",
@@ -397,7 +427,9 @@ describe("TeamWorkspaceV2 — add pokemon flow", () => {
 
     await waitFor(() => {
       expect(mockToastError).toHaveBeenCalledWith("Slot is full.");
-      expect(mockRouterRefresh).not.toHaveBeenCalled();
+      // refresh on failure rolls the UI back to the canonical server state,
+      // dropping the optimistic placeholder.
+      expect(mockRouterRefresh).toHaveBeenCalled();
     });
   });
 
@@ -456,7 +488,37 @@ describe("TeamWorkspaceV2 — remove pokemon flow", () => {
     });
   });
 
-  it("shows error toast and does NOT refresh on removal failure", async () => {
+  it("empties the slot optimistically before the server action resolves", async () => {
+    let resolveRemove: (value: { success: true; data: undefined }) => void = () => {};
+    mockRemovePokemonFromTeamAction.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRemove = resolve;
+        })
+    );
+
+    const user = userEvent.setup();
+    renderWorkspace();
+
+    // Slot 0 holds the seeded pokemon before removal.
+    expect(screen.getByTestId("poke-row-0")).not.toHaveTextContent("empty");
+
+    await user.click(screen.getByTestId("remove-0"));
+    await user.click(screen.getByRole("button", { name: /^remove$/i }));
+
+    // Optimistic UI: slot empties before the server resolves.
+    await waitFor(() => {
+      expect(screen.getByTestId("poke-row-0")).toHaveTextContent("empty");
+    });
+    expect(mockRouterRefresh).not.toHaveBeenCalled();
+
+    resolveRemove({ success: true, data: undefined });
+    await waitFor(() => {
+      expect(mockRouterRefresh).toHaveBeenCalled();
+    });
+  });
+
+  it("shows error toast and refreshes (rolling back the optimistic remove) on removal failure", async () => {
     mockRemovePokemonFromTeamAction.mockResolvedValueOnce({
       success: false,
       error: "Permission denied.",
@@ -470,7 +532,9 @@ describe("TeamWorkspaceV2 — remove pokemon flow", () => {
 
     await waitFor(() => {
       expect(mockToastError).toHaveBeenCalledWith("Permission denied.");
-      expect(mockRouterRefresh).not.toHaveBeenCalled();
+      // refresh on failure rolls the UI back to the canonical server state,
+      // restoring the pokemon that was optimistically removed.
+      expect(mockRouterRefresh).toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/components/team-builder/v2/__tests__/team-workspace-v2.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/team-workspace-v2.test.tsx
@@ -169,10 +169,12 @@ jest.mock("../builder.module.css", () => new Proxy({}, { get: (_t, k) => k }));
 // Toast — capture calls
 const mockToastError = jest.fn();
 const mockToastSuccess = jest.fn();
+const mockToastInfo = jest.fn();
 jest.mock("sonner", () => ({
   toast: {
     error: (...args: unknown[]) => mockToastError(...args),
     success: (...args: unknown[]) => mockToastSuccess(...args),
+    info: (...args: unknown[]) => mockToastInfo(...args),
   },
 }));
 
@@ -592,6 +594,51 @@ describe("TeamWorkspaceV2 — remove pokemon flow", () => {
       // No pokemon in slot → action should not be called
       expect(mockRemovePokemonFromTeamAction).not.toHaveBeenCalled();
     });
+  });
+});
+
+// =============================================================================
+// optimistic placeholder guards — block mutate/remove/reorder for negative ids
+// =============================================================================
+
+describe("TeamWorkspaceV2 — optimistic placeholder guards", () => {
+  /** Team where slot 0 holds a not-yet-saved pokemon (negative id). */
+  const PENDING_TEAM = makeTeam([
+    {
+      id: -1,
+      pokemon_id: -1,
+      team_position: 1,
+      pokemon: makePokemon(-1, "Pikachu"),
+    },
+  ]);
+
+  it("update on a pending placeholder is skipped and shows an info toast", async () => {
+    const user = userEvent.setup();
+    renderWorkspace(PENDING_TEAM);
+
+    await user.click(screen.getByTestId("update-0"));
+
+    await waitFor(() => {
+      expect(mockToastInfo).toHaveBeenCalledWith(
+        expect.stringContaining("Still saving")
+      );
+    });
+    expect(mockUpdatePokemonAction).not.toHaveBeenCalled();
+  });
+
+  it("remove on a pending placeholder is skipped and shows an info toast", async () => {
+    const user = userEvent.setup();
+    renderWorkspace(PENDING_TEAM);
+
+    await user.click(screen.getByTestId("remove-0"));
+    await user.click(screen.getByRole("button", { name: /^remove$/i }));
+
+    await waitFor(() => {
+      expect(mockToastInfo).toHaveBeenCalledWith(
+        expect.stringContaining("Still saving")
+      );
+    });
+    expect(mockRemovePokemonFromTeamAction).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/components/team-builder/v2/team-workspace-v2.tsx
+++ b/apps/web/src/components/team-builder/v2/team-workspace-v2.tsx
@@ -123,6 +123,10 @@ function buildOptimisticTeamPokemon(
   position: number,
   tempId: number
 ): TeamWithPokemon["team_pokemon"][number] {
+  // Numeric and boolean defaults mirror pokemonPayloadSchema's `.default(...)`
+  // values — the same defaults the server applies on insert. Without them the
+  // optimistic row would render with null fields then visibly snap to 50/0/31
+  // when router.refresh lands the canonical row.
   const pokemon: Tables<"pokemon"> = {
     id: tempId,
     species,
@@ -137,22 +141,22 @@ function buildOptimisticTeamPokemon(
     held_item: null,
     tera_type: null,
     gender: null,
-    is_shiny: null,
-    level: null,
+    is_shiny: false,
+    level: 50,
     format_legal: null,
     created_at: null,
-    ev_hp: null,
-    ev_attack: null,
-    ev_defense: null,
-    ev_special_attack: null,
-    ev_special_defense: null,
-    ev_speed: null,
-    iv_hp: null,
-    iv_attack: null,
-    iv_defense: null,
-    iv_special_attack: null,
-    iv_special_defense: null,
-    iv_speed: null,
+    ev_hp: 0,
+    ev_attack: 0,
+    ev_defense: 0,
+    ev_special_attack: 0,
+    ev_special_defense: 0,
+    ev_speed: 0,
+    iv_hp: 31,
+    iv_attack: 31,
+    iv_defense: 31,
+    iv_special_attack: 31,
+    iv_special_defense: 31,
+    iv_speed: 31,
   };
   return {
     id: tempId,
@@ -260,7 +264,10 @@ export function TeamWorkspaceV2({
               : tp
           );
         case "remove":
-          return current.filter((tp) => tp.pokemon?.id !== action.pokemonId);
+          // Filter by pokemon_id (always non-null) rather than pokemon?.id —
+          // the join can theoretically yield `pokemon: null` rows even though
+          // pokemon_id holds the canonical FK.
+          return current.filter((tp) => tp.pokemon_id !== action.pokemonId);
         case "add": {
           // Replace any existing entry at the same position with the placeholder.
           const filtered = current.filter(
@@ -296,6 +303,12 @@ export function TeamWorkspaceV2({
     pokemonId: number,
     fields: Partial<TablesUpdate<"pokemon">>
   ) {
+    // Negative ids are optimistic placeholders — the row hasn't landed in
+    // the DB yet, so the server can't accept an update for it.
+    if (pokemonId < 1) {
+      toast.info("Still saving the new Pokémon — try again in a moment.");
+      return;
+    }
     startTransition(async () => {
       applyOptimistic({ kind: "update", pokemonId, fields });
       const result = await updatePokemonAction(team.id, pokemonId, fields);
@@ -349,6 +362,11 @@ export function TeamWorkspaceV2({
     setRemoveSlotIdx(null);
     if (!p) return;
     const pokemonId = p.id;
+
+    if (pokemonId < 1) {
+      toast.info("Still saving the new Pokémon — try again in a moment.");
+      return;
+    }
 
     startTransition(async () => {
       applyOptimistic({ kind: "remove", pokemonId });
@@ -406,6 +424,14 @@ export function TeamWorkspaceV2({
   async function handleDragEnd(event: DragEndEvent) {
     const { active, over } = event;
     if (!over || active.id === over.id) return;
+
+    // Block reorder while any optimistic placeholder is pending — its negative
+    // id can't be sent to reorderTeamPokemonAction (rejected by positiveIntSchema)
+    // and a partial reorder would desync the UI from the server.
+    if (optimisticTeamPokemon.some((tp) => tp.pokemon_id < 1)) {
+      toast.info("Still saving the new Pokémon — try reordering in a moment.");
+      return;
+    }
 
     const oldIndex = itemIds.indexOf(active.id as string);
     const newIndex = itemIds.indexOf(over.id as string);

--- a/apps/web/src/components/team-builder/v2/team-workspace-v2.tsx
+++ b/apps/web/src/components/team-builder/v2/team-workspace-v2.tsx
@@ -97,6 +97,72 @@ function buildSlots(
 }
 
 // =============================================================================
+// Optimistic state — actions and placeholder construction
+// =============================================================================
+
+type OptimisticAction =
+  | {
+      kind: "update";
+      pokemonId: number;
+      fields: Partial<Tables<"pokemon">>;
+    }
+  | { kind: "add"; position: number; species: string }
+  | { kind: "remove"; pokemonId: number };
+
+/**
+ * Counter for placeholder ids on optimistic adds. Negative so they can never
+ * collide with real DB ids; decremented per call so multiple concurrent adds
+ * still get unique keys for React reconciliation.
+ */
+let nextOptimisticId = -1;
+
+/**
+ * Build a placeholder team_pokemon entry for an optimistic add. Mirrors the
+ * server-side defaults in addPokemonToTeamAction (ability/move1 empty, neutral
+ * Serious nature) so the optimistic row matches what the DB actually inserts.
+ */
+function buildOptimisticTeamPokemon(species: string, position: number) {
+  const tempId = nextOptimisticId--;
+  const pokemon: Tables<"pokemon"> = {
+    id: tempId,
+    species,
+    ability: "",
+    move1: "",
+    move2: null,
+    move3: null,
+    move4: null,
+    nature: "Serious",
+    nickname: null,
+    notes: null,
+    held_item: null,
+    tera_type: null,
+    gender: null,
+    is_shiny: null,
+    level: null,
+    format_legal: null,
+    created_at: null,
+    ev_hp: null,
+    ev_attack: null,
+    ev_defense: null,
+    ev_special_attack: null,
+    ev_special_defense: null,
+    ev_speed: null,
+    iv_hp: null,
+    iv_attack: null,
+    iv_defense: null,
+    iv_special_attack: null,
+    iv_special_defense: null,
+    iv_speed: null,
+  };
+  return {
+    id: tempId,
+    pokemon_id: tempId,
+    team_position: position,
+    pokemon,
+  };
+}
+
+// =============================================================================
 // DockbarConnected
 // =============================================================================
 
@@ -165,24 +231,32 @@ export function TeamWorkspaceV2({
   // ---------------------------------------------------------------------------
   // Optimistic team-pokemon state
   //
-  // applyOptimisticPatch updates the UI on the next paint; the server save runs
-  // in the background via startTransition. On failure: toast + revert.
+  // applyOptimistic updates the UI on the next paint; the server save runs
+  // in the background via startTransition. router.refresh() is what drives the
+  // transition to completion — at that point useOptimistic reverts to the
+  // (now updated) prop and the optimistic patch is dropped cleanly. On
+  // failure: toast + refresh to roll back to canonical server state.
   // ---------------------------------------------------------------------------
 
-  const [optimisticTeamPokemon, applyOptimisticPatch] = useOptimistic(
+  const [optimisticTeamPokemon, applyOptimistic] = useOptimistic(
     team.team_pokemon,
-    (
-      current,
-      {
-        pokemonId,
-        fields,
-      }: { pokemonId: number; fields: Partial<Tables<"pokemon">> }
-    ) =>
-      current.map((tp) =>
-        tp.pokemon_id === pokemonId && tp.pokemon
-          ? { ...tp, pokemon: { ...tp.pokemon, ...fields } }
-          : tp
-      )
+    (current, action: OptimisticAction) => {
+      if (action.kind === "update") {
+        return current.map((tp) =>
+          tp.pokemon_id === action.pokemonId && tp.pokemon
+            ? { ...tp, pokemon: { ...tp.pokemon, ...action.fields } }
+            : tp
+        );
+      }
+      if (action.kind === "remove") {
+        return current.filter((tp) => tp.pokemon?.id !== action.pokemonId);
+      }
+      // add — replace any existing entry at the same position with a placeholder
+      const filtered = current.filter(
+        (tp) => tp.team_position !== action.position
+      );
+      return [...filtered, buildOptimisticTeamPokemon(action.species, action.position)];
+    }
   );
 
   const [, startTransition] = useTransition();
@@ -203,15 +277,14 @@ export function TeamWorkspaceV2({
     fields: Partial<TablesUpdate<"pokemon">>
   ) {
     startTransition(async () => {
-      applyOptimisticPatch({ pokemonId, fields });
+      applyOptimistic({ kind: "update", pokemonId, fields });
       const result = await updatePokemonAction(team.id, pokemonId, fields);
       if (!result.success) {
         toast.error(result.error ?? "Failed to save changes.");
-        // Refresh to revert the optimistic patch — the server rejected the change
-        // so the UI must roll back to the last known server state.
-        router.refresh();
-        return;
       }
+      // router.refresh runs in both branches — on success it lands the canonical
+      // server state into the prop so useOptimistic reverts cleanly; on failure
+      // it rolls the UI back to last known good.
       router.refresh();
     });
   }
@@ -232,9 +305,13 @@ export function TeamWorkspaceV2({
     };
 
     startTransition(async () => {
+      // Optimistic insert lands on the next paint — the user sees the new
+      // pokemon in the slot before the network round-trip finishes.
+      applyOptimistic({ kind: "add", position, species: speciesId });
       const result = await addPokemonToTeamAction(team.id, pokemon, position);
       if (!result.success) {
         toast.error(result.error ?? "Failed to add Pokémon.");
+        router.refresh();
         return;
       }
       toast.success(`${speciesId} added to slot ${position}.`);
@@ -256,9 +333,13 @@ export function TeamWorkspaceV2({
     const pokemonId = p.id;
 
     startTransition(async () => {
+      // Optimistic remove — the slot empties on the next paint, the server
+      // delete and revalidation run in the background.
+      applyOptimistic({ kind: "remove", pokemonId });
       const result = await removePokemonFromTeamAction(team.id, pokemonId);
       if (!result.success) {
         toast.error(result.error ?? "Failed to remove Pokémon.");
+        router.refresh();
         return;
       }
       toast.success("Pokémon removed.");

--- a/apps/web/src/components/team-builder/v2/team-workspace-v2.tsx
+++ b/apps/web/src/components/team-builder/v2/team-workspace-v2.tsx
@@ -96,33 +96,33 @@ function buildSlots(
   return slots;
 }
 
-// =============================================================================
-// Optimistic state — actions and placeholder construction
-// =============================================================================
-
 type OptimisticAction =
   | {
       kind: "update";
       pokemonId: number;
-      fields: Partial<Tables<"pokemon">>;
+      fields: Partial<TablesUpdate<"pokemon">>;
     }
-  | { kind: "add"; position: number; species: string }
+  | {
+      kind: "add";
+      position: number;
+      species: string;
+      // Generated in the event handler so the reducer stays pure — React may
+      // invoke the reducer multiple times during reconciliation, and the row
+      // must keep the same React key across every call.
+      tempId: number;
+    }
   | { kind: "remove"; pokemonId: number };
 
 /**
- * Counter for placeholder ids on optimistic adds. Negative so they can never
- * collide with real DB ids; decremented per call so multiple concurrent adds
- * still get unique keys for React reconciliation.
+ * Build a placeholder team_pokemon entry for an optimistic add. Defaults
+ * mirror addPokemonToTeamAction (ability/move1 empty, Serious nature) so
+ * the optimistic row matches what the DB actually inserts.
  */
-let nextOptimisticId = -1;
-
-/**
- * Build a placeholder team_pokemon entry for an optimistic add. Mirrors the
- * server-side defaults in addPokemonToTeamAction (ability/move1 empty, neutral
- * Serious nature) so the optimistic row matches what the DB actually inserts.
- */
-function buildOptimisticTeamPokemon(species: string, position: number) {
-  const tempId = nextOptimisticId--;
+function buildOptimisticTeamPokemon(
+  species: string,
+  position: number,
+  tempId: number
+): TeamWithPokemon["team_pokemon"][number] {
   const pokemon: Tables<"pokemon"> = {
     id: tempId,
     species,
@@ -228,34 +228,54 @@ export function TeamWorkspaceV2({
    *  pointer's offset within the lane during drag. */
   const worklaneRef = useRef<HTMLDivElement | null>(null);
 
+  /**
+   * Counter for placeholder ids on optimistic adds. Negative so they can
+   * never collide with real DB ids (bigint identity columns are always
+   * positive); decremented per call so multiple concurrent adds still get
+   * unique React keys. Lives on a ref so it's instance-scoped — no module-
+   * level shared state across tabs, tests, or HMR reloads.
+   */
+  const nextOptimisticIdRef = useRef(-1);
+
   // ---------------------------------------------------------------------------
   // Optimistic team-pokemon state
   //
-  // applyOptimistic updates the UI on the next paint; the server save runs
-  // in the background via startTransition. router.refresh() is what drives the
-  // transition to completion — at that point useOptimistic reverts to the
-  // (now updated) prop and the optimistic patch is dropped cleanly. On
-  // failure: toast + refresh to roll back to canonical server state.
+  // The reducer must stay pure — React may call it multiple times during
+  // reconciliation. Side effects (e.g., generating temp ids for `add`) live
+  // in the event handler and are passed in via the action payload.
+  //
+  // router.refresh() ends every transition — on success it lands the canonical
+  // server state into the prop so useOptimistic reverts cleanly; on failure
+  // it rolls the UI back to last known good. Both paths must call it.
   // ---------------------------------------------------------------------------
 
   const [optimisticTeamPokemon, applyOptimistic] = useOptimistic(
     team.team_pokemon,
     (current, action: OptimisticAction) => {
-      if (action.kind === "update") {
-        return current.map((tp) =>
-          tp.pokemon_id === action.pokemonId && tp.pokemon
-            ? { ...tp, pokemon: { ...tp.pokemon, ...action.fields } }
-            : tp
-        );
+      switch (action.kind) {
+        case "update":
+          return current.map((tp) =>
+            tp.pokemon_id === action.pokemonId && tp.pokemon
+              ? { ...tp, pokemon: { ...tp.pokemon, ...action.fields } }
+              : tp
+          );
+        case "remove":
+          return current.filter((tp) => tp.pokemon?.id !== action.pokemonId);
+        case "add": {
+          // Replace any existing entry at the same position with the placeholder.
+          const filtered = current.filter(
+            (tp) => tp.team_position !== action.position
+          );
+          return [
+            ...filtered,
+            buildOptimisticTeamPokemon(
+              action.species,
+              action.position,
+              action.tempId
+            ),
+          ];
+        }
       }
-      if (action.kind === "remove") {
-        return current.filter((tp) => tp.pokemon?.id !== action.pokemonId);
-      }
-      // add — replace any existing entry at the same position with a placeholder
-      const filtered = current.filter(
-        (tp) => tp.team_position !== action.position
-      );
-      return [...filtered, buildOptimisticTeamPokemon(action.species, action.position)];
     }
   );
 
@@ -282,9 +302,6 @@ export function TeamWorkspaceV2({
       if (!result.success) {
         toast.error(result.error ?? "Failed to save changes.");
       }
-      // router.refresh runs in both branches — on success it lands the canonical
-      // server state into the prop so useOptimistic reverts cleanly; on failure
-      // it rolls the UI back to last known good.
       router.refresh();
     });
   }
@@ -303,11 +320,12 @@ export function TeamWorkspaceV2({
       move1: "",
       nature: "Serious",
     };
+    // Generate the temp id here, not in the reducer — the reducer must be
+    // pure across React's reconciliation re-invocations.
+    const tempId = nextOptimisticIdRef.current--;
 
     startTransition(async () => {
-      // Optimistic insert lands on the next paint — the user sees the new
-      // pokemon in the slot before the network round-trip finishes.
-      applyOptimistic({ kind: "add", position, species: speciesId });
+      applyOptimistic({ kind: "add", position, species: speciesId, tempId });
       const result = await addPokemonToTeamAction(team.id, pokemon, position);
       if (!result.success) {
         toast.error(result.error ?? "Failed to add Pokémon.");
@@ -333,8 +351,6 @@ export function TeamWorkspaceV2({
     const pokemonId = p.id;
 
     startTransition(async () => {
-      // Optimistic remove — the slot empties on the next paint, the server
-      // delete and revalidation run in the background.
       applyOptimistic({ kind: "remove", pokemonId });
       const result = await removePokemonFromTeamAction(team.id, pokemonId);
       if (!result.success) {


### PR DESCRIPTION
## Summary

- Adding a Pokemon to a slot blocked on the full server round-trip + RSC refresh before any UI feedback. Same for remove. Only \`update\` was using \`useOptimistic\`.
- Extends the \`useOptimistic\` reducer in \`team-workspace-v2.tsx\` to a discriminated union over \`add\` / \`remove\` / \`update\`. Both \`handleAdd\` and \`handleConfirmRemove\` apply the optimistic patch before awaiting the server action — the slot reflects the change on the next paint.
- \`router.refresh()\` now runs in both success and failure branches so \`useOptimistic\` reverts cleanly to canonical server state when the transition completes (or rolls back on error).

## Test plan

- [x] \`pnpm lint\` — clean
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test\` — 5010/5010 pass, including 2 new regression tests that hold the server action open with an unresolved promise to pin optimistic UI behavior
- [ ] E2E in CI (couldn't run locally — Supabase container wasn't up; change is purely client-side state, no plausible E2E impact)
- [ ] Manual smoke: open team builder, add a Pokemon, confirm it appears instantly; remove a Pokemon, confirm slot empties instantly; trigger a server-side legality violation, confirm UI rolls back

## Notes for reviewer

Did **not** touch in this PR (called out for follow-up if perceived perf is still off):
- Server-side \`getTeamWithPokemon\` legality fetch in \`addPokemonToTeamAction\` (extra query before insert).
- Update throttling for rapid EV slider drags — still triggers \`router.refresh()\` on every keystroke. Optimistic UI hides the lag but the server-side cost compounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved optimistic UI updates for adding, removing, and updating Pokémon in your team builder
  * Changes now display immediately in the interface while processing on the server
  * Enhanced error handling with proper rollback and clearer error messages when operations fail

<!-- end of auto-generated comment: release notes by coderabbit.ai -->