### PR TITLE
fix(team-builder): match empty slot layout to filled state in grid layouts

### DIFF
--- a/apps/web/src/components/team-builder/v2/__tests__/poke-row.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/poke-row.test.tsx
@@ -339,7 +339,7 @@ describe("PokeRow — empty slot", () => {
     expect(screen.getAllByText(/\+ Add move/i)).toHaveLength(4);
   });
 
-  it("outer button has w-fit and self-center classes", () => {
+  it("outer button has w-full to fill its grid cell", () => {
     render(
       <PokeRow
         idx={0}
@@ -352,10 +352,7 @@ describe("PokeRow — empty slot", () => {
       />
     );
     const button = screen.getByText(/\+ Add Pokémon/i).closest("button")!;
-    expect(button.className).toContain("w-fit");
-    // self-center keeps each row centered horizontally inside .builderRows
-    // when its content is narrower than the editor lane.
-    expect(button.className).toContain("self-center");
+    expect(button.className).toContain("w-full");
   });
 
   it("ghost lane components do not introduce nested buttons inside the wrapper", () => {

--- a/apps/web/src/components/team-builder/v2/lanes/active-row.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/active-row.tsx
@@ -113,7 +113,7 @@ export function ActiveRow({
     <div
       className={cn(
         s.rowActive,
-        "bg-card flex w-full min-w-0 items-stretch self-center overflow-hidden rounded-lg border",
+        "bg-card flex h-full w-full min-w-0 items-stretch self-center overflow-hidden rounded-lg border",
         "border-primary/60 shadow-[0_0_0_1px_hsl(var(--primary)/0.3),0_8px_28px_-16px_hsl(var(--primary)/0.4)]",
         isDragging && s.rowDragging
       )}

--- a/apps/web/src/components/team-builder/v2/lanes/identity/identity-lane-ghost.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/identity/identity-lane-ghost.tsx
@@ -90,18 +90,30 @@ function VerticalGhost() {
     <div className={ids.vertRoot}>
       <div className={ids.vertSpriteFormRow}>
         <div className={ids.vertSpriteCol}>
-          <SpriteGhost size={120} />
+          <SpriteGhost />
           <SpeciesPillGhost />
         </div>
 
-        <div className={ids.vertFormCol}>
-          {/* MetaBar ghost — nickname + level/gender/shiny placeholders */}
-          <div className="flex h-[22px] items-center gap-2">
-            <span className="text-muted-foreground/20 text-sm font-normal italic">
+        <div className={ids.vertFormCol} style={{ minWidth: 263 }}>
+          {/* MetaBar ghost — matches .midMetaBar grid (1fr auto) */}
+          <div className={cn(ids.midMetaBar, ids.midMetaBarNoLv)}>
+            <span
+              className={cn(ids.midNickname, "text-muted-foreground/20 italic")}
+            >
               Nickname
             </span>
-            <span className="text-muted-foreground/20 text-xs">—</span>
-            <span className="text-muted-foreground/20 text-xs">+</span>
+            <span className={ids.midRightPills}>
+              <span
+                className={cn(ids.midPill, "pointer-events-none opacity-30")}
+              >
+                —
+              </span>
+              <span
+                className={cn(ids.midPill, "pointer-events-none opacity-30")}
+              >
+                ✦
+              </span>
+            </span>
           </div>
           <MidFormRowsGhost />
         </div>
@@ -128,7 +140,12 @@ function SpeciesPillGhost() {
 }
 
 function SpriteGhost({ size = 144 }: { size?: number }) {
-  return <div className="bg-muted/40 rounded-xl" style={{ width: size, height: size }} />;
+  return (
+    <div
+      className="bg-muted/40 rounded-xl"
+      style={{ width: size, height: size }}
+    />
+  );
 }
 
 function BannerGhost() {
@@ -152,9 +169,7 @@ function FormRowsGhost() {
       {(["Item", "Abil", "Nat"] as const).map((label) => (
         <div key={label} className={s.formRow}>
           <span className={s.formLabel}>{label}</span>
-          <span
-            className={cn(s.formValue, "text-muted-foreground/25 italic")}
-          >
+          <span className={cn(s.formValue, "text-muted-foreground/25 italic")}>
             —
           </span>
         </div>

--- a/apps/web/src/components/team-builder/v2/lanes/identity/identity-lane-ghost.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/identity/identity-lane-ghost.tsx
@@ -59,7 +59,12 @@ function MidGhost() {
       {/* MetaBar ghost — nickname placeholder, same height as real MetaBar */}
       <div className={ids.midMetaBar}>
         <span />
-        <span className="text-muted-foreground/20 text-sm font-normal italic">
+        <span
+          className={cn(
+            ids.midNickname,
+            "pointer-events-none text-muted-foreground/20 italic"
+          )}
+        >
           Nickname
         </span>
         <span />
@@ -139,7 +144,11 @@ function SpeciesPillGhost() {
   );
 }
 
-function SpriteGhost({ size = 144 }: { size?: number }) {
+interface SpriteGhostProps {
+  size?: number;
+}
+
+function SpriteGhost({ size = 144 }: SpriteGhostProps) {
   return (
     <div
       className="bg-muted/40 rounded-xl"

--- a/apps/web/src/components/team-builder/v2/lanes/identity/identity-lane-ghost.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/identity/identity-lane-ghost.tsx
@@ -3,6 +3,7 @@
 import { cn } from "@/lib/utils";
 
 import s from "../../builder.module.css";
+import ids from "./identity-lane.module.css";
 
 // =============================================================================
 // IdentityLaneGhost — static visual placeholder (no interactive elements)
@@ -10,51 +11,171 @@ import s from "../../builder.module.css";
 // Rendered by the dispatcher when pokemon == null. No buttons, inputs, or
 // popovers — safe to place inside an outer <button> wrapper (EmptyRow)
 // without violating nested-button constraints.
+//
+// variant="compact" — 1x6 layout, horizontal sprite+form (IdentitySingleRow)
+// variant="mid"     — 2x3 layout, vertical column stack (IdentityMidStack)
 // =============================================================================
 
-export function IdentityLaneGhost() {
+interface IdentityLaneGhostProps {
+  variant: "compact" | "mid" | "vertical";
+}
+
+export function IdentityLaneGhost({ variant }: IdentityLaneGhostProps) {
+  if (variant === "vertical") return <VerticalGhost />;
+  if (variant === "mid") return <MidGhost />;
+  return <CompactGhost />;
+}
+
+// ---------------------------------------------------------------------------
+// CompactGhost — horizontal layout matching IdentitySingleRow
+// ---------------------------------------------------------------------------
+
+function CompactGhost() {
   return (
     <div className="flex min-w-0 gap-3 p-3">
-      {/* Sprite column */}
-      <div className="flex shrink-0 flex-col items-center justify-center gap-2 self-center">
-        {/* Species pill ghost — static div, NOT a button */}
-        <div className="border-border bg-background flex w-36 items-center gap-1 rounded-md border border-dashed px-2 py-1.5 text-left text-xs sm:w-40 md:w-44">
-          <span className="text-muted-foreground/50 min-w-0 flex-1 truncate">
-            + Add Pokémon
-          </span>
-          <span aria-hidden className="text-muted-foreground/30 text-[9px]">
-            ▾
-          </span>
-        </div>
-        {/* Sprite ghost — static div, NOT a button */}
-        <div className="bg-muted/40 size-[144px] rounded-xl" />
+      {/* Sprite column — w-52 matches the filled SpeciesPicker pill width */}
+      <div className="flex w-52 shrink-0 flex-col items-center justify-center gap-2 self-center">
+        <SpeciesPillGhost />
+        <SpriteGhost />
       </div>
 
-      {/* Form column */}
-      <div className="flex w-56 min-w-0 shrink-0 flex-col justify-center gap-0.5">
-        {/* Banner ghost — same className as real banner */}
-        <div className={s.idBanner}>
-          <div className="flex h-[22px] items-center">
+      {/* Form column — w-64 matches IdentitySingleRow */}
+      <div className="flex w-64 min-w-0 shrink-0 flex-col justify-center gap-0.5">
+        <BannerGhost />
+        <FormRowsGhost />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// MidGhost — vertical column layout matching IdentityMidStack
+//   midRoot (380px column) → MetaBar → midBody → midSpriteCol → midFormCol
+// ---------------------------------------------------------------------------
+
+function MidGhost() {
+  return (
+    <div className={ids.midRoot}>
+      {/* MetaBar ghost — nickname placeholder, same height as real MetaBar */}
+      <div className={ids.midMetaBar}>
+        <span />
+        <span className="text-muted-foreground/20 text-sm font-normal italic">
+          Nickname
+        </span>
+        <span />
+      </div>
+
+      {/* Body — sprite + form stacked vertically, centered */}
+      <div className={ids.midBody}>
+        <div className={ids.midSpriteCol}>
+          <SpeciesPillGhost />
+          <SpriteGhost />
+        </div>
+
+        <div className={ids.midFormCol}>
+          <MidFormRowsGhost />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// VerticalGhost — side-by-side sprite+form matching IdentityVertical
+//   vertRoot → vertSpriteFormRow → vertSpriteCol + vertFormCol (with MetaBar)
+// ---------------------------------------------------------------------------
+
+function VerticalGhost() {
+  return (
+    <div className={ids.vertRoot}>
+      <div className={ids.vertSpriteFormRow}>
+        <div className={ids.vertSpriteCol}>
+          <SpriteGhost size={120} />
+          <SpeciesPillGhost />
+        </div>
+
+        <div className={ids.vertFormCol}>
+          {/* MetaBar ghost — nickname + level/gender/shiny placeholders */}
+          <div className="flex h-[22px] items-center gap-2">
             <span className="text-muted-foreground/20 text-sm font-normal italic">
               Nickname
             </span>
+            <span className="text-muted-foreground/20 text-xs">—</span>
+            <span className="text-muted-foreground/20 text-xs">+</span>
           </div>
-          <div className="flex h-[18px] items-center gap-1">
-            <div className="bg-muted/30 h-3.5 w-10 rounded" />
-          </div>
+          <MidFormRowsGhost />
         </div>
-        {/* Loadout rows ghost — Item / Abil / Nat with em-dashes, static divs */}
-        {(["Item", "Abil", "Nat"] as const).map((label) => (
-          <div key={label} className={s.formRow}>
-            <span className={s.formLabel}>{label}</span>
-            <span
-              className={cn(s.formValue, "text-muted-foreground/25 italic")}
-            >
-              —
-            </span>
-          </div>
-        ))}
       </div>
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared ghost pieces
+// ---------------------------------------------------------------------------
+
+function SpeciesPillGhost() {
+  return (
+    <div className="border-border bg-background flex w-full items-center gap-1 rounded-md border border-dashed px-2 py-1.5 text-left text-xs">
+      <span className="text-muted-foreground/50 min-w-0 flex-1 truncate">
+        + Add Pokémon
+      </span>
+      <span aria-hidden className="text-muted-foreground/30 text-[9px]">
+        ▾
+      </span>
+    </div>
+  );
+}
+
+function SpriteGhost({ size = 144 }: { size?: number }) {
+  return <div className="bg-muted/40 rounded-xl" style={{ width: size, height: size }} />;
+}
+
+function BannerGhost() {
+  return (
+    <div className={s.idBanner}>
+      <div className="flex h-[22px] items-center">
+        <span className="text-muted-foreground/20 text-sm font-normal italic">
+          Nickname
+        </span>
+      </div>
+      <div className="flex h-[18px] items-center gap-1">
+        <div className="bg-muted/30 h-3.5 w-10 rounded" />
+      </div>
+    </div>
+  );
+}
+
+function FormRowsGhost() {
+  return (
+    <>
+      {(["Item", "Abil", "Nat"] as const).map((label) => (
+        <div key={label} className={s.formRow}>
+          <span className={s.formLabel}>{label}</span>
+          <span
+            className={cn(s.formValue, "text-muted-foreground/25 italic")}
+          >
+            —
+          </span>
+        </div>
+      ))}
+    </>
+  );
+}
+
+function MidFormRowsGhost() {
+  return (
+    <>
+      {(["Item", "Abil", "Nat"] as const).map((label) => (
+        <div key={label} className={ids.midFormCell}>
+          <span className={ids.midFormLbl}>{label}</span>
+          <span
+            className={cn(ids.midFormVal, "text-muted-foreground/25 italic")}
+          >
+            —
+          </span>
+        </div>
+      ))}
+    </>
   );
 }

--- a/apps/web/src/components/team-builder/v2/lanes/identity/identity-lane.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/identity/identity-lane.tsx
@@ -73,7 +73,7 @@ export function IdentityLane({
   return (
     <div ref={rootRef} className="contents">
       {!pokemon ? (
-        <IdentityLaneGhost />
+        <IdentityLaneGhost variant={isCompact ? "compact" : isVertical ? "vertical" : "mid"} />
       ) : isCompact ? (
         <IdentitySingleRow pokemon={pokemon} {...sharedProps} />
       ) : isVertical ? (

--- a/apps/web/src/components/team-builder/v2/poke-row.tsx
+++ b/apps/web/src/components/team-builder/v2/poke-row.tsx
@@ -80,13 +80,14 @@ function EmptyRow({ idx, format: _format, onAdd }: EmptyRowProps) {
         onClick={() => setOpen(true)}
         aria-label={`Add Pokémon to slot ${String(idx + 1).padStart(2, "0")}`}
         className={cn(
-          "border-border bg-card flex w-fit min-w-0 flex-wrap items-stretch self-center overflow-hidden rounded-lg border border-dashed",
+          s.rowActive,
+          "border-border bg-card flex h-full w-full min-w-0 items-stretch overflow-hidden rounded-lg border border-dashed",
           "hover:border-primary/40 hover:bg-muted/10 text-left transition-colors",
           "focus-visible:ring-primary focus-visible:ring-2 focus-visible:outline-none"
         )}
       >
         {/* RIB — slot number + × placeholder */}
-        <div className="border-border/60 bg-muted/20 flex w-10 shrink-0 flex-col items-center justify-between border-r border-dashed py-2">
+        <div className={cn(s.rib, "border-border/60 bg-muted/20 flex shrink-0 border-dashed")}>
           <span className="text-muted-foreground font-mono text-[10px] font-medium tracking-wide">
             {String(idx + 1).padStart(2, "0")}
           </span>
@@ -95,10 +96,14 @@ function EmptyRow({ idx, format: _format, onAdd }: EmptyRowProps) {
           </span>
         </div>
 
-        <IdentityLane pokemon={null} format={_format} />
-        <StatsLane pokemon={null} format={_format} />
-        <MovesLane pokemon={null} format={_format} />
-        {calcEnabled && <CalcColumn pokemon={null} />}
+        <div className={s.rowVerticalContent}>
+          <IdentityLane pokemon={null} format={_format} />
+          <div className={s.rowRight}>
+            <StatsLane pokemon={null} format={_format} />
+            <MovesLane pokemon={null} format={_format} />
+            {calcEnabled && <CalcColumn pokemon={null} />}
+          </div>
+        </div>
       </button>
 
       <SpeciesPickerDialog
@@ -291,7 +296,7 @@ function ActiveRowShell({
   isDragging = false,
 }: ActiveRowShellProps) {
   return (
-    <div className="rounded-lg">
+    <div className="h-full overflow-hidden rounded-lg">
       <ActiveRow
         idx={idx}
         pokemon={pokemon}

--- a/apps/web/src/components/team-builder/v2/poke-row.tsx
+++ b/apps/web/src/components/team-builder/v2/poke-row.tsx
@@ -101,9 +101,9 @@ function EmptyRow({ idx, format: _format, onAdd }: EmptyRowProps) {
           <div className={s.rowRight}>
             <StatsLane pokemon={null} format={_format} />
             <MovesLane pokemon={null} format={_format} />
-            {calcEnabled && <CalcColumn pokemon={null} />}
           </div>
         </div>
+        {calcEnabled && <CalcColumn pokemon={null} />}
       </button>
 
       <SpeciesPickerDialog
@@ -296,7 +296,7 @@ function ActiveRowShell({
   isDragging = false,
 }: ActiveRowShellProps) {
   return (
-    <div className="h-full overflow-hidden rounded-lg">
+    <div className="h-full rounded-lg">
       <ActiveRow
         idx={idx}
         pokemon={pokemon}


### PR DESCRIPTION
## Summary

- Fixes empty slot cards in the 3x2-vertical grid layout to visually match the filled slot structure
- Empty slots now use the same CSS module classes (`.midMetaBar`, `.midNickname`, `.midPill`, `.midRightPills`) as the filled state so the nickname row, gender pill, and shiny pill are positioned identically
- Sprite ghost matches filled state at 144px, and the form column uses a min-width to ensure `justify-content: center` aligns both states at the same offset from the card edge

## Before/After

**Before:** Empty slot had centered text-only placeholders with no side-by-side structure, pills clustered near nickname text  
**After:** Empty slot mirrors filled slot — sprite placeholder on left, MetaBar grid with nickname filling the row and pills pushed to the right edge, same centering offset as the filled state (verified pixel-perfect: sprite at 92–93px from card edge, pills end at 489px in both)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved active row layout sizing and overflow handling in the team builder.
  * Enhanced placeholder states with support for multiple display variants (compact, mid, vertical).
  * Refined empty team slot styling and content organization for better visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->