### PR TITLE
fix(team-builder): remove ~16px viewport overflow causing minor scroll

### DIFF
--- a/apps/web/src/app/(dashboard)/dashboard/alts/[username]/teams/[teamId]/layout.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/alts/[username]/teams/[teamId]/layout.tsx
@@ -68,5 +68,5 @@ export default async function TeamWorkspaceLayout({
     notFound();
   }
 
-  return <div className="flex h-full min-h-dvh flex-col">{children}</div>;
+  return <div className="flex h-full flex-col">{children}</div>;
 }

--- a/apps/web/src/components/team-builder/v2/builder.module.css
+++ b/apps/web/src/components/team-builder/v2/builder.module.css
@@ -1,7 +1,7 @@
 .builderApp {
   display: flex;
   flex-direction: column;
-  height: 100dvh;
+  height: 100%;
   overflow: hidden;
 
   /* ── KO-tier semantic tokens ─────────────────────────────────────────────


### PR DESCRIPTION
The builder used height: 100dvh inside a SidebarInset with m-2 margin, making the page scrollable by ~16px. Match the container height instead.