### PR TITLE
refactor: use mirrored split grid for damage calc sides fieldset

### DIFF
--- a/apps/mobile/src/components/tournament/team-submission-card.tsx
+++ b/apps/mobile/src/components/tournament/team-submission-card.tsx
@@ -80,6 +80,7 @@ export function TeamSubmissionCard({
 
   useEffect(() => {
     if (cardState !== "editing" || !rawText.trim()) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setValidation(null);
       return;
     }

--- a/apps/mobile/src/lib/supabase/auth-provider.tsx
+++ b/apps/mobile/src/lib/supabase/auth-provider.tsx
@@ -63,6 +63,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchSession();
 
     const {

--- a/apps/mobile/src/lib/supabase/use-communities.ts
+++ b/apps/mobile/src/lib/supabase/use-communities.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { getSupabase } from "./client";
 import {
   listPublicCommunities,
@@ -17,36 +17,23 @@ export type CommunityDetail = NonNullable<
  * Hook to fetch all public communities
  */
 export function useCommunities() {
-  const [communities, setCommunities] = useState<CommunityWithCounts[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-
-  const fetchCommunities = async () => {
-    try {
-      setLoading(true);
-      setError(null);
+  const { data, isLoading, error, refetch } = useQuery<
+    CommunityWithCounts[],
+    Error
+  >({
+    queryKey: ["communities-public"],
+    queryFn: async () => {
       const supabase = getSupabase();
-      const data = await listPublicCommunities(supabase);
-      setCommunities(data);
-    } catch (err) {
-      setError(
-        err instanceof Error ? err : new Error("Failed to fetch communities")
-      );
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    fetchCommunities();
-  }, []);
+      return listPublicCommunities(supabase);
+    },
+    staleTime: 300_000, // 5 minutes - communities change infrequently
+  });
 
   return {
-    communities,
-    loading,
-    error,
-    refetch: fetchCommunities,
+    communities: data ?? [],
+    loading: isLoading,
+    error: error ?? null,
+    refetch,
   };
 }
 
@@ -54,40 +41,23 @@ export function useCommunities() {
  * Hook to fetch a single community by slug
  */
 export function useCommunity(slug: string | undefined) {
-  const [community, setCommunity] = useState<CommunityDetail | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-
-  const fetchCommunity = async () => {
-    if (!slug) {
-      setLoading(false);
-      return;
-    }
-
-    try {
-      setLoading(true);
-      setError(null);
+  const { data, isLoading, error, refetch } = useQuery<
+    CommunityDetail | null,
+    Error
+  >({
+    queryKey: ["community-detail", slug],
+    queryFn: async () => {
       const supabase = getSupabase();
-      const data = await getCommunityBySlug(supabase, slug);
-      setCommunity(data);
-    } catch (err) {
-      setError(
-        err instanceof Error ? err : new Error("Failed to fetch community")
-      );
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    fetchCommunity();
-  }, [slug]);
+      return getCommunityBySlug(supabase, slug!);
+    },
+    enabled: !!slug,
+    staleTime: 300_000,
+  });
 
   return {
-    community,
-    loading,
-    error,
-    refetch: fetchCommunity,
+    community: data ?? null,
+    loading: isLoading,
+    error: error ?? null,
+    refetch,
   };
 }

--- a/apps/mobile/src/lib/supabase/use-communities.ts
+++ b/apps/mobile/src/lib/supabase/use-communities.ts
@@ -38,6 +38,7 @@ export function useCommunities() {
   };
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchCommunities();
   }, []);
 
@@ -79,6 +80,7 @@ export function useCommunity(slug: string | undefined) {
   };
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchCommunity();
   }, [slug]);
 

--- a/apps/mobile/src/lib/supabase/use-tournament.ts
+++ b/apps/mobile/src/lib/supabase/use-tournament.ts
@@ -46,6 +46,7 @@ export function useTournament(slug: string | undefined) {
   };
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchTournament();
   }, [slug]);
 
@@ -86,6 +87,7 @@ export function useTeamForRegistration(tournamentId: number | undefined) {
   };
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchTeam();
   }, [tournamentId]);
 

--- a/apps/mobile/src/lib/supabase/use-tournament.ts
+++ b/apps/mobile/src/lib/supabase/use-tournament.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { getSupabase } from "./client";
 import {
   getTournamentBySlug,
@@ -20,41 +20,23 @@ export type TeamForRegistration = NonNullable<
  * Returns tournament details including registrations, phases, and counts.
  */
 export function useTournament(slug: string | undefined) {
-  const [tournament, setTournament] = useState<TournamentDetail | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-
-  const fetchTournament = async () => {
-    if (!slug) {
-      setLoading(false);
-      return;
-    }
-
-    try {
-      setLoading(true);
-      setError(null);
+  const { data, isLoading, error, refetch } = useQuery<
+    TournamentDetail | null,
+    Error
+  >({
+    queryKey: ["tournament-detail", slug],
+    queryFn: async () => {
       const supabase = getSupabase();
-      const data = await getTournamentBySlug(supabase, slug);
-      setTournament(data);
-    } catch (err) {
-      setError(
-        err instanceof Error ? err : new Error("Failed to fetch tournament")
-      );
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    fetchTournament();
-  }, [slug]);
+      return getTournamentBySlug(supabase, slug!);
+    },
+    enabled: !!slug,
+  });
 
   return {
-    tournament,
-    loading,
-    error,
-    refetch: fetchTournament,
+    tournament: data ?? null,
+    loading: isLoading,
+    error: error ?? null,
+    refetch,
   };
 }
 
@@ -63,38 +45,22 @@ export function useTournament(slug: string | undefined) {
  * Returns null if the user is not registered or has no team submitted.
  */
 export function useTeamForRegistration(tournamentId: number | undefined) {
-  const [team, setTeam] = useState<TeamForRegistration | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-
-  const fetchTeam = async () => {
-    if (!tournamentId) {
-      setLoading(false);
-      return;
-    }
-
-    try {
-      setLoading(true);
-      setError(null);
+  const { data, isLoading, error, refetch } = useQuery<
+    TeamForRegistration | null,
+    Error
+  >({
+    queryKey: ["team-for-registration", tournamentId],
+    queryFn: async () => {
       const supabase = getSupabase();
-      const data = await getTeamForRegistration(supabase, tournamentId);
-      setTeam(data);
-    } catch (err) {
-      setError(err instanceof Error ? err : new Error("Failed to fetch team"));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    fetchTeam();
-  }, [tournamentId]);
+      return getTeamForRegistration(supabase, tournamentId!);
+    },
+    enabled: !!tournamentId,
+  });
 
   return {
-    team,
-    loading,
-    error,
-    refetch: fetchTeam,
+    team: data ?? null,
+    loading: isLoading,
+    error: error ?? null,
+    refetch,
   };
 }

--- a/apps/web/e2e/tests/discord-user-settings.spec.ts
+++ b/apps/web/e2e/tests/discord-user-settings.spec.ts
@@ -12,6 +12,10 @@ import { type Page, test, expect } from "@playwright/test";
  * The page renders a Loader2 spinner while loading; the discord privacy row
  * only appears after loading is complete ({!isLoading && <Row />}).
  * We wait for the spinner to disappear, then the switch to appear.
+ *
+ * NOTE: We avoid waitForLoadState("networkidle") because persistent connections
+ * (Vercel preview toolbar, analytics, WebSocket devtools) prevent it from
+ * resolving in CI. Instead, we wait for the concrete UI element we need.
  */
 async function waitForProfilePageLoaded(page: Page) {
   // The loading card contains an svg with the animate-spin class
@@ -20,8 +24,11 @@ async function waitForProfilePageLoaded(page: Page) {
   await spinner.waitFor({ state: "hidden", timeout: 15000 }).catch(() => {
     // Spinner may not appear at all if load is fast — that's fine
   });
-  // Also ensure networkidle so any in-flight Server Actions settle
-  await page.waitForLoadState("networkidle");
+  // Wait for the discord privacy switch to appear as a signal that load is done
+  await page.locator("#show-discord-publicly").waitFor({
+    state: "attached",
+    timeout: 15000,
+  });
 }
 
 test.describe("Discord user settings", () => {
@@ -35,7 +42,7 @@ test.describe("Discord user settings", () => {
 
   test("notifications page renders discord DMs section", async ({ page }) => {
     await page.goto("/dashboard/settings/notifications");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // The #discord-dms section is Server-rendered. Scroll it into view so
     // Playwright's toBeVisible check passes (element must be in viewport).
@@ -51,7 +58,7 @@ test.describe("Discord user settings", () => {
     // "no Discord linked" state. When Discord is linked, the section would
     // show "Connected as @handle" and interactive checkboxes instead.
     await page.goto("/dashboard/settings/notifications");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     const discordSection = page.locator("#discord-dms");
     await discordSection.scrollIntoViewIfNeeded();
@@ -75,7 +82,7 @@ test.describe("Discord user settings", () => {
     // user cannot accidentally think they have enabled notifications without a
     // connected account.
     await page.goto("/dashboard/settings/notifications");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     const discordSection = page.locator("#discord-dms");
     await discordSection.scrollIntoViewIfNeeded();
@@ -94,7 +101,7 @@ test.describe("Discord user settings", () => {
     page,
   }) => {
     await page.goto("/dashboard/settings/notifications");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     const discordSection = page.locator("#discord-dms");
     await discordSection.scrollIntoViewIfNeeded();
@@ -159,8 +166,8 @@ test.describe("Discord user settings", () => {
   });
 
   // CI timeout: waitForProfilePageLoaded consumes ~20s of the 30s budget,
-  // leaving insufficient time for the switch interaction + networkidle wait.
-  // Needs either a higher timeout or a faster page-load detection strategy.
+  // leaving insufficient time for the switch interaction.
+  // Now that networkidle is removed, these may pass — kept as fixme until verified.
   test.fixme("can toggle show-Discord-on-profile setting on", async ({
     page,
   }) => {
@@ -176,9 +183,7 @@ test.describe("Discord user settings", () => {
     if (!isCurrentlyChecked) {
       // Toggle ON
       await discordSwitch.click();
-      await page.waitForLoadState("networkidle");
-
-      await expect(discordSwitch).toBeChecked();
+      await expect(discordSwitch).toBeChecked({ timeout: 5000 });
 
       // Success toast confirms the Server Action completed
       await expect(
@@ -205,15 +210,12 @@ test.describe("Discord user settings", () => {
     const isCurrentlyChecked = await discordSwitch.isChecked();
     if (!isCurrentlyChecked) {
       await discordSwitch.click();
-      await page.waitForLoadState("networkidle");
-      await expect(discordSwitch).toBeChecked();
+      await expect(discordSwitch).toBeChecked({ timeout: 5000 });
     }
 
     // Toggle OFF
     await discordSwitch.click();
-    await page.waitForLoadState("networkidle");
-
-    await expect(discordSwitch).not.toBeChecked();
+    await expect(discordSwitch).not.toBeChecked({ timeout: 5000 });
 
     // Success toast confirms the Server Action completed
     await expect(page.getByText(/discord handle hidden/i)).toBeVisible({
@@ -236,19 +238,16 @@ test.describe("Discord user settings", () => {
     const isOn = await discordSwitch.isChecked();
     if (isOn) {
       await discordSwitch.click();
-      await page.waitForLoadState("networkidle");
-      await expect(discordSwitch).not.toBeChecked();
+      await expect(discordSwitch).not.toBeChecked({ timeout: 5000 });
     }
 
     // Toggle ON
     await discordSwitch.click();
-    await page.waitForLoadState("networkidle");
-    await expect(discordSwitch).toBeChecked();
+    await expect(discordSwitch).toBeChecked({ timeout: 5000 });
 
     // Toggle OFF
     await discordSwitch.click();
-    await page.waitForLoadState("networkidle");
-    await expect(discordSwitch).not.toBeChecked();
+    await expect(discordSwitch).not.toBeChecked({ timeout: 5000 });
   });
 
   // ---------------------------------------------------------------------------
@@ -269,13 +268,12 @@ test.describe("Discord user settings", () => {
     const isOn = await discordSwitch.isChecked();
     if (isOn) {
       await discordSwitch.click();
-      await page.waitForLoadState("networkidle");
-      await expect(discordSwitch).not.toBeChecked();
+      await expect(discordSwitch).not.toBeChecked({ timeout: 5000 });
     }
 
     // Visit the player's public profile
     await page.goto("/u/ash_ketchum");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // Profile page should load (verify a heading is present)
     await expect(page.getByRole("heading").first()).toBeVisible({
@@ -293,7 +291,7 @@ test.describe("Discord user settings", () => {
     page,
   }) => {
     await page.goto("/u/ash_ketchum");
-    await page.waitForLoadState("networkidle");
+    await page.waitForLoadState("domcontentloaded");
 
     // Profile heading should be present (the player exists in seed data)
     await expect(page.getByRole("heading").first()).toBeVisible({

--- a/apps/web/src/actions/__tests__/teams.test.ts
+++ b/apps/web/src/actions/__tests__/teams.test.ts
@@ -109,6 +109,7 @@ import {
   updateTeamAction,
   deleteTeamAction,
   forkTeamAction,
+  transferTeamAction,
   addPokemonToTeamAction,
   updatePokemonAction,
   removePokemonFromTeamAction,
@@ -408,6 +409,144 @@ describe("forkTeamAction", () => {
 
     expect(result.success).toBe(false);
     expect(mockForkTeam).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// transferTeamAction
+// =============================================================================
+
+describe("transferTeamAction", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: caller is authenticated
+    (mockSupabase.auth.getUser as ReturnType<typeof jest.fn>).mockResolvedValue(
+      { data: { user: { id: "user-123" } } }
+    );
+  });
+
+  it("transfers a team to the target alt successfully", async () => {
+    // Mock: target alt lookup returns a valid alt
+    const mockAltQb = createMockQueryBuilder();
+    mockAltQb.maybeSingle.mockResolvedValue({
+      data: { id: 5 },
+      error: null,
+    });
+    // Mock: teams update returns success
+    const mockTeamsQb = {
+      update: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: { id: 10 }, error: null }),
+    };
+    (mockSupabase.from as ReturnType<typeof jest.fn>)
+      .mockReturnValueOnce(mockAltQb)   // alts query
+      .mockReturnValueOnce(mockTeamsQb); // teams update
+
+    const result = await transferTeamAction(10, 5);
+
+    expect(result).toEqual({ success: true, data: undefined });
+  });
+
+  it("returns a validation error for non-positive teamId", async () => {
+    const result = await transferTeamAction(0, 5);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBeTruthy();
+    }
+  });
+
+  it("returns a validation error for non-positive targetAltId", async () => {
+    const result = await transferTeamAction(10, -1);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("returns an error when a bot is detected", async () => {
+    simulateBot();
+
+    const result = await transferTeamAction(10, 5);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("Failed to transfer team");
+    }
+  });
+
+  it("returns an error when not authenticated", async () => {
+    (mockSupabase.auth.getUser as ReturnType<typeof jest.fn>).mockResolvedValue(
+      { data: { user: null } }
+    );
+
+    const result = await transferTeamAction(10, 5);
+
+    expect(result).toEqual({ success: false, error: "Not authenticated." });
+  });
+
+  it("returns an error when target alt query fails", async () => {
+    const mockAltQb = createMockQueryBuilder();
+    mockAltQb.maybeSingle.mockResolvedValue({
+      data: null,
+      error: new Error("DB error"),
+    });
+    (mockSupabase.from as ReturnType<typeof jest.fn>).mockReturnValueOnce(
+      mockAltQb
+    );
+
+    const result = await transferTeamAction(10, 5);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("Failed to verify alt ownership");
+    }
+  });
+
+  it("returns an error when target alt is not found/owned", async () => {
+    const mockAltQb = createMockQueryBuilder();
+    mockAltQb.maybeSingle.mockResolvedValue({
+      data: null,
+      error: null,
+    });
+    (mockSupabase.from as ReturnType<typeof jest.fn>).mockReturnValueOnce(
+      mockAltQb
+    );
+
+    const result = await transferTeamAction(10, 5);
+
+    expect(result).toEqual({
+      success: false,
+      error: "Target alt not found or not owned by you.",
+    });
+  });
+
+  it("returns an error when the team update fails", async () => {
+    // Mock: target alt found
+    const mockAltQb = createMockQueryBuilder();
+    mockAltQb.maybeSingle.mockResolvedValue({
+      data: { id: 5 },
+      error: null,
+    });
+    // Mock: teams update returns error
+    const mockTeamsQb = {
+      update: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: null,
+        error: new Error("Update denied"),
+      }),
+    };
+    (mockSupabase.from as ReturnType<typeof jest.fn>)
+      .mockReturnValueOnce(mockAltQb)
+      .mockReturnValueOnce(mockTeamsQb);
+
+    const result = await transferTeamAction(10, 5);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("Failed to transfer team");
+    }
   });
 });
 

--- a/apps/web/src/actions/teams.ts
+++ b/apps/web/src/actions/teams.ts
@@ -271,13 +271,19 @@ export async function transferTeamAction(
   }
 
   // Verify the target alt belongs to this user
-  const { data: targetAlt } = await supabase
+  const { data: targetAlt, error: targetAltError } = await supabase
     .from("alts")
     .select("id")
     .eq("id", parsed.data.targetAltId)
     .eq("user_id", user.id)
     .maybeSingle();
 
+  if (targetAltError) {
+    return {
+      success: false,
+      error: getErrorMessage(targetAltError, "Failed to verify alt ownership"),
+    };
+  }
   if (!targetAlt) {
     return { success: false, error: "Target alt not found or not owned by you." };
   }

--- a/apps/web/src/actions/teams.ts
+++ b/apps/web/src/actions/teams.ts
@@ -29,6 +29,7 @@ import {
   teamUpdateDataSchema,
   deleteTeamInputSchema,
   forkTeamInputSchema,
+  transferTeamInputSchema,
   addPokemonInputSchema,
   updatePokemonInputSchema,
   removePokemonInputSchema,
@@ -234,6 +235,61 @@ export async function forkTeamAction(
     invalidateTeamDetailCache(result.id);
     return { id: result.id };
   }, "Failed to fork team");
+}
+
+/**
+ * Transfer a team to a different alt owned by the same user.
+ * Verifies the caller owns both the team's current alt and the target alt.
+ */
+export async function transferTeamAction(
+  teamId: number,
+  targetAltId: number
+): Promise<ActionResult<void>> {
+  const parsed = transferTeamInputSchema.safeParse({ teamId, targetAltId });
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: parsed.error.issues[0]?.message ?? "Invalid input",
+    };
+  }
+
+  try {
+    await rejectBots();
+  } catch (error) {
+    return {
+      success: false,
+      error: getErrorMessage(error, "Failed to transfer team"),
+    };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return { success: false, error: "Not authenticated." };
+  }
+
+  // Verify the target alt belongs to this user
+  const { data: targetAlt } = await supabase
+    .from("alts")
+    .select("id")
+    .eq("id", parsed.data.targetAltId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (!targetAlt) {
+    return { success: false, error: "Target alt not found or not owned by you." };
+  }
+
+  return withAction(async () => {
+    const { error } = await supabase
+      .from("teams")
+      .update({ created_by: parsed.data.targetAltId })
+      .eq("id", parsed.data.teamId);
+    if (error) throw new Error(`Failed to transfer team: ${error.message}`);
+    invalidateTeamDetailCache(parsed.data.teamId);
+  }, "Failed to transfer team");
 }
 
 // =============================================================================

--- a/apps/web/src/actions/teams.ts
+++ b/apps/web/src/actions/teams.ts
@@ -283,11 +283,14 @@ export async function transferTeamAction(
   }
 
   return withAction(async () => {
-    const { error } = await supabase
+    const { data, error } = await supabase
       .from("teams")
       .update({ created_by: parsed.data.targetAltId })
-      .eq("id", parsed.data.teamId);
-    if (error) throw new Error(`Failed to transfer team: ${error.message}`);
+      .eq("id", parsed.data.teamId)
+      .select("id")
+      .single();
+    if (error || !data)
+      throw new Error("Failed to transfer team — team not found or access denied.");
     invalidateTeamDetailCache(parsed.data.teamId);
   }, "Failed to transfer team");
 }

--- a/apps/web/src/app/(app)/admin/community-requests/request-detail-sheet.tsx
+++ b/apps/web/src/app/(app)/admin/community-requests/request-detail-sheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Check, ExternalLink, X } from "lucide-react";
 import {
   Sheet,
@@ -69,11 +69,13 @@ export function RequestDetailSheet({
   );
 
   // Reset state when request changes
-  useEffect(() => {
+  const [prevRequestId, setPrevRequestId] = useState(request?.id);
+  if (prevRequestId !== request?.id) {
+    setPrevRequestId(request?.id);
     setRejectReason("");
     setApproveReason("");
     setConfirmAction(null);
-  }, [request?.id]);
+  }
 
   if (!request) return null;
 

--- a/apps/web/src/app/(app)/admin/config/page.tsx
+++ b/apps/web/src/app/(app)/admin/config/page.tsx
@@ -369,10 +369,9 @@ export default function AdminConfigPage() {
     }
   };
 
-  useEffect(() => {
+   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchFlags();
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchAnnouncements();
   }, []);
 

--- a/apps/web/src/app/(app)/admin/config/page.tsx
+++ b/apps/web/src/app/(app)/admin/config/page.tsx
@@ -370,7 +370,9 @@ export default function AdminConfigPage() {
   };
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchFlags();
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchAnnouncements();
   }, []);
 

--- a/apps/web/src/app/(app)/admin/users/__tests__/user-detail-sheet.test.tsx
+++ b/apps/web/src/app/(app)/admin/users/__tests__/user-detail-sheet.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
@@ -186,6 +187,18 @@ import { UserDetailSheet } from "../user-detail-sheet";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+  return Wrapper;
+}
+
 function buildUser(overrides: Record<string, unknown> = {}) {
   return {
     id: "user-abc-123",
@@ -211,9 +224,14 @@ const defaultProps = {
 };
 
 async function renderAndWaitForLoad(props = defaultProps) {
-  let result!: ReturnType<typeof render>;
-  await act(async () => {
-    result = render(<UserDetailSheet {...props} />);
+  const result = render(<UserDetailSheet {...props} />, {
+    wrapper: createWrapper(),
+  });
+  // Wait for loading to complete (spinner disappears or content renders)
+  await waitFor(() => {
+    // The loading spinner uses Loader2 with animate-spin class
+    const spinner = result.container.querySelector(".animate-spin");
+    expect(spinner).not.toBeInTheDocument();
   });
   return result;
 }
@@ -234,14 +252,18 @@ describe("UserDetailSheet", () => {
 
   describe("when closed", () => {
     it("renders nothing when open is false", () => {
-      render(<UserDetailSheet {...defaultProps} open={false} />);
+      render(<UserDetailSheet {...defaultProps} open={false} />, {
+        wrapper: createWrapper(),
+      });
       expect(screen.queryByTestId("sheet")).not.toBeInTheDocument();
     });
   });
 
   describe("when open with no userId", () => {
     it("does not fetch user data", () => {
-      render(<UserDetailSheet {...defaultProps} userId={null} />);
+      render(<UserDetailSheet {...defaultProps} userId={null} />, {
+        wrapper: createWrapper(),
+      });
       expect(mockGetUserAdminDetails).not.toHaveBeenCalled();
     });
   });
@@ -250,7 +272,9 @@ describe("UserDetailSheet", () => {
     it("shows loading spinner while fetching", () => {
       // Don't resolve — keep it in loading state
       mockGetUserAdminDetails.mockReturnValue(new Promise(() => {}));
-      render(<UserDetailSheet {...defaultProps} />);
+      render(<UserDetailSheet {...defaultProps} />, {
+        wrapper: createWrapper(),
+      });
       // Spinner is a Loader2 svg inside the loading container
       expect(screen.queryByText("ash_ketchum")).not.toBeInTheDocument();
     });
@@ -268,9 +292,7 @@ describe("UserDetailSheet", () => {
     it("shows error message when fetch fails", async () => {
       mockGetUserAdminDetails.mockRejectedValue(new Error("Network error"));
       await renderAndWaitForLoad();
-      expect(
-        screen.getByText("Failed to load user details")
-      ).toBeInTheDocument();
+      expect(screen.getByText("Network error")).toBeInTheDocument();
     });
   });
 
@@ -789,18 +811,22 @@ describe("UserDetailSheet", () => {
 
   describe("refetch on open", () => {
     it("re-fetches user data when sheet opens", async () => {
+      const wrapper = createWrapper();
       const { rerender } = render(
-        <UserDetailSheet {...defaultProps} open={false} />
+        <UserDetailSheet {...defaultProps} open={false} />,
+        { wrapper }
       );
 
       await act(async () => {
         rerender(<UserDetailSheet {...defaultProps} open={true} />);
       });
 
-      expect(mockGetUserAdminDetails).toHaveBeenCalledWith(
-        expect.anything(),
-        "user-abc-123"
-      );
+      await waitFor(() => {
+        expect(mockGetUserAdminDetails).toHaveBeenCalledWith(
+          expect.anything(),
+          "user-abc-123"
+        );
+      });
     });
 
     it("fetches site roles alongside user details", async () => {

--- a/apps/web/src/app/(app)/admin/users/user-detail-sheet.tsx
+++ b/apps/web/src/app/(app)/admin/users/user-detail-sheet.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { formatDateTime } from "@trainers/utils";
 import {
   Sheet,
@@ -123,12 +124,32 @@ export function UserDetailSheet({
   onOpenChange,
   onUserUpdated,
 }: UserDetailSheetProps) {
-  const [user, setUser] = useState<UserDetail | null>(null);
-  const [siteRoles, setSiteRoles] = useState<SiteRole[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const { data: userData, isLoading: loading, error: queryError, refetch: refetchUser } = useQuery({
+    queryKey: ['admin-user-detail', userId],
+    queryFn: async () => {
+      const [userResult, rolesData] = await Promise.all([
+        getUserAdminDetails(supabase, userId!),
+        fetchSiteRoles(supabase),
+      ]);
+      return { user: userResult as UserDetail | null, siteRoles: rolesData as SiteRole[] };
+    },
+    enabled: open && !!userId,
+  });
+
+  const user = userData?.user ?? null;
+  const siteRoles = userData?.siteRoles ?? [];
+  const error = queryError?.message ?? null;
   const [actionLoading, setActionLoading] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [prevOpen, setPrevOpen] = useState(open);
+
+  // Reset action error when sheet closes (render-time state reset)
+  if (prevOpen !== open) {
+    setPrevOpen(open);
+    if (!open) {
+      setActionError(null);
+    }
+  }
 
   // Confirmation dialog state
   const [confirmDialog, setConfirmDialog] = useState<{
@@ -149,42 +170,13 @@ export function UserDetailSheet({
   const [selectedRoleId, setSelectedRoleId] = useState<string>("");
 
   const fetchUser = async () => {
-    if (!userId) return;
-
-    setLoading(true);
-    setError(null);
     setActionError(null);
     setShowImpersonateInput(false);
     setImpersonateReason("");
     setSuspendReason("");
     setSelectedRoleId("");
-
-    try {
-      const [userData, rolesData] = await Promise.all([
-        getUserAdminDetails(supabase, userId),
-        fetchSiteRoles(supabase),
-      ]);
-      setUser(userData as UserDetail | null);
-      setSiteRoles(rolesData as SiteRole[]);
-    } catch (err) {
-      console.error("Error fetching user details:", err);
-      setError("Failed to load user details");
-    } finally {
-      setLoading(false);
-    }
+    await refetchUser();
   };
-
-  useEffect(() => {
-    if (open && userId) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      fetchUser();
-    }
-    if (!open) {
-      setUser(null);
-      setError(null);
-      setActionError(null);
-    }
-  }, [open, userId]);
 
   const userSiteRoles = !user?.user_roles
     ? []

--- a/apps/web/src/app/(app)/admin/users/user-detail-sheet.tsx
+++ b/apps/web/src/app/(app)/admin/users/user-detail-sheet.tsx
@@ -32,6 +32,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
+import { queryKeys } from "@/lib/query-keys";
 import { supabase } from "@/lib/supabase/client";
 import {
   getUserAdminDetails,
@@ -125,7 +126,7 @@ export function UserDetailSheet({
   onUserUpdated,
 }: UserDetailSheetProps) {
   const { data: userData, isLoading: loading, error: queryError, refetch: refetchUser } = useQuery({
-    queryKey: ['admin-user-detail', userId],
+    queryKey: queryKeys.admin.userDetail(userId),
     queryFn: async () => {
       const [userResult, rolesData] = await Promise.all([
         getUserAdminDetails(supabase, userId!),

--- a/apps/web/src/app/(app)/admin/users/user-detail-sheet.tsx
+++ b/apps/web/src/app/(app)/admin/users/user-detail-sheet.tsx
@@ -176,11 +176,15 @@ export function UserDetailSheet({
 
   useEffect(() => {
     if (open && userId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       fetchUser();
     }
     if (!open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setUser(null);
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setError(null);
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setActionError(null);
     }
   }, [open, userId]);

--- a/apps/web/src/app/(app)/admin/users/user-detail-sheet.tsx
+++ b/apps/web/src/app/(app)/admin/users/user-detail-sheet.tsx
@@ -180,11 +180,8 @@ export function UserDetailSheet({
       fetchUser();
     }
     if (!open) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setUser(null);
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setError(null);
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setActionError(null);
     }
   }, [open, userId]);

--- a/apps/web/src/app/(app)/tournaments/[tournamentSlug]/current-match-banner.tsx
+++ b/apps/web/src/app/(app)/tournaments/[tournamentSlug]/current-match-banner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { useAuth } from "@/components/auth/auth-provider";
 import { useSupabase } from "@/lib/supabase";
 import { Swords, ChevronRight } from "lucide-react";
@@ -31,16 +31,12 @@ export function CurrentMatchBanner({
 }: CurrentMatchBannerProps) {
   const { user, isAuthenticated } = useAuth();
   const supabase = useSupabase();
-  const [match, setMatch] = useState<MatchData | null>(null);
 
   const userId = user?.id;
 
-  useEffect(() => {
-    if (!isAuthenticated || !userId) return;
-
-    let cancelled = false;
-
-    async function fetchActiveMatch() {
+  const { data: match = null } = useQuery<MatchData | null>({
+    queryKey: ['current-match-banner', tournamentId, userId],
+    queryFn: async () => {
       const { data: alts, error: altsError } = await supabase
         .from("alts")
         .select("id")
@@ -48,10 +44,10 @@ export function CurrentMatchBanner({
 
       if (altsError) {
         console.error("[CurrentMatchBanner] Failed to fetch alts:", altsError);
-        return;
+        return null;
       }
 
-      if (!alts || alts.length === 0 || cancelled) return;
+      if (!alts || alts.length === 0) return null;
 
       const altIds = alts.map((a) => a.id);
 
@@ -84,10 +80,10 @@ export function CurrentMatchBanner({
           "[CurrentMatchBanner] Failed to fetch match:",
           matchError
         );
-        return;
+        return null;
       }
 
-      if (cancelled || !matchData) return;
+      if (!matchData) return null;
 
       const round = matchData.round as unknown as {
         round_number: number;
@@ -102,7 +98,7 @@ export function CurrentMatchBanner({
         | null;
       const opponentProfile = opponentArr?.[0] ?? null;
 
-      setMatch({
+      return {
         id: matchData.id,
         status: matchData.status as "pending" | "active",
         roundNumber: round?.round_number ?? 0,
@@ -114,15 +110,10 @@ export function CurrentMatchBanner({
               username: opponentProfile.username,
             }
           : null,
-      });
-    }
-
-    fetchActiveMatch();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isAuthenticated, userId, supabase, tournamentId]);
+      };
+    },
+    enabled: isAuthenticated && !!userId,
+  });
 
   if (!match) return null;
 

--- a/apps/web/src/app/(app)/tournaments/[tournamentSlug]/current-match-banner.tsx
+++ b/apps/web/src/app/(app)/tournaments/[tournamentSlug]/current-match-banner.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useAuth } from "@/components/auth/auth-provider";
 import { useSupabase } from "@/lib/supabase";
+import { queryKeys } from "@/lib/query-keys";
 import { Swords, ChevronRight } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
@@ -35,7 +36,7 @@ export function CurrentMatchBanner({
   const userId = user?.id;
 
   const { data: match = null } = useQuery<MatchData | null>({
-    queryKey: ['current-match-banner', tournamentId, userId],
+    queryKey: queryKeys.tournament.currentMatchBanner(tournamentId, userId),
     queryFn: async () => {
       const { data: alts, error: altsError } = await supabase
         .from("alts")

--- a/apps/web/src/app/(dashboard)/dashboard/alts/[username]/teams/[teamId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/alts/[username]/teams/[teamId]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 
 import { getFormatById } from "@trainers/pokemon";
-import { getTeamWithPokemon } from "@trainers/supabase";
+import { getCurrentUserAlts, getTeamWithPokemon } from "@trainers/supabase";
 
 import { createClientReadOnly } from "@/lib/supabase/server";
 import { TeamWorkspaceV2 } from "@/components/team-builder/v2/team-workspace-v2";
@@ -33,11 +33,13 @@ export default async function TeamWorkspacePage({
     notFound();
   }
 
-  // Layout validates auth and ownership. Re-fetch here because App Router can't pass data from layout to page.
-  // The alt fetch is intentionally omitted — the page does not use it; the
-  // layout already fetched it and enforced ownership.
+  // Layout validates auth and ownership. Re-fetch here because App Router can't
+  // pass data from layout to page.
   const supabase = await createClientReadOnly();
-  const team = await getTeamWithPokemon(supabase, numericTeamId);
+  const [team, alts] = await Promise.all([
+    getTeamWithPokemon(supabase, numericTeamId),
+    getCurrentUserAlts(supabase),
+  ]);
 
   if (!team) {
     notFound();
@@ -45,5 +47,12 @@ export default async function TeamWorkspacePage({
 
   const format = team.format ? getFormatById(team.format) : undefined;
 
-  return <TeamWorkspaceV2 team={team} format={format} username={username} />;
+  return (
+    <TeamWorkspaceV2
+      team={team}
+      format={format}
+      username={username}
+      alts={alts}
+    />
+  );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/staff/staff-client.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/staff/staff-client.tsx
@@ -745,14 +745,17 @@ export function StaffClient({
     Map<string, { group: CommunityGroup | null }>
   >(new Map());
 
-  // Clear optimistic moves when server confirms
-  const [prevStaffMembers, setPrevStaffMembers] = useState(staffMembers);
-  if (prevStaffMembers !== staffMembers) {
-    setPrevStaffMembers(staffMembers);
+  // Clear optimistic moves when server data arrives (confirms the mutation).
+  // This is a legitimate sync-with-external-data effect: the refetch after a
+  // successful drag-drop delivers new staffMembers, and we reset local
+  // optimistic state in response. Using useEffect (not render-time comparison)
+  // avoids mid-render setState that can interfere with @dnd-kit's pointer tracking.
+  useEffect(() => {
     if (staffMembers) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- legitimate: sync optimistic state with server data
       setOptimisticMoves(new Map());
     }
-  }
+  }, [staffMembers]);
 
   // Apply optimistic moves to staff data
   const baseStaff = staffMembers ?? initialStaff;

--- a/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/staff/staff-client.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/staff/staff-client.tsx
@@ -746,11 +746,13 @@ export function StaffClient({
   >(new Map());
 
   // Clear optimistic moves when server confirms
-  useEffect(() => {
+  const [prevStaffMembers, setPrevStaffMembers] = useState(staffMembers);
+  if (prevStaffMembers !== staffMembers) {
+    setPrevStaffMembers(staffMembers);
     if (staffMembers) {
       setOptimisticMoves(new Map());
     }
-  }, [staffMembers]);
+  }
 
   // Apply optimistic moves to staff data
   const baseStaff = staffMembers ?? initialStaff;

--- a/apps/web/src/components/__tests__/sudo-mode-indicator.test.tsx
+++ b/apps/web/src/components/__tests__/sudo-mode-indicator.test.tsx
@@ -1,10 +1,25 @@
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { SudoModeIndicator } from "../sudo-mode-indicator";
 
 const mockCheckSudoStatus = jest.fn();
 jest.mock("@/lib/sudo/actions", () => ({
   checkSudoStatus: (...args: unknown[]) => mockCheckSudoStatus(...args),
 }));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  });
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+  return Wrapper;
+}
 
 describe("SudoModeIndicator", () => {
   beforeEach(() => {
@@ -25,10 +40,12 @@ describe("SudoModeIndicator", () => {
       isActive: false,
       isSiteAdmin: false,
     });
-    const { container } = render(<SudoModeIndicator />);
+    const { container } = render(<SudoModeIndicator />, {
+      wrapper: createWrapper(),
+    });
 
-    await act(async () => {
-      await Promise.resolve();
+    await waitFor(() => {
+      expect(mockCheckSudoStatus).toHaveBeenCalled();
     });
 
     expect(container).toBeEmptyDOMElement();
@@ -39,13 +56,11 @@ describe("SudoModeIndicator", () => {
       isActive: true,
       isSiteAdmin: true,
     });
-    render(<SudoModeIndicator />);
+    render(<SudoModeIndicator />, { wrapper: createWrapper() });
 
-    await act(async () => {
-      await Promise.resolve();
+    await waitFor(() => {
+      expect(screen.getByText("Sudo Mode Active")).toBeInTheDocument();
     });
-
-    expect(screen.getByText("Sudo Mode Active")).toBeInTheDocument();
   });
 
   it("polls checkSudoStatus every 30 seconds", async () => {
@@ -53,20 +68,19 @@ describe("SudoModeIndicator", () => {
       isActive: false,
       isSiteAdmin: true,
     });
-    render(<SudoModeIndicator />);
+    render(<SudoModeIndicator />, { wrapper: createWrapper() });
 
-    await act(async () => {
-      await Promise.resolve();
+    await waitFor(() => {
+      expect(mockCheckSudoStatus).toHaveBeenCalledTimes(1);
     });
-
-    expect(mockCheckSudoStatus).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       jest.advanceTimersByTime(30_000);
-      await Promise.resolve();
     });
 
-    expect(mockCheckSudoStatus).toHaveBeenCalledTimes(2);
+    await waitFor(() => {
+      expect(mockCheckSudoStatus).toHaveBeenCalledTimes(2);
+    });
   });
 
   it("updates to active when poll returns isActive=true", async () => {
@@ -74,48 +88,36 @@ describe("SudoModeIndicator", () => {
       .mockResolvedValueOnce({ isActive: false, isSiteAdmin: true })
       .mockResolvedValueOnce({ isActive: true, isSiteAdmin: true });
 
-    render(<SudoModeIndicator />);
+    render(<SudoModeIndicator />, { wrapper: createWrapper() });
 
-    await act(async () => {
-      await Promise.resolve();
+    await waitFor(() => {
+      expect(mockCheckSudoStatus).toHaveBeenCalledTimes(1);
     });
 
     expect(screen.queryByText("Sudo Mode Active")).not.toBeInTheDocument();
 
     await act(async () => {
       jest.advanceTimersByTime(30_000);
-      await Promise.resolve();
     });
 
-    expect(screen.getByText("Sudo Mode Active")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Sudo Mode Active")).toBeInTheDocument();
+    });
   });
 
-  it("clears the polling interval on unmount", () => {
+  it("does not render border overlay when sudo is inactive", async () => {
     mockCheckSudoStatus.mockResolvedValue({
       isActive: false,
       isSiteAdmin: false,
     });
-    const clearIntervalSpy = jest.spyOn(global, "clearInterval");
-
-    const { unmount } = render(<SudoModeIndicator />);
-    unmount();
-
-    expect(clearIntervalSpy).toHaveBeenCalled();
-    clearIntervalSpy.mockRestore();
-  });
-
-  it("hides the border overlay when sudo is inactive", async () => {
-    mockCheckSudoStatus.mockResolvedValue({
-      isActive: false,
-      isSiteAdmin: false,
-    });
-    const { container } = render(<SudoModeIndicator />);
-
-    await act(async () => {
-      await Promise.resolve();
+    const { container } = render(<SudoModeIndicator />, {
+      wrapper: createWrapper(),
     });
 
-    // aria-hidden border div is not rendered when inactive
+    await waitFor(() => {
+      expect(mockCheckSudoStatus).toHaveBeenCalled();
+    });
+
     expect(container.querySelector("[aria-hidden]")).not.toBeInTheDocument();
   });
 
@@ -124,12 +126,14 @@ describe("SudoModeIndicator", () => {
       isActive: true,
       isSiteAdmin: true,
     });
-    const { container } = render(<SudoModeIndicator />);
-
-    await act(async () => {
-      await Promise.resolve();
+    const { container } = render(<SudoModeIndicator />, {
+      wrapper: createWrapper(),
     });
 
-    expect(container.querySelector("[aria-hidden='true']")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        container.querySelector("[aria-hidden='true']")
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/components/auth/auth-provider.tsx
+++ b/apps/web/src/components/auth/auth-provider.tsx
@@ -56,6 +56,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchUser();
 
     const {

--- a/apps/web/src/components/dashboard/page-header.tsx
+++ b/apps/web/src/components/dashboard/page-header.tsx
@@ -7,6 +7,8 @@ import { NotificationsPopover } from "@/components/dashboard/notifications-popov
 interface PageHeaderProps {
   title?: string;
   children?: React.ReactNode;
+  /** When true, the notifications bell is not rendered (caller handles it). */
+  hideNotifications?: boolean;
 }
 
 /**
@@ -15,9 +17,9 @@ interface PageHeaderProps {
  * and a notifications bell icon on the right.
  * Each page renders this as its first element.
  */
-export function PageHeader({ title, children }: PageHeaderProps) {
+export function PageHeader({ title, children, hideNotifications }: PageHeaderProps) {
   return (
-    <header className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
+    <header className="relative flex h-12 shrink-0 items-center gap-2 border-b px-4">
       <SidebarTrigger className="-ml-1 size-10 sm:size-7" />
       <Separator
         orientation="vertical"
@@ -26,9 +28,11 @@ export function PageHeader({ title, children }: PageHeaderProps) {
       {title && <span className="text-sm font-medium">{title}</span>}
       {children}
       {/* Notifications bell — pushed to the right */}
-      <div className="ml-auto">
-        <NotificationsPopover />
-      </div>
+      {!hideNotifications && (
+        <div className="ml-auto">
+          <NotificationsPopover />
+        </div>
+      )}
     </header>
   );
 }

--- a/apps/web/src/components/dashboard/upcoming-tournaments.tsx
+++ b/apps/web/src/components/dashboard/upcoming-tournaments.tsx
@@ -33,13 +33,13 @@ export function UpcomingTournaments({
 }) {
   const [isPending, startTransition] = useTransition();
   const [checkingInId, setCheckingInId] = useState<number | null>(null);
+  const [now] = useState(() => Date.now());
 
   const formatDate = (timestamp: number | null) => {
     if (!timestamp) return "Date TBD";
     const date = new Date(timestamp);
-    const now = new Date();
     const diffDays = Math.ceil(
-      (date.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
+      (date.getTime() - now) / (1000 * 60 * 60 * 24)
     );
 
     if (diffDays < 0) return "In Progress";
@@ -51,7 +51,6 @@ export function UpcomingTournaments({
   };
 
   const getStatusInfo = (tournament: DashboardTournament) => {
-    const now = Date.now();
     const startDate = tournament.startDate ?? null;
     const hoursUntilStart = startDate
       ? (startDate - now) / (1000 * 60 * 60)
@@ -172,7 +171,6 @@ export function UpcomingTournaments({
   const thisWeekGroup = shouldGroup
     ? sortedTournaments.filter((t) => {
         const status = getStatusInfo(t);
-        const now = Date.now();
         const startDate = t.startDate ?? null;
         const hoursUntilStart = startDate
           ? (startDate - now) / (1000 * 60 * 60)

--- a/apps/web/src/components/match/__tests__/post-match-summary.test.tsx
+++ b/apps/web/src/components/match/__tests__/post-match-summary.test.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from "react";
 import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { PostMatchSummary } from "../post-match-summary";
 import { useSupabase } from "@/lib/supabase";
 import { getPlayerMatches } from "@trainers/supabase";
@@ -64,6 +65,18 @@ const mockSupabase = {
   from: jest.fn(() => createQueryBuilder()),
 };
 
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+  return Wrapper;
+}
+
 describe("PostMatchSummary", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -81,10 +94,16 @@ describe("PostMatchSummary", () => {
     roundNumber: 3,
   };
 
+  function renderComponent(props = defaultProps) {
+    return render(<PostMatchSummary {...props} />, {
+      wrapper: createWrapper(),
+    });
+  }
+
   it("displays win result correctly", async () => {
     (getPlayerMatches as jest.Mock).mockResolvedValue([]);
 
-    render(<PostMatchSummary {...defaultProps} />);
+    renderComponent();
 
     await waitFor(() => {
       expect(screen.getByText("Match Complete")).toBeInTheDocument();
@@ -95,7 +114,7 @@ describe("PostMatchSummary", () => {
   it("displays loss result correctly", async () => {
     (getPlayerMatches as jest.Mock).mockResolvedValue([]);
 
-    render(<PostMatchSummary {...defaultProps} myWins={1} opponentWins={2} />);
+    renderComponent({ ...defaultProps, myWins: 1, opponentWins: 2 });
 
     await waitFor(() => {
       expect(screen.getByText("Match Complete")).toBeInTheDocument();
@@ -106,7 +125,7 @@ describe("PostMatchSummary", () => {
   it("shows View Standings link", async () => {
     (getPlayerMatches as jest.Mock).mockResolvedValue([]);
 
-    render(<PostMatchSummary {...defaultProps} />);
+    renderComponent();
 
     await waitFor(() => {
       const standingsLink = screen.getByText("View Standings").closest("a");
@@ -127,7 +146,7 @@ describe("PostMatchSummary", () => {
       },
     ]);
 
-    render(<PostMatchSummary {...defaultProps} />);
+    renderComponent();
 
     await waitFor(() => {
       const nextMatchButton = screen.getByText(/Next Match \(Round 4\)/);
@@ -143,7 +162,7 @@ describe("PostMatchSummary", () => {
   it("does not show Next Match link when no next match exists", async () => {
     (getPlayerMatches as jest.Mock).mockResolvedValue([]);
 
-    render(<PostMatchSummary {...defaultProps} />);
+    renderComponent();
 
     await waitFor(() => {
       expect(screen.queryByText(/Next Match/)).not.toBeInTheDocument();
@@ -155,7 +174,7 @@ describe("PostMatchSummary", () => {
       { id: 100, status: "completed", round: { id: 1, round_number: 3 } },
     ]);
 
-    render(<PostMatchSummary {...defaultProps} />);
+    renderComponent();
 
     await waitFor(() => {
       expect(screen.getByText("Round 3 complete")).toBeInTheDocument();
@@ -181,7 +200,7 @@ describe("PostMatchSummary", () => {
 
     (useSupabase as jest.Mock).mockReturnValue(mockSupabaseWithActiveMatches);
 
-    render(<PostMatchSummary {...defaultProps} />);
+    renderComponent();
 
     await waitFor(() => {
       expect(
@@ -193,7 +212,7 @@ describe("PostMatchSummary", () => {
   it("handles null userAltId gracefully", async () => {
     (getPlayerMatches as jest.Mock).mockResolvedValue([]);
 
-    render(<PostMatchSummary {...defaultProps} userAltId={null} />);
+    renderComponent({ ...defaultProps, userAltId: null });
 
     await waitFor(() => {
       expect(screen.getByText("Match Complete")).toBeInTheDocument();
@@ -201,23 +220,16 @@ describe("PostMatchSummary", () => {
     });
   });
 
-  it("handles error when loading next match data", async () => {
-    const consoleErrorSpy = jest
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
+  it("handles error when loading next match data gracefully", async () => {
     (getPlayerMatches as jest.Mock).mockRejectedValue(
       new Error("Failed to fetch")
     );
 
-    render(<PostMatchSummary {...defaultProps} />);
+    renderComponent();
 
+    // Should still render the result even if fetch fails
     await waitFor(() => {
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "Error loading next match data:",
-        expect.any(Error)
-      );
+      expect(screen.getByText("Match Complete")).toBeInTheDocument();
     });
-
-    consoleErrorSpy.mockRestore();
   });
 });

--- a/apps/web/src/components/match/post-match-summary.tsx
+++ b/apps/web/src/components/match/post-match-summary.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { useSupabase } from "@/lib/supabase";
 import { getPlayerMatches } from "@trainers/supabase";
 import { Trophy, TrendingUp, Clock, ArrowRight } from "lucide-react";
@@ -28,120 +28,89 @@ export function PostMatchSummary({
   roundNumber,
 }: PostMatchSummaryProps) {
   const supabase = useSupabase();
-  const [nextMatch, setNextMatch] = useState<{
-    id: number;
-    roundNumber: number;
-    tableNumber: number;
-  } | null>(null);
-  const [roundStatus, setRoundStatus] = useState<"active" | "completed" | null>(
-    null
-  );
-  const [isLoading, setIsLoading] = useState(true);
 
-  useEffect(() => {
-    if (!userAltId) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setNextMatch(null);
-      setRoundStatus(null);
-      setIsLoading(false);
-      return;
-    }
+  const { data, isLoading } = useQuery({
+    queryKey: ['post-match-summary', tournamentId, matchId, userAltId],
+    queryFn: async () => {
+      // Get all player matches to find the next one
+      const matches = await getPlayerMatches(
+        supabase,
+        tournamentId,
+        userAltId!
+      );
 
-    let isCancelled = false;
-
-    async function loadNextMatchData() {
-      try {
-        // Get all player matches to find the next one
-        const matches = await getPlayerMatches(
-          supabase,
-          tournamentId,
-          userAltId!
-        );
-
-        if (isCancelled) return;
-
-        // Find the next pending match (after current match) in a deterministic way
-        const pendingMatches = matches
-          .filter((m) => m.id !== matchId && m.status === "pending")
-          .map((m) => {
-            const round = m.round as { round_number: number } | null;
-            const matchRoundNumber =
-              typeof round?.round_number === "number"
-                ? round.round_number
-                : Number.POSITIVE_INFINITY;
-            return { match: m, roundNumber: matchRoundNumber };
-          });
-
-        let candidateMatches = pendingMatches;
-
-        // If we know the current match's round, prefer pending matches in later rounds
-        if (typeof roundNumber === "number") {
-          const laterRoundMatches = pendingMatches.filter(
-            (m) => m.roundNumber > roundNumber
-          );
-          if (laterRoundMatches.length > 0) {
-            candidateMatches = laterRoundMatches;
-          }
-        }
-
-        candidateMatches.sort((a, b) => {
-          if (a.roundNumber !== b.roundNumber) {
-            return a.roundNumber - b.roundNumber;
-          }
-          return a.match.id - b.match.id;
+      // Find the next pending match (after current match) in a deterministic way
+      const pendingMatches = matches
+        .filter((m) => m.id !== matchId && m.status === "pending")
+        .map((m) => {
+          const round = m.round as { round_number: number } | null;
+          const matchRoundNumber =
+            typeof round?.round_number === "number"
+              ? round.round_number
+              : Number.POSITIVE_INFINITY;
+          return { match: m, roundNumber: matchRoundNumber };
         });
 
-        const nextPendingMatch = candidateMatches[0]?.match;
+      let candidateMatches = pendingMatches;
 
-        if (nextPendingMatch) {
-          const round = nextPendingMatch.round as {
-            round_number: number;
-          } | null;
-          setNextMatch({
-            id: nextPendingMatch.id,
-            roundNumber: round?.round_number ?? 0,
-            tableNumber: nextPendingMatch.table_number ?? 0,
-          });
-        } else {
-          setNextMatch(null);
-        }
-
-        // Check current round status by deriving round_id from the current match
-        const currentMatch = matches.find((m) => m.id === matchId);
-        const currentRound = currentMatch?.round as {
-          id: number;
-          round_number: number;
-        } | null;
-
-        if (currentRound?.id) {
-          const { count, error: countError } = await supabase
-            .from("tournament_matches")
-            .select("*", { count: "exact", head: true })
-            .eq("round_id", currentRound.id)
-            .eq("status", "active");
-
-          if (countError) {
-            console.error("Error checking round status:", countError);
-          } else if (!isCancelled) {
-            setRoundStatus((count ?? 0) > 0 ? "active" : "completed");
-          }
-        }
-      } catch (error) {
-        if (isCancelled) return;
-        console.error("Error loading next match data:", error);
-      } finally {
-        if (!isCancelled) {
-          setIsLoading(false);
+      // If we know the current match's round, prefer pending matches in later rounds
+      if (typeof roundNumber === "number") {
+        const laterRoundMatches = pendingMatches.filter(
+          (m) => m.roundNumber > roundNumber
+        );
+        if (laterRoundMatches.length > 0) {
+          candidateMatches = laterRoundMatches;
         }
       }
-    }
 
-    loadNextMatchData();
+      candidateMatches.sort((a, b) => {
+        if (a.roundNumber !== b.roundNumber) {
+          return a.roundNumber - b.roundNumber;
+        }
+        return a.match.id - b.match.id;
+      });
 
-    return () => {
-      isCancelled = true;
-    };
-  }, [supabase, tournamentId, userAltId, matchId, roundNumber]);
+      const nextPendingMatch = candidateMatches[0]?.match;
+
+      let nextMatch = null;
+      if (nextPendingMatch) {
+        const round = nextPendingMatch.round as {
+          round_number: number;
+        } | null;
+        nextMatch = {
+          id: nextPendingMatch.id,
+          roundNumber: round?.round_number ?? 0,
+          tableNumber: nextPendingMatch.table_number ?? 0,
+        };
+      }
+
+      // Check current round status by deriving round_id from the current match
+      const currentMatch = matches.find((m) => m.id === matchId);
+      const currentRound = currentMatch?.round as {
+        id: number;
+        round_number: number;
+      } | null;
+
+      let roundStatus: "active" | "completed" | null = null;
+      if (currentRound?.id) {
+        const { count, error: countError } = await supabase
+          .from("tournament_matches")
+          .select("*", { count: "exact", head: true })
+          .eq("round_id", currentRound.id)
+          .eq("status", "active");
+
+        if (!countError) {
+          roundStatus = (count ?? 0) > 0 ? "active" : "completed";
+        }
+      }
+
+      return { nextMatch, roundStatus };
+    },
+    enabled: !!userAltId,
+  });
+
+  const nextMatch = data?.nextMatch ?? null;
+  const roundStatus = data?.roundStatus ?? null;
 
   const didWin = myWins > opponentWins;
   const resultText = didWin

--- a/apps/web/src/components/match/post-match-summary.tsx
+++ b/apps/web/src/components/match/post-match-summary.tsx
@@ -40,8 +40,11 @@ export function PostMatchSummary({
 
   useEffect(() => {
     if (!userAltId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setNextMatch(null);
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setRoundStatus(null);
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsLoading(false);
       return;
     }

--- a/apps/web/src/components/match/post-match-summary.tsx
+++ b/apps/web/src/components/match/post-match-summary.tsx
@@ -42,9 +42,7 @@ export function PostMatchSummary({
     if (!userAltId) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setNextMatch(null);
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setRoundStatus(null);
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsLoading(false);
       return;
     }

--- a/apps/web/src/components/match/post-match-summary.tsx
+++ b/apps/web/src/components/match/post-match-summary.tsx
@@ -2,6 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { useSupabase } from "@/lib/supabase";
+import { queryKeys } from "@/lib/query-keys";
 import { getPlayerMatches } from "@trainers/supabase";
 import { Trophy, TrendingUp, Clock, ArrowRight } from "lucide-react";
 import Link from "next/link";
@@ -30,7 +31,7 @@ export function PostMatchSummary({
   const supabase = useSupabase();
 
   const { data, isLoading } = useQuery({
-    queryKey: ['post-match-summary', tournamentId, matchId, userAltId],
+    queryKey: queryKeys.match.postMatchSummary(tournamentId, matchId, userAltId),
     queryFn: async () => {
       // Get all player matches to find the next one
       const matches = await getPlayerMatches(

--- a/apps/web/src/components/settings/__tests__/discord-dm-preferences-section.test.tsx
+++ b/apps/web/src/components/settings/__tests__/discord-dm-preferences-section.test.tsx
@@ -46,6 +46,30 @@ jest.mock("@/actions/discord-integration", () => ({
     mockSetDmPreferenceAction(...args),
 }));
 
+jest.mock("@/components/ui/switch", () => ({
+  Switch: ({
+    checked,
+    onCheckedChange,
+    disabled,
+    ...props
+  }: {
+    checked?: boolean;
+    onCheckedChange?: (v: boolean) => void;
+    disabled?: boolean;
+    "aria-label"?: string;
+    id?: string;
+  }) => (
+    <button
+      role="switch"
+      aria-checked={checked}
+      aria-label={props["aria-label"]}
+      aria-disabled={disabled || undefined}
+      data-disabled={disabled ? "" : undefined}
+      onClick={() => !disabled && onCheckedChange?.(!checked)}
+    />
+  ),
+}));
+
 // =============================================================================
 // Test helpers
 // =============================================================================

--- a/apps/web/src/components/settings/__tests__/linked-identities-section.test.tsx
+++ b/apps/web/src/components/settings/__tests__/linked-identities-section.test.tsx
@@ -34,9 +34,11 @@ jest.mock("next/link", () => ({
 }));
 
 // Mock TanStack Query — useQuery returns data from our per-test variable
-const mockUseQuery = jest.fn(() => ({ data: 0 }));
+const mockUseQuery = jest.fn();
+const mockQueryClient = { invalidateQueries: jest.fn() };
 jest.mock("@tanstack/react-query", () => ({
   useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  useQueryClient: () => mockQueryClient,
 }));
 
 // Mock dependencies
@@ -111,8 +113,14 @@ describe("LinkedIdentitiesSection", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUserIdentities = [];
-    // Reset useQuery to return 0 enabled DM preferences by default
-    mockUseQuery.mockReturnValue({ data: 0 });
+    // Default: bluesky status query returns loaded with null, DM count returns 0
+    mockUseQuery.mockImplementation((opts: { queryKey: string[] }) => {
+      if (opts.queryKey[0] === "bluesky-status") {
+        return { data: { did: null, handle: null }, isLoading: false };
+      }
+      // discord-dm-preferences-count
+      return { data: 0, isLoading: false };
+    });
     mockGetBlueskyStatus.mockResolvedValue({
       success: true,
       data: { did: null, pdsStatus: null, handle: null },
@@ -121,6 +129,12 @@ describe("LinkedIdentitiesSection", () => {
 
   describe("rendering", () => {
     it("shows loading state initially", () => {
+      mockUseQuery.mockImplementation((opts: { queryKey: string[] }) => {
+        if (opts.queryKey[0] === "bluesky-status") {
+          return { data: undefined, isLoading: true };
+        }
+        return { data: 0, isLoading: false };
+      });
       render(<LinkedIdentitiesSection />);
       expect(screen.getByRole("status")).toBeInTheDocument();
     });
@@ -165,13 +179,17 @@ describe("LinkedIdentitiesSection", () => {
     });
 
     it("renders Bluesky when user has DID", async () => {
-      mockGetBlueskyStatus.mockResolvedValue({
-        success: true,
-        data: {
-          did: "did:plc:test123",
-          pdsStatus: "active",
-          handle: "testuser.trainers.gg",
-        },
+      mockUseQuery.mockImplementation((opts: { queryKey: string[] }) => {
+        if (opts.queryKey[0] === "bluesky-status") {
+          return {
+            data: {
+              did: "did:plc:test123",
+              handle: "testuser.trainers.gg",
+            },
+            isLoading: false,
+          };
+        }
+        return { data: 0, isLoading: false };
       });
 
       render(<LinkedIdentitiesSection />);
@@ -376,13 +394,17 @@ describe("LinkedIdentitiesSection", () => {
           provider: "discord",
         },
       ];
-      mockGetBlueskyStatus.mockResolvedValue({
-        success: true,
-        data: {
-          did: "did:plc:test123",
-          pdsStatus: "active",
-          handle: "testuser.trainers.gg",
-        },
+      mockUseQuery.mockImplementation((opts: { queryKey: string[] }) => {
+        if (opts.queryKey[0] === "bluesky-status") {
+          return {
+            data: {
+              did: "did:plc:test123",
+              handle: "testuser.trainers.gg",
+            },
+            isLoading: false,
+          };
+        }
+        return { data: 0, isLoading: false };
       });
       mockUnlinkBlueskyAction.mockResolvedValue({ success: true });
 
@@ -446,13 +468,17 @@ describe("LinkedIdentitiesSection", () => {
           provider: "discord",
         },
       ];
-      mockGetBlueskyStatus.mockResolvedValue({
-        success: true,
-        data: {
-          did: "did:plc:test123",
-          pdsStatus: "active",
-          handle: "testuser.trainers.gg",
-        },
+      mockUseQuery.mockImplementation((opts: { queryKey: string[] }) => {
+        if (opts.queryKey[0] === "bluesky-status") {
+          return {
+            data: {
+              did: "did:plc:test123",
+              handle: "testuser.trainers.gg",
+            },
+            isLoading: false,
+          };
+        }
+        return { data: 0, isLoading: false };
       });
 
       render(<LinkedIdentitiesSection />);
@@ -645,13 +671,17 @@ describe("LinkedIdentitiesSection", () => {
           provider: "discord",
         },
       ];
-      mockGetBlueskyStatus.mockResolvedValue({
-        success: true,
-        data: {
-          did: "did:plc:test123",
-          pdsStatus: "active",
-          handle: "testuser.trainers.gg",
-        },
+      mockUseQuery.mockImplementation((opts: { queryKey: string[] }) => {
+        if (opts.queryKey[0] === "bluesky-status") {
+          return {
+            data: {
+              did: "did:plc:test123",
+              handle: "testuser.trainers.gg",
+            },
+            isLoading: false,
+          };
+        }
+        return { data: 0, isLoading: false };
       });
       mockUnlinkBlueskyAction.mockResolvedValue({
         success: false,
@@ -692,7 +722,12 @@ describe("LinkedIdentitiesSection", () => {
     });
 
     it("renders DM summary when Discord is linked", async () => {
-      mockUseQuery.mockReturnValue({ data: 7 });
+      mockUseQuery.mockImplementation((opts: { queryKey: string[] }) => {
+        if (opts.queryKey[0] === "bluesky-status") {
+          return { data: { did: null, handle: null }, isLoading: false };
+        }
+        return { data: 7, isLoading: false };
+      });
       mockUserIdentities = [
         {
           id: "identity-1",
@@ -717,7 +752,12 @@ describe("LinkedIdentitiesSection", () => {
     });
 
     it("Manage link points to /dashboard/settings/notifications#discord-dms", async () => {
-      mockUseQuery.mockReturnValue({ data: 3 });
+      mockUseQuery.mockImplementation((opts: { queryKey: string[] }) => {
+        if (opts.queryKey[0] === "bluesky-status") {
+          return { data: { did: null, handle: null }, isLoading: false };
+        }
+        return { data: 3, isLoading: false };
+      });
       mockUserIdentities = [
         {
           id: "identity-1",
@@ -741,7 +781,12 @@ describe("LinkedIdentitiesSection", () => {
     });
 
     it("shows 0 enabled when no DM preferences are set", async () => {
-      mockUseQuery.mockReturnValue({ data: 0 });
+      mockUseQuery.mockImplementation((opts: { queryKey: string[] }) => {
+        if (opts.queryKey[0] === "bluesky-status") {
+          return { data: { did: null, handle: null }, isLoading: false };
+        }
+        return { data: 0, isLoading: false };
+      });
       mockUserIdentities = [
         {
           id: "identity-1",

--- a/apps/web/src/components/settings/linked-identities-section.tsx
+++ b/apps/web/src/components/settings/linked-identities-section.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import Link from "next/link";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { useAuth } from "@/hooks/use-auth";
 import { createClient } from "@/lib/supabase/client";
@@ -82,11 +82,24 @@ const providerIcons: Record<string, () => React.JSX.Element> = {
 export function LinkedIdentitiesSection() {
   const { user, signInWithOAuth } = useAuth();
   const supabase = createClient();
-  const [identities, setIdentities] = useState<UserIdentity[]>([]);
-  const [blueskyDid, setBlueskyDid] = useState<string | null>(null);
-  const [blueskyHandle, setBlueskyHandle] = useState<string | null>(null);
+  const queryClient = useQueryClient();
   const [unlinking, setUnlinking] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
+
+  // Derive identities directly from user object
+  const identities = (user?.identities as UserIdentity[]) || [];
+
+  // Fetch Bluesky status
+  const { data: blueskyStatus, isLoading: loading } = useQuery({
+    queryKey: ['bluesky-status', user?.id],
+    queryFn: async () => {
+      const result = await getBlueskyStatus();
+      if (result.success) return result.data;
+      return { did: null, handle: null };
+    },
+    enabled: !!user,
+  });
+  const blueskyDid = blueskyStatus?.did ?? null;
+  const blueskyHandle = blueskyStatus?.handle ?? null;
 
   // Fetch enabled DM preference count via DB-side count (user-specific — TanStack Query)
   const { data: enabledDmCount = 0 } = useQuery({
@@ -105,30 +118,6 @@ export function LinkedIdentitiesSection() {
     enabled: !!user?.id,
     staleTime: 60_000,
   });
-
-  // Load identities and Bluesky status on mount
-  useEffect(() => {
-    const loadIdentities = async () => {
-      if (!user) {
-        setLoading(false);
-        return;
-      }
-
-      // Set identities from user object
-      setIdentities((user.identities as UserIdentity[]) || []);
-
-      // Fetch Bluesky status from server
-      const result = await getBlueskyStatus();
-      if (result.success) {
-        setBlueskyDid(result.data.did);
-        setBlueskyHandle(result.data.handle);
-      }
-
-      setLoading(false);
-    };
-
-    loadIdentities();
-  }, [user]);
 
   // Calculate total linked methods for lockout protection
   const totalLinkedMethods = identities.length + (blueskyDid ? 1 : 0);
@@ -169,8 +158,7 @@ export function LinkedIdentitiesSection() {
         // Unlink Bluesky via server action
         const result = await unlinkBlueskyAction();
         if (result.success) {
-          setBlueskyDid(null);
-          setBlueskyHandle(null);
+          void queryClient.invalidateQueries({ queryKey: ['bluesky-status', user?.id] });
           toast.success("Bluesky account disconnected");
         } else {
           toast.error(result.error || "Failed to disconnect Bluesky");
@@ -188,8 +176,7 @@ export function LinkedIdentitiesSection() {
         if (error) {
           toast.error(error.message);
         } else {
-          // Remove from local state
-          setIdentities((prev) => prev.filter((i) => i.id !== identityId));
+          // Auth state will update via onAuthStateChange, refreshing user.identities
           toast.success("Account disconnected");
         }
       }

--- a/apps/web/src/components/sudo-mode-indicator.tsx
+++ b/apps/web/src/components/sudo-mode-indicator.tsx
@@ -2,6 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { checkSudoStatus } from "@/lib/sudo/actions";
+import { queryKeys } from "@/lib/query-keys";
 import { ShieldAlert } from "lucide-react";
 
 /**
@@ -14,7 +15,7 @@ import { ShieldAlert } from "lucide-react";
  */
 export function SudoModeIndicator() {
   const { data: isActive = false } = useQuery({
-    queryKey: ['sudo-status'],
+    queryKey: queryKeys.sudo.status(),
     queryFn: async () => {
       const status = await checkSudoStatus();
       return status.isActive;

--- a/apps/web/src/components/sudo-mode-indicator.tsx
+++ b/apps/web/src/components/sudo-mode-indicator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { checkSudoStatus } from "@/lib/sudo/actions";
 import { ShieldAlert } from "lucide-react";
 
@@ -13,21 +13,14 @@ import { ShieldAlert } from "lucide-react";
  * This component should be included in the root layout to appear on all pages.
  */
 export function SudoModeIndicator() {
-  const [isActive, setIsActive] = useState(false);
-
-  useEffect(() => {
-    // Check sudo status on mount
-    checkSudoStatus().then((status) => setIsActive(status.isActive));
-
-    // Poll for sudo status changes every 30 seconds
-    // This ensures the indicator updates if sudo expires or is toggled elsewhere
-    const interval = setInterval(async () => {
+  const { data: isActive = false } = useQuery({
+    queryKey: ['sudo-status'],
+    queryFn: async () => {
       const status = await checkSudoStatus();
-      setIsActive(status.isActive);
-    }, 30000);
-
-    return () => clearInterval(interval);
-  }, []);
+      return status.isActive;
+    },
+    refetchInterval: 30000,
+  });
 
   if (!isActive) {
     return null;

--- a/apps/web/src/components/team-builder/__tests__/teams-list-client.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/teams-list-client.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "@jest/globals";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
 
 // =============================================================================

--- a/apps/web/src/components/team-builder/__tests__/teams-list-client.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/teams-list-client.test.tsx
@@ -1,10 +1,19 @@
 import { describe, it, expect } from "@jest/globals";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import React from "react";
 
 // =============================================================================
 // Module-level mocks
 // =============================================================================
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, refresh: jest.fn() }),
+}));
+
+jest.mock("@/actions/teams", () => ({
+  createTeamAction: jest.fn().mockResolvedValue({ success: true, data: { id: 999 } }),
+}));
 
 jest.mock("@tanstack/react-query", () => ({
   useQuery: jest.fn(({ initialData }: { initialData: unknown }) => ({
@@ -223,20 +232,20 @@ describe("TeamsListClient", () => {
     expect(importLinks.length).toBeGreaterThan(0);
   });
 
-  it("opens the dialog in empty mode when New Team is clicked", () => {
-    render(<TeamsListClient {...defaultProps} initialTeams={[buildTeam()]} />);
+  it("calls createTeamAction and navigates when New Team is clicked", async () => {
+    const { createTeamAction } = jest.requireMock("@/actions/teams");
+    (createTeamAction as jest.Mock).mockResolvedValue({ success: true, data: { id: 999 } });
+    mockPush.mockClear();
 
-    // Dialog starts closed
-    expect(screen.getByTestId("new-team-dialog")).toHaveAttribute(
-      "data-open",
-      "false"
-    );
+    render(<TeamsListClient {...defaultProps} initialTeams={[buildTeam()]} />);
 
     fireEvent.click(screen.getByText("New Team"));
 
-    const dialog = screen.getByTestId("new-team-dialog");
-    expect(dialog).toHaveAttribute("data-open", "true");
-    expect(dialog).toHaveAttribute("data-mode", "empty");
+    // Wait for async action to resolve
+    await screen.findByText("New Team");
+
+    expect(createTeamAction).toHaveBeenCalledWith(42, "Untitled Team", "gen9vgc2024regg");
+    expect(mockPush).toHaveBeenCalledWith("/dashboard/alts/ash_ketchum/teams/999");
   });
 
   it("opens the dialog in import mode when Import Paste is clicked", () => {

--- a/apps/web/src/components/team-builder/__tests__/use-calc-state.integration.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/use-calc-state.integration.test.tsx
@@ -845,6 +845,9 @@ describe("mega toggle (real engine)", () => {
       })
     );
 
+    // Remove the defender's mega stone so toggling its mega flag has no effect.
+    act(() => result.current.setDefenderItem(""));
+
     act(() => result.current.setAttackerMegaActive(false));
     const onlyAttackerOff = mid(
       result.current.selectedMoveOutput!.minPercent,
@@ -857,8 +860,8 @@ describe("mega toggle (real engine)", () => {
       result.current.selectedMoveOutput!.maxPercent
     );
 
-    // Defender is the default Incineroar (not a mega), so toggling the
-    // defender flag must not change damage.
+    // Defender has no mega stone, so toggling the defender flag must not
+    // change damage.
     expect(bothOff).toBeCloseTo(onlyAttackerOff, 1);
   });
 });
@@ -1145,14 +1148,14 @@ describe("null and empty guards", () => {
   });
 
   it("multi-move pokemon: filled slots produce outputs (immunities included), empty slots are null", () => {
-    // Default defender is Incineroar (Dark/Fire). Moonblast (Fairy → Dark)
-    // is super-effective; Psyshock (Psychic → Dark) is immune and now
-    // surfaces as a valid 0%/0% output rather than null.
+    // Default defender is Floette-Eternal (Fairy). Moonblast (Fairy → Fairy)
+    // is resisted but deals damage; Draco Meteor (Dragon → Fairy) is immune
+    // and surfaces as a valid 0%/0% output rather than null.
     const { result } = renderHook(() =>
       useCalcState({
         selectedPokemon: makePokemon({
           move1: "Moonblast",
-          move2: "Psyshock",
+          move2: "Draco Meteor",
           move3: null,
           move4: null,
         }),

--- a/apps/web/src/components/team-builder/__tests__/use-calc-state.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/use-calc-state.test.tsx
@@ -777,3 +777,92 @@ describe("attackerMegaActive / defenderMegaActive", () => {
     expect(result.current.attackerMegaActive).toBe(true);
   });
 });
+
+// =============================================================================
+// Per-row mega scoping in computeReverseOutputsForRow
+// Regression guard for the bug fixed at use-calc-state.ts:1355 — the panel's
+// attackerMegaActive flag must only apply to the FOCUSED row. Non-focused team
+// rows always build with megaActive=true so each species shows its raw matchup
+// vs the defender (mirrors the forward-path symmetry at line 1276).
+// =============================================================================
+
+describe("computeReverseOutputsForRow — mega scoping", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("non-focused row builds with mega species even when attackerMegaActive is false", () => {
+    // Both rows are mega-capable Charizards (Charizardite Y → Charizard-Mega-Y).
+    // Same species + same item lets us isolate the megaActive flag as the only
+    // differentiator in effectiveSpecies between focused vs non-focused rows.
+    const focusedCharizard = makePokemon({
+      id: 1,
+      species: "Charizard",
+      held_item: "Charizardite Y",
+    });
+    const nonFocusedCharizard = makePokemon({
+      id: 2,
+      species: "Charizard",
+      held_item: "Charizardite Y",
+    });
+
+    const { result } = renderHook(() =>
+      useCalcState({ selectedPokemon: focusedCharizard })
+    );
+
+    // Turn off the panel-level mega flag for the focused row.
+    act(() => result.current.setAttackerMegaActive(false));
+    // Reverse calc requires a defender species to engage.
+    act(() => result.current.setDefenderSpecies("Garchomp"));
+
+    // Drop all prior Pokemon constructions (shared attacker/defender, etc.) so
+    // we only inspect what the upcoming row-level call constructs.
+    mockPokemonConstructor.mockClear();
+
+    result.current.computeReverseOutputsForRow(nonFocusedCharizard, [
+      "Earthquake",
+      "",
+      "",
+      "",
+    ] as const);
+
+    // The non-focused row's defender Pokemon should be the Mega form because
+    // the fix passes `true` for non-focused rows regardless of the panel flag.
+    // Without the isFocused guard this would be base "Charizard" and the test
+    // would fail — that's the exact regression we're guarding against.
+    const speciesCalls = getPokemonSpeciesCalls();
+    expect(speciesCalls).toContain("Charizard-Mega-Y");
+    expect(speciesCalls).not.toContain("Charizard");
+  });
+
+  it("focused row honors attackerMegaActive=false (builds as base species)", () => {
+    // Counterpart assertion: when the row IS focused, the panel flag governs.
+    // This proves the isFocused branch is wired correctly in both directions.
+    const focusedCharizard = makePokemon({
+      id: 1,
+      species: "Charizard",
+      held_item: "Charizardite Y",
+    });
+
+    const { result } = renderHook(() =>
+      useCalcState({ selectedPokemon: focusedCharizard })
+    );
+
+    act(() => result.current.setAttackerMegaActive(false));
+    act(() => result.current.setDefenderSpecies("Garchomp"));
+
+    mockPokemonConstructor.mockClear();
+
+    // Pass the SAME pokemon instance so isFocused matches by id.
+    result.current.computeReverseOutputsForRow(focusedCharizard, [
+      "Earthquake",
+      "",
+      "",
+      "",
+    ] as const);
+
+    const speciesCalls = getPokemonSpeciesCalls();
+    expect(speciesCalls).toContain("Charizard");
+    expect(speciesCalls).not.toContain("Charizard-Mega-Y");
+  });
+});

--- a/apps/web/src/components/team-builder/__tests__/use-calc-state.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/use-calc-state.test.tsx
@@ -16,9 +16,18 @@ const mockCalculate = jest.fn(() => ({
 
 // Tracks all Move constructor invocations: [gen, name, opts]
 const mockMoveConstructor = jest.fn();
+// Tracks all Pokemon constructor invocations: [gen, species, opts]. Lets tests
+// verify which species was passed to new Pokemon() (e.g. mega vs base form).
+const mockPokemonConstructor = jest.fn();
 
 jest.mock("@smogon/calc", () => {
-  const MockPokemon = jest.fn(function (this: Record<string, unknown>) {
+  const MockPokemon = jest.fn(function (
+    this: Record<string, unknown>,
+    gen: unknown,
+    species: unknown,
+    opts: unknown
+  ) {
+    mockPokemonConstructor(gen, species, opts);
     this.maxHP = mockMaxHP;
   });
   const MockMove = jest.fn(function (
@@ -45,6 +54,11 @@ jest.mock("@smogon/calc", () => {
 function getMoveOptsFor(moveName: string): Record<string, unknown> | undefined {
   const call = mockMoveConstructor.mock.calls.find((c) => c[1] === moveName);
   return call ? (call[2] as Record<string, unknown>) : undefined;
+}
+
+/** Returns every species name passed to new Pokemon(gen, species, opts). */
+function getPokemonSpeciesCalls(): string[] {
+  return mockPokemonConstructor.mock.calls.map((c) => String(c[1]));
 }
 
 import { getFormatById } from "@trainers/pokemon";

--- a/apps/web/src/components/team-builder/teams-list-client.tsx
+++ b/apps/web/src/components/team-builder/teams-list-client.tsx
@@ -3,7 +3,8 @@
 import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { Plus, Upload } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { Loader2, Plus, Upload } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 
 import {
@@ -15,6 +16,7 @@ import { getPokemonSprite } from "@trainers/pokemon/sprites";
 import { getTeamsForAltList, type TeamListItem } from "@trainers/supabase";
 import { formatTimeAgo } from "@trainers/utils";
 
+import { createTeamAction } from "@/actions/teams";
 import { useSupabase } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -61,10 +63,11 @@ export function TeamsListClient({
   activeFormats,
 }: TeamsListClientProps) {
   const supabase = useSupabase();
+  const router = useRouter();
   const [selectedGame, setSelectedGame] = useState<string>("");
   const [selectedFormat, setSelectedFormat] = useState<string | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [dialogMode, setDialogMode] = useState<"empty" | "import">("empty");
+  const [creating, setCreating] = useState(false);
 
   const {
     data: teams = [],
@@ -93,9 +96,22 @@ export function TeamsListClient({
     ? teams.filter((t) => t.format === selectedFormat)
     : teams;
 
-  function openDialog(mode: "empty" | "import") {
-    setDialogMode(mode);
+  function openImportDialog() {
     setDialogOpen(true);
+  }
+
+  async function handleNewTeam() {
+    if (creating || activeFormats.length === 0) return;
+    setCreating(true);
+    try {
+      const defaultFormat = selectedFormat ?? activeFormats[0]!.id;
+      const result = await createTeamAction(altId, "Untitled Team", defaultFormat);
+      if (result.success) {
+        router.push(`/dashboard/alts/${handle}/teams/${result.data.id}`);
+      }
+    } finally {
+      setCreating(false);
+    }
   }
 
   return (
@@ -140,13 +156,17 @@ export function TeamsListClient({
           <Button
             variant="outline"
             size="sm"
-            onClick={() => openDialog("import")}
+            onClick={openImportDialog}
           >
             <Upload className="size-4" />
             Import Paste
           </Button>
-          <Button size="sm" onClick={() => openDialog("empty")}>
-            <Plus className="size-4" />
+          <Button size="sm" onClick={handleNewTeam} disabled={creating}>
+            {creating ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Plus className="size-4" />
+            )}
             New Team
           </Button>
         </div>
@@ -171,12 +191,16 @@ export function TeamsListClient({
           }
           action={
             <div className="flex items-center gap-2">
-              <Button variant="outline" onClick={() => openDialog("import")}>
+              <Button variant="outline" onClick={openImportDialog}>
                 <Upload className="size-4" />
                 Import Paste
               </Button>
-              <Button onClick={() => openDialog("empty")}>
-                <Plus className="size-4" />
+              <Button onClick={handleNewTeam} disabled={creating}>
+                {creating ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Plus className="size-4" />
+                )}
                 New Team
               </Button>
             </div>
@@ -208,7 +232,7 @@ export function TeamsListClient({
         onOpenChange={setDialogOpen}
         activeFormats={activeFormats}
         defaultFormat={selectedFormat ?? undefined}
-        initialMode={dialogMode}
+        initialMode="import"
         altId={altId}
         altUsername={handle}
       />

--- a/apps/web/src/components/team-builder/teams-list-client.tsx
+++ b/apps/web/src/components/team-builder/teams-list-client.tsx
@@ -16,6 +16,8 @@ import { getPokemonSprite } from "@trainers/pokemon/sprites";
 import { getTeamsForAltList, type TeamListItem } from "@trainers/supabase";
 import { formatTimeAgo } from "@trainers/utils";
 
+import { toast } from "sonner";
+
 import { createTeamAction } from "@/actions/teams";
 import { useSupabase } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
@@ -108,6 +110,8 @@ export function TeamsListClient({
       const result = await createTeamAction(altId, "Untitled Team", defaultFormat);
       if (result.success) {
         router.push(`/dashboard/alts/${handle}/teams/${result.data.id}`);
+      } else {
+        toast.error(result.error ?? "Failed to create team");
       }
     } finally {
       setCreating(false);

--- a/apps/web/src/components/team-builder/use-calc-state.ts
+++ b/apps/web/src/components/team-builder/use-calc-state.ts
@@ -1345,13 +1345,14 @@ export function useCalcState({
     if (!sharedDefenderAsAttacker) return NULL_OUTPUTS;
     if (!effectiveMoves.some(Boolean)) return NULL_OUTPUTS;
 
+    const isFocused = selectedPokemon?.id === rowPokemon.id;
     // Build this team member as a defender (neutral boosts, healthy)
     const ourDefender = buildAttackerFromDb(
       gen,
       rowPokemon,
       EMPTY_BOOSTS,
       "Healthy",
-      attackerMegaActive
+      isFocused ? attackerMegaActive : true
     );
     if (!ourDefender) return NULL_OUTPUTS;
 

--- a/apps/web/src/components/team-builder/v2/__tests__/calc-attacker-block.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/calc-attacker-block.test.tsx
@@ -7,15 +7,8 @@
  *   - "Attacker" and "your team" header labels render
  *   - AttackerChipStrip receives teamSlots and activeIdx
  *   - Attacker species name, types, nature/level/item/ability display
- *   - "No attacker selected" fallback when slot is null
+ *   - "No attacker selected." fallback when attacker slot is null
  *   - Inherits-from-row note shows correct 1-based slot number
- *   - Stat-boost grid: all 5 stat keys render labels
- *   - Stat-boost stepper: decrease/increase buttons per stat
- *   - Clicking stepper + calls setAttackerBoost with incremented value
- *   - Clicking stepper − calls setAttackerBoost with decremented value
- *   - Stepper clamps at +6 max / −6 min
- *   - Quick-pick chips render for each stat and fire setAttackerBoost
- *   - Stat boosts section appears before inherits note
  *   - onPickAttacker is called through the chip strip
  */
 
@@ -28,7 +21,6 @@ import { type Tables } from "@trainers/supabase";
 // =============================================================================
 // Mocks
 // =============================================================================
-
 
 // AttackerChipStrip — render a simple test stub
 jest.mock("../calc/attacker-chip-strip", () => ({
@@ -70,7 +62,16 @@ jest.mock("../type-pill", () => ({
   ),
 }));
 
-// @trainers/pokemon — only getSpeciesTypes is used
+// MegaToggle — stub
+jest.mock("../calc/mega-toggle", () => ({
+  MegaToggle: ({ active, onToggle }: { active: boolean; onToggle: () => void }) => (
+    <button data-testid="mega-toggle" aria-pressed={active} onClick={onToggle}>
+      Mega
+    </button>
+  ),
+}));
+
+// @trainers/pokemon
 const mockGetSpeciesTypes = jest.fn();
 
 jest.mock("@trainers/pokemon", () => {
@@ -78,6 +79,7 @@ jest.mock("@trainers/pokemon", () => {
   return {
     ...actual,
     getSpeciesTypes: (...args: unknown[]) => mockGetSpeciesTypes(...args),
+    getMegaAbilityForSpecies: jest.fn().mockReturnValue(null),
   };
 });
 
@@ -86,7 +88,6 @@ jest.mock("@trainers/pokemon", () => {
 // =============================================================================
 
 import { CalcAttackerBlock } from "../calc/calc-attacker-block";
-import { type AttackerBoosts } from "../../use-calc-state";
 
 // =============================================================================
 // Fixtures
@@ -129,34 +130,30 @@ function makePokemon(
   };
 }
 
-function makeBoosts(overrides: Partial<AttackerBoosts> = {}): AttackerBoosts {
-  return { atk: 0, def: 0, spa: 0, spd: 0, spe: 0, ...overrides };
-}
-
 interface RenderProps {
   teamSlots?: (Tables<"pokemon"> | null)[];
   attackerIdx?: number;
   onPickAttacker?: jest.Mock;
-  attackerBoosts?: AttackerBoosts;
-  setAttackerBoost?: jest.Mock;
+  attackerMegaActive?: boolean;
+  setAttackerMegaActive?: jest.Mock;
 }
 
 function renderAttacker(props: RenderProps = {}) {
   const teamSlots = props.teamSlots ?? [makePokemon(), null, null, null, null, null];
   const onPickAttacker = props.onPickAttacker ?? jest.fn();
-  const setAttackerBoost = props.setAttackerBoost ?? jest.fn();
+  const setAttackerMegaActive = props.setAttackerMegaActive ?? jest.fn();
 
   const result = render(
     <CalcAttackerBlock
       teamSlots={teamSlots}
       attackerIdx={props.attackerIdx ?? 0}
       onPickAttacker={onPickAttacker}
-      attackerBoosts={props.attackerBoosts ?? makeBoosts()}
-      setAttackerBoost={setAttackerBoost}
+      attackerMegaActive={props.attackerMegaActive ?? false}
+      setAttackerMegaActive={setAttackerMegaActive}
     />
   );
 
-  return { ...result, onPickAttacker, setAttackerBoost };
+  return { ...result, onPickAttacker, setAttackerMegaActive };
 }
 
 // =============================================================================
@@ -181,11 +178,6 @@ describe("CalcAttackerBlock — header labels", () => {
   it("renders the 'your team' sub-label", () => {
     renderAttacker();
     expect(screen.getByText("your team")).toBeInTheDocument();
-  });
-
-  it("renders the 'Stat boosts' section header", () => {
-    renderAttacker();
-    expect(screen.getByText("Stat boosts")).toBeInTheDocument();
   });
 });
 
@@ -219,7 +211,6 @@ describe("CalcAttackerBlock — chip strip", () => {
 describe("CalcAttackerBlock — attacker display", () => {
   it("renders the attacker species name in the mon head", () => {
     renderAttacker({ teamSlots: [makePokemon({ species: "Garchomp" }), null, null, null, null, null] });
-    // The name appears in both the chip stub and the mon head — at least one must be present
     expect(screen.getAllByText("Garchomp").length).toBeGreaterThanOrEqual(1);
   });
 
@@ -304,161 +295,6 @@ describe("CalcAttackerBlock — inherits-from note", () => {
       expect(note).toBeInTheDocument();
     }
   );
-});
-
-describe("CalcAttackerBlock — stat boost grid labels", () => {
-  it.each([
-    ["ATK", "atk"],
-    ["DEF", "def"],
-    ["SPA", "spa"],
-    ["SPD", "spd"],
-    ["SPE", "spe"],
-  ] as const)(
-    "renders the %s stat label",
-    (label) => {
-      renderAttacker();
-      expect(screen.getByText(label)).toBeInTheDocument();
-    }
-  );
-});
-
-describe("CalcAttackerBlock — stat boost stepper", () => {
-  it("renders stat boost stepper with decrease and increase buttons for each stat", () => {
-    renderAttacker({ attackerBoosts: makeBoosts() });
-    expect(screen.getByRole("button", { name: /decrease atk boost/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /increase atk boost/i })).toBeInTheDocument();
-  });
-
-  it("renders stepper decrease/increase buttons for all 5 stats", () => {
-    renderAttacker({ attackerBoosts: makeBoosts() });
-    const statKeys = ["atk", "def", "spa", "spd", "spe"] as const;
-    for (const stat of statKeys) {
-      expect(
-        screen.getByRole("button", { name: new RegExp(`decrease ${stat} boost`, "i") })
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: new RegExp(`increase ${stat} boost`, "i") })
-      ).toBeInTheDocument();
-    }
-  });
-
-  it("clicking + calls setAttackerBoost with incremented value", () => {
-    const setAttackerBoost = jest.fn();
-    renderAttacker({
-      attackerBoosts: makeBoosts({ atk: 1 }),
-      setAttackerBoost,
-    });
-    fireEvent.click(screen.getByRole("button", { name: /increase atk boost/i }));
-    expect(setAttackerBoost).toHaveBeenCalledWith("atk", 2);
-  });
-
-  it("clicking − calls setAttackerBoost with decremented value", () => {
-    const setAttackerBoost = jest.fn();
-    renderAttacker({
-      attackerBoosts: makeBoosts({ atk: 2 }),
-      setAttackerBoost,
-    });
-    fireEvent.click(screen.getByRole("button", { name: /decrease atk boost/i }));
-    expect(setAttackerBoost).toHaveBeenCalledWith("atk", 1);
-  });
-
-  it("+ clamps at +6 — does not exceed maximum", () => {
-    const setAttackerBoost = jest.fn();
-    renderAttacker({
-      attackerBoosts: makeBoosts({ atk: 6 }),
-      setAttackerBoost,
-    });
-    fireEvent.click(screen.getByRole("button", { name: /increase atk boost/i }));
-    expect(setAttackerBoost).toHaveBeenCalledWith("atk", 6);
-  });
-
-  it("− clamps at −6 — does not go below minimum", () => {
-    const setAttackerBoost = jest.fn();
-    renderAttacker({
-      attackerBoosts: makeBoosts({ spe: -6 }),
-      setAttackerBoost,
-    });
-    fireEvent.click(screen.getByRole("button", { name: /decrease spe boost/i }));
-    expect(setAttackerBoost).toHaveBeenCalledWith("spe", -6);
-  });
-
-  it("clicking + on SPE stat calls setAttackerBoost('spe', incremented)", () => {
-    const setAttackerBoost = jest.fn();
-    renderAttacker({
-      attackerBoosts: makeBoosts({ spe: 3 }),
-      setAttackerBoost,
-    });
-    fireEvent.click(screen.getByRole("button", { name: /increase spe boost/i }));
-    expect(setAttackerBoost).toHaveBeenCalledWith("spe", 4);
-  });
-});
-
-describe("CalcAttackerBlock — quick-pick chips", () => {
-  it("renders quick-pick chips +6 for all 5 stats", () => {
-    renderAttacker({ attackerBoosts: makeBoosts() });
-    const chips = screen.getAllByRole("button", { name: "+6" });
-    expect(chips.length).toBe(5);
-  });
-
-  it("renders quick-pick chips for values 0, +1, +2, +3, +6 per stat", () => {
-    renderAttacker({ attackerBoosts: makeBoosts() });
-    // 5 stats × 5 quick-pick values = 25 chips total; check the first stat row
-    // QUICK_PICKS = [0, 1, 2, 3, 6], rendered as "0", "+1", "+2", "+3", "+6"
-    expect(screen.getAllByRole("button", { name: "0" }).length).toBeGreaterThanOrEqual(5);
-    expect(screen.getAllByRole("button", { name: "+1" }).length).toBe(5);
-    expect(screen.getAllByRole("button", { name: "+2" }).length).toBe(5);
-    expect(screen.getAllByRole("button", { name: "+3" }).length).toBe(5);
-    expect(screen.getAllByRole("button", { name: "+6" }).length).toBe(5);
-  });
-
-  it("clicking a quick-pick chip calls setAttackerBoost with that value", () => {
-    const setAttackerBoost = jest.fn();
-    renderAttacker({
-      attackerBoosts: makeBoosts(),
-      setAttackerBoost,
-    });
-    // First "+2" chip corresponds to the ATK row (first stat)
-    fireEvent.click(screen.getAllByRole("button", { name: "+2" })[0]);
-    expect(setAttackerBoost).toHaveBeenCalledWith("atk", 2);
-  });
-
-  it("clicking the +6 quick-pick chip for DEF calls setAttackerBoost('def', 6)", () => {
-    const setAttackerBoost = jest.fn();
-    renderAttacker({
-      attackerBoosts: makeBoosts(),
-      setAttackerBoost,
-    });
-    // Second "+6" chip corresponds to the DEF row (second stat)
-    fireEvent.click(screen.getAllByRole("button", { name: "+6" })[1]);
-    expect(setAttackerBoost).toHaveBeenCalledWith("def", 6);
-  });
-
-  it("quick-pick chip shows aria-pressed=true when value matches current boost", () => {
-    renderAttacker({ attackerBoosts: makeBoosts({ atk: 2 }) });
-    // The "+2" chip in the ATK row should be aria-pressed=true
-    const plus2Chips = screen.getAllByRole("button", { name: "+2" });
-    expect(plus2Chips[0]).toHaveAttribute("aria-pressed", "true");
-  });
-
-  it("quick-pick chips other than the active value show aria-pressed=false", () => {
-    renderAttacker({ attackerBoosts: makeBoosts({ atk: 2 }) });
-    // "+1" chips should all be not-pressed
-    const plus1Chips = screen.getAllByRole("button", { name: "+1" });
-    for (const chip of plus1Chips) {
-      expect(chip).toHaveAttribute("aria-pressed", "false");
-    }
-  });
-});
-
-describe("CalcAttackerBlock — stat boosts ordering", () => {
-  it("stat boosts section appears before inherits note in the DOM", () => {
-    renderAttacker();
-    const boostsLabel = screen.getByText(/stat boosts/i);
-    const inheritsNote = screen.getByText(/inherits spread/i);
-    expect(
-      boostsLabel.compareDocumentPosition(inheritsNote) & Node.DOCUMENT_POSITION_FOLLOWING
-    ).toBeTruthy();
-  });
 });
 
 describe("CalcAttackerBlock — types display", () => {

--- a/apps/web/src/components/team-builder/v2/__tests__/calc-attacker-block.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/calc-attacker-block.test.tsx
@@ -313,3 +313,33 @@ describe("CalcAttackerBlock — types display", () => {
     expect(screen.queryByTestId(/^type-pill-(?!Fire)/)).not.toBeInTheDocument();
   });
 });
+
+describe("CalcAttackerBlock — mega toggle interaction", () => {
+  beforeEach(() => {
+    // Make getMegaAbilityForSpecies return a value so MegaToggle renders
+    const pokemon = jest.requireMock("@trainers/pokemon") as { getMegaAbilityForSpecies: jest.Mock };
+    pokemon.getMegaAbilityForSpecies.mockReturnValue("Tough Claws");
+  });
+
+  afterEach(() => {
+    const pokemon = jest.requireMock("@trainers/pokemon") as { getMegaAbilityForSpecies: jest.Mock };
+    pokemon.getMegaAbilityForSpecies.mockReturnValue(null);
+  });
+
+  it("calls setAttackerMegaActive when mega-toggle is clicked", () => {
+    const setAttackerMegaActive = jest.fn();
+    renderAttacker({ attackerMegaActive: false, setAttackerMegaActive });
+    fireEvent.click(screen.getByTestId("mega-toggle"));
+    expect(setAttackerMegaActive).toHaveBeenCalled();
+  });
+
+  it("reflects active state via aria-pressed", () => {
+    renderAttacker({ attackerMegaActive: true });
+    expect(screen.getByTestId("mega-toggle")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("reflects inactive state via aria-pressed", () => {
+    renderAttacker({ attackerMegaActive: false });
+    expect(screen.getByTestId("mega-toggle")).toHaveAttribute("aria-pressed", "false");
+  });
+});

--- a/apps/web/src/components/team-builder/v2/__tests__/calc-bottom-panel.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/calc-bottom-panel.test.tsx
@@ -130,6 +130,8 @@ jest.mock("@trainers/pokemon", () => ({
   calculateHP: (...args: unknown[]) => mockCalculateHP(...args),
   calculateChampionsHP: (...args: unknown[]) =>
     mockCalculateChampionsHP(...args),
+  getMegaAbilityForSpecies: jest.fn().mockReturnValue(null),
+  getMegaSpeciesForBaseAndItem: jest.fn().mockReturnValue(null),
 }));
 
 // CalcAttackerBlock stub
@@ -178,20 +180,15 @@ jest.mock("../calc/calc-field-block", () => ({
   ),
 }));
 
-// DefenderMonHeader stub — renders species, attacker name, and HP
+// DefenderMonHeader stub
 jest.mock("../calc/calc-defender-header", () => ({
   DefenderMonHeader: ({
     defenderSpecies,
-    attackerName,
-    attackerHP,
   }: {
     defenderSpecies: string;
-    attackerName: string;
-    attackerHP: number | null;
   }) => (
     <div data-testid="defender-mon-header">
       <span data-testid="defender-species">{defenderSpecies}</span>
-      <span data-testid="vs-info">{`vs ${attackerName} · ${attackerHP !== null ? `${attackerHP} HP` : "—"}`}</span>
     </div>
   ),
 }));
@@ -269,7 +266,6 @@ interface RenderProps {
   format?: GameFormat | undefined;
   onClose?: jest.Mock;
   attackerIdx?: number;
-  onPickAttacker?: jest.Mock;
   faintedYours?: number;
   setFaintedYours?: jest.Mock;
   faintedTheirs?: number;
@@ -278,7 +274,6 @@ interface RenderProps {
 
 function renderPanel(props: RenderProps = {}) {
   const onClose = props.onClose ?? jest.fn();
-  const onPickAttacker = props.onPickAttacker ?? jest.fn();
   const setFaintedYours = props.setFaintedYours ?? jest.fn();
   const setFaintedTheirs = props.setFaintedTheirs ?? jest.fn();
   const teamSlots = props.teamSlots ?? [makePokemon(), null, null, null, null, null];
@@ -289,7 +284,6 @@ function renderPanel(props: RenderProps = {}) {
       format={props.format ?? VGC_FORMAT}
       onClose={onClose}
       attackerIdx={props.attackerIdx ?? 0}
-      onPickAttacker={onPickAttacker}
       faintedYours={props.faintedYours ?? 0}
       setFaintedYours={setFaintedYours}
       faintedTheirs={props.faintedTheirs ?? 0}
@@ -315,14 +309,9 @@ beforeEach(() => {
 // =============================================================================
 
 describe("CalcBottomPanel — header", () => {
-  it("renders the 'Damage calc' eyebrow label", () => {
+  it("renders the 'Damage Calc' eyebrow label", () => {
     renderPanel();
-    expect(screen.getByText("Damage calc")).toBeInTheDocument();
-  });
-
-  it("renders 'live · 2-way' label", () => {
-    renderPanel();
-    expect(screen.getByText("live · 2-way")).toBeInTheDocument();
+    expect(screen.getByText("Damage Calc")).toBeInTheDocument();
   });
 
   it("renders the Close button", () => {
@@ -346,79 +335,7 @@ describe("CalcBottomPanel — header", () => {
   });
 });
 
-describe("CalcBottomPanel — attacker name in defender header", () => {
-  it("shows attacker species name in 'vs X' readout", () => {
-    renderPanel({
-      teamSlots: [makePokemon({ species: "Gardevoir", nickname: null }), null, null, null, null, null],
-      attackerIdx: 0,
-    });
-    expect(screen.getByText(/vs Gardevoir/)).toBeInTheDocument();
-  });
-
-  it("prefers nickname over species in 'vs X' readout", () => {
-    renderPanel({
-      teamSlots: [makePokemon({ species: "Gardevoir", nickname: "Lady G" }), null, null, null, null, null],
-      attackerIdx: 0,
-    });
-    expect(screen.getByText(/vs Lady G/)).toBeInTheDocument();
-  });
-
-  it("shows '—' when slot is null", () => {
-    renderPanel({
-      teamSlots: [null, null, null, null, null, null],
-      attackerIdx: 0,
-    });
-    expect(screen.getByText(/vs —/)).toBeInTheDocument();
-  });
-});
-
-describe("CalcBottomPanel — attacker HP readout", () => {
-  it("shows HP in defender header when species has base stats", () => {
-    mockGetBaseStats.mockReturnValue({ hp: 68 });
-    mockCalculateHP.mockReturnValue(145);
-    renderPanel({
-      teamSlots: [makePokemon({ species: "Gardevoir" }), null, null, null, null, null],
-    });
-    expect(screen.getByText(/145 HP/)).toBeInTheDocument();
-  });
-
-  it("shows '—' in HP position when slot species is absent", () => {
-    renderPanel({
-      teamSlots: [null, null, null, null, null, null],
-    });
-    // "vs — · —" for name and HP
-    const metaLine = screen.getByText(/vs —/);
-    expect(metaLine).toBeInTheDocument();
-  });
-
-  it("uses calculateChampionsHP for champions format", () => {
-    mockIsChampionsFormat.mockReturnValue(true);
-    mockGetBaseStats.mockReturnValue({ hp: 68 });
-    mockCalculateChampionsHP.mockReturnValue(135);
-    renderPanel({
-      teamSlots: [makePokemon({ species: "Gardevoir" }), null, null, null, null, null],
-    });
-    expect(mockCalculateChampionsHP).toHaveBeenCalled();
-    expect(screen.getByText(/135 HP/)).toBeInTheDocument();
-  });
-
-  it("shows '—' HP when getBaseStats returns null", () => {
-    mockGetBaseStats.mockReturnValue(null);
-    renderPanel({
-      teamSlots: [makePokemon({ species: "Gardevoir" }), null, null, null, null, null],
-    });
-    // No HP number in the readout
-    expect(screen.queryByText(/\d+ HP/)).not.toBeInTheDocument();
-  });
-});
-
 describe("CalcBottomPanel — child components", () => {
-  it("renders CalcAttackerBlock", () => {
-    renderPanel({ attackerIdx: 2 });
-    expect(screen.getByTestId("calc-attacker-block")).toBeInTheDocument();
-    expect(screen.getByTestId("calc-attacker-block")).toHaveAttribute("data-idx", "2");
-  });
-
   it("renders CalcFieldBlock with gameType from context", () => {
     renderPanel();
     const fieldBlock = screen.getByTestId("calc-field-block");
@@ -438,21 +355,9 @@ describe("CalcBottomPanel — child components", () => {
     expect(screen.getByTestId("calc-defender-moves")).toBeInTheDocument();
   });
 
-  it("renders Defender column header", () => {
-    renderPanel();
-    expect(screen.getByText("Defender")).toBeInTheDocument();
-  });
-
-  it("renders DefenderMonHeader with species and attacker info", () => {
+  it("renders DefenderMonHeader with species from context", () => {
     renderPanel();
     expect(screen.getByTestId("defender-mon-header")).toBeInTheDocument();
     expect(screen.getByTestId("defender-species")).toHaveTextContent("Incineroar");
-  });
-
-  it("renders DefenderMonHeader full-width in the defender column", () => {
-    renderPanel();
-    // The header is rendered — its presence confirms the full-width placement
-    const header = screen.getByTestId("defender-mon-header");
-    expect(header).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/team-builder/v2/__tests__/calc-defender-header.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/calc-defender-header.test.tsx
@@ -212,6 +212,7 @@ jest.mock("@trainers/pokemon", () => ({
   formatHasTera: (...args: unknown[]) => mockFormatHasTera(...args),
   // Mega-aware helpers — defaults assume non-mega species (no override).
   getMegaAbilityForSpecies: jest.fn().mockReturnValue(null),
+  getMegaSpeciesForBaseAndItem: jest.fn().mockReturnValue(null),
   getCanonicalBaseSpecies: jest.fn((s: string) => s),
   // Used by NatureChevrons, which calc-defender-header renders for the Nat chip.
   STAT_LABELS: {
@@ -312,7 +313,7 @@ beforeEach(() => {
 describe("DefenderMonHeader — species pill", () => {
   it("shows 'Choose species…' placeholder when no species is set", () => {
     render(<DefenderMonHeader {...makeProps()} />);
-    expect(screen.getByText("Choose species…")).toBeInTheDocument();
+    expect(screen.getByText("Choose…")).toBeInTheDocument();
   });
 
   it("shows the species name when defenderSpecies is set", () => {
@@ -363,7 +364,7 @@ describe("DefenderMonHeader — sprite", () => {
 describe("DefenderMonHeader — Item row", () => {
   it("renders the Item label", () => {
     render(<DefenderMonHeader {...makeProps()} />);
-    expect(screen.getByText("Item")).toBeInTheDocument();
+    expect(screen.getByText("ITEM")).toBeInTheDocument();
   });
 
   it("shows the em-dash placeholder when defenderItem is empty", () => {
@@ -394,7 +395,7 @@ describe("DefenderMonHeader — Item row", () => {
 describe("DefenderMonHeader — Ability row", () => {
   it("renders the Abil label", () => {
     render(<DefenderMonHeader {...makeProps()} />);
-    expect(screen.getByText("Abil")).toBeInTheDocument();
+    expect(screen.getByText("ABIL")).toBeInTheDocument();
   });
 
   it("shows the em-dash placeholder when defenderAbility is empty", () => {
@@ -494,7 +495,7 @@ describe("DefenderMonHeader — no-abilities warning", () => {
 describe("DefenderMonHeader — Nature row", () => {
   it("renders the Nat label", () => {
     render(<DefenderMonHeader {...makeProps()} />);
-    expect(screen.getByText("Nat")).toBeInTheDocument();
+    expect(screen.getByText("NAT")).toBeInTheDocument();
   });
 
   it("shows the em-dash placeholder when defenderNature is empty", () => {

--- a/apps/web/src/components/team-builder/v2/__tests__/calc-defender-moves.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/calc-defender-moves.test.tsx
@@ -1,28 +1,16 @@
 "use client";
 
 /**
- * Behavioral tests for CalcDefenderMoves and its inner DefenderMoveTile.
+ * Behavioral tests for CalcDefenderMoves.
  *
- * Covers:
- *   - "Their moves → your atk" header renders
- *   - 4 tiles always render (empty slots show "+ Add move")
- *   - Move name renders for filled slots
- *   - Type icon rendered for a move with type data
- *   - BP renders on row 1 for damaging moves ("BP 80")
- *   - BP omitted for status moves (basePower 0)
- *   - Accuracy renders on row 1 only when < 100% ("· 70% acc")
- *   - No accuracy shown when accuracy is true (always-hit) or 100
- *   - Damage % renders on row 2 with KO-tier color class
- *   - KO tier label renders on row 2 (OHKO / 2HKO / 3HKO / 4HKO+)
- *   - HP range renders on row 2 when attackerHP is provided
- *   - Debuff notes on row 2: "· −2 SpA after" (Draco Meteor)
- *   - Pivot note on row 2: "· pivots out" (U-turn)
- *   - Row 2 not rendered when output is null
- *   - computeReverseOutput called with move name for each filled slot
- *   - onPick called with slotIdx and move name after picking
+ * The component renders 4 move tile cards with:
+ * - Move name (or "+ Add move" for empty slots)
+ * - Type icon for moves with type data
+ * - BP label for damaging moves
+ * - A dialog-based move picker triggered on click
  */
 
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React from "react";
 
 import type * as TrainersPokemon from "@trainers/pokemon";
@@ -31,215 +19,46 @@ import type * as TrainersPokemon from "@trainers/pokemon";
 // Mocks
 // =============================================================================
 
-
-// Popover — render children inline
-jest.mock("@/components/ui/popover", () => ({
-  Popover: ({
-    children,
-    open,
-    onOpenChange,
-  }: {
-    children: React.ReactNode;
-    open?: boolean;
-    onOpenChange?: (open: boolean) => void;
-  }) => (
-    <div
-      data-testid="popover"
-      data-open={String(!!open)}
-      onClick={() => onOpenChange?.(!open)}
-    >
-      {children}
-    </div>
-  ),
-  PopoverTrigger: ({
-    children,
-    render: renderProp,
-  }: {
-    children?: React.ReactNode;
-    render?: React.ReactElement;
-  }) => (
-    <div data-testid="popover-trigger">
-      {renderProp}
-      {children}
-    </div>
-  ),
-  PopoverContent: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="popover-content">{children}</div>
-  ),
-}));
-
-// Dialog — render children inline so MovePicker is always queryable
-jest.mock("@/components/ui/dialog", () => ({
-  Dialog: ({
-    children,
-    open,
-    onOpenChange,
-  }: {
-    children: React.ReactNode;
-    open?: boolean;
-    onOpenChange?: (open: boolean) => void;
-  }) => (
-    <div
-      data-testid="dialog"
-      data-open={String(!!open)}
-      onClick={() => onOpenChange?.(!open)}
-    >
-      {children}
-    </div>
-  ),
-  DialogTrigger: ({
-    children,
-    render: renderProp,
-  }: {
-    children?: React.ReactNode;
-    render?: React.ReactElement;
-  }) => (
-    <div data-testid="dialog-trigger">
-      {renderProp}
-      {children}
-    </div>
-  ),
-  DialogContent: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="dialog-content">{children}</div>
-  ),
-  DialogTitle: ({ children }: { children: React.ReactNode }) => (
-    <span>{children}</span>
-  ),
-}));
-
-// MovePicker stub — interactive so we can simulate picking
-jest.mock("../pickers/move-picker", () => ({
-  MovePicker: ({
-    value,
-    onPick,
-    onClose,
-  }: {
-    value: string | null;
-    onPick: (name: string) => void;
-    onClose: () => void;
-  }) => (
-    <div data-testid="move-picker" data-value={value ?? ""}>
-      <button onClick={() => onPick("Flamethrower")}>pick-flamethrower</button>
-      <button onClick={onClose}>close-picker</button>
-    </div>
-  ),
-}));
-
-// @trainers/pokemon — mock getMoveData
 const mockGetMoveData = jest.fn();
 
 jest.mock("@trainers/pokemon", () => {
-  const actual =
-    jest.requireActual<typeof TrainersPokemon>("@trainers/pokemon");
+  const actual = jest.requireActual<typeof TrainersPokemon>("@trainers/pokemon");
   return {
     ...actual,
     getMoveData: (...args: unknown[]) => mockGetMoveData(...args),
   };
 });
 
-// @trainers/pokemon/sprites
 jest.mock("@trainers/pokemon/sprites", () => ({
-  getShowdownTypeIconUrl: jest.fn((type: string) => `/types/${type}.png`),
+  getSpriteUrl: jest.fn(() => ""),
 }));
 
-// getVerdict from use-calc-state
-const mockGetVerdict = jest.fn();
-jest.mock("../../use-calc-state", () => ({
-  ...jest.requireActual("../../use-calc-state"),
-  getVerdict: (...args: unknown[]) => mockGetVerdict(...args),
+// Dialog — render children inline (no actual dialog behavior)
+jest.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  DialogTrigger: ({ children, render: renderProp }: { children?: React.ReactNode; render?: React.ReactElement }) =>
+    renderProp ? <>{renderProp}{children}</> : <>{children}</>,
+}));
+
+// TypeSymbolIcon — stub
+jest.mock("../../type-symbol-icon", () => ({
+  TypeSymbolIcon: ({ type }: { type: string }) => (
+    <span data-testid={`type-icon-${type}`} />
+  ),
+}));
+
+// MovePicker — stub
+jest.mock("../pickers/move-picker", () => ({
+  MovePicker: () => <div data-testid="move-picker" />,
 }));
 
 // =============================================================================
 // Import after mocks
 // =============================================================================
 
-import {
-  CalcDefenderMoves,
-  type CalcDefenderMovesProps,
-} from "../calc/calc-defender-moves";
-import { type CalcOutput } from "../../use-calc-state";
-
-// =============================================================================
-// Fixtures
-// =============================================================================
-
-const VGC_FORMAT: TrainersPokemon.GameFormat = {
-  id: "gen9vgc2026regi",
-  game: "Scarlet & Violet",
-  gameShort: "SV",
-  generation: 9,
-  category: "VGC",
-  year: 2026,
-  regulation: "I",
-  label: "SV: Reg I",
-  showdownName: "[Gen 9] VGC 2026 Reg I",
-  doubles: true,
-  active: true,
-};
-
-function makeOutput(overrides: Partial<CalcOutput> = {}): CalcOutput {
-  return {
-    minPercent: 45.2,
-    maxPercent: 53.1,
-    desc: "Test damage",
-    rolls: [
-      80, 82, 84, 86, 88, 90, 92, 94, 96, 98, 100, 102, 104, 106, 108, 110,
-    ],
-    defenderMaxHP: 300,
-    ...overrides,
-  };
-}
-
-function makeMoveData(
-  overrides: Partial<{
-    type: string;
-    category: string;
-    basePower: number;
-    accuracy: number | boolean;
-    shortDesc: string;
-  }> = {}
-) {
-  return {
-    type: "Fire",
-    category: "Special",
-    basePower: 90,
-    accuracy: 100,
-    shortDesc: "No additional effect.",
-    ...overrides,
-  };
-}
-
-type EffectiveMoves = [string, string, string, string];
-
-interface RenderProps {
-  effectiveMoves?: EffectiveMoves;
-  computeReverseOutput?: jest.Mock;
-  attackerHP?: number | null;
-  defenderSpecies?: string;
-  format?: TrainersPokemon.GameFormat | undefined;
-  onPick?: jest.Mock;
-}
-
-function renderMoves(props: RenderProps = {}) {
-  const computeReverseOutput =
-    props.computeReverseOutput ?? jest.fn().mockReturnValue(null);
-  const onPick = props.onPick ?? jest.fn();
-
-  const result = render(
-    <CalcDefenderMoves
-      effectiveMoves={props.effectiveMoves ?? ["", "", "", ""]}
-      computeReverseOutput={
-        computeReverseOutput as CalcDefenderMovesProps["computeReverseOutput"]
-      }
-      attackerHP={props.attackerHP ?? null}
-      defenderSpecies={props.defenderSpecies ?? "Incineroar"}
-      format={props.format ?? VGC_FORMAT}
-      onPick={onPick}
-    />
-  );
-
-  return { ...result, computeReverseOutput, onPick };
-}
+import { CalcDefenderMoves } from "../calc/calc-defender-moves";
 
 // =============================================================================
 // Setup
@@ -247,468 +66,116 @@ function renderMoves(props: RenderProps = {}) {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockGetMoveData.mockReturnValue(makeMoveData());
-  mockGetVerdict.mockReturnValue(null);
+  mockGetMoveData.mockReturnValue(null);
 });
 
 // =============================================================================
 // Tests
 // =============================================================================
 
-describe("CalcDefenderMoves — header", () => {
-  it("renders the 'Their moves → your atk' header", () => {
-    renderMoves();
-    expect(screen.getByText("Their moves → your atk")).toBeInTheDocument();
-  });
-});
-
 describe("CalcDefenderMoves — tile rendering", () => {
-  it("renders 4 picker dialog triggers (one per slot)", () => {
-    renderMoves();
-    expect(screen.getAllByTestId("dialog-trigger").length).toBe(4);
+  it("renders 4 move tile buttons", () => {
+    render(
+      <CalcDefenderMoves
+        effectiveMoves={["", "", "", ""]}
+        defenderSpecies=""
+        format={undefined}
+        onPick={jest.fn()}
+      />
+    );
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(4);
   });
 
   it("shows '+ Add move' for empty slots", () => {
-    renderMoves({ effectiveMoves: ["", "", "", ""] });
-    expect(screen.getAllByText("+ Add move").length).toBe(4);
-  });
-
-  it("renders move names for filled slots", () => {
-    renderMoves({ effectiveMoves: ["Flare Blitz", "Knock Off", "", ""] });
-    expect(screen.getByText("Flare Blitz")).toBeInTheDocument();
-    expect(screen.getByText("Knock Off")).toBeInTheDocument();
-  });
-
-  it.each([
-    [0, "Flamethrower"],
-    [1, "Moonblast"],
-    [2, "Earthquake"],
-    [3, "Protect"],
-  ] as const)("slot %i renders move name '%s'", (slotIdx, moveName) => {
-    const moves: EffectiveMoves = ["", "", "", ""];
-    moves[slotIdx] = moveName;
-    renderMoves({ effectiveMoves: moves });
-    expect(screen.getByText(moveName)).toBeInTheDocument();
-  });
-
-  it("renders 4 move pickers in popover content", () => {
-    renderMoves({ effectiveMoves: ["", "", "", ""] });
-    expect(screen.getAllByTestId("move-picker").length).toBe(4);
-  });
-});
-
-describe("CalcDefenderMoves — type icon", () => {
-  it("renders a wordless type icon for a move with type data", () => {
-    mockGetMoveData.mockReturnValue(makeMoveData({ type: "Fire" }));
-    renderMoves({ effectiveMoves: ["Flare Blitz", "", "", ""] });
-    const icon = screen.getByRole("img", { name: "Fire" });
-    expect(icon).toBeInTheDocument();
-    expect(icon).toHaveAttribute("data-type", "Fire");
-  });
-
-  it("does not render a type icon for empty slots (no move name)", () => {
-    renderMoves({ effectiveMoves: ["", "", "", ""] });
-    expect(screen.queryByRole("img", { name: "Fire" })).not.toBeInTheDocument();
-  });
-});
-
-describe("CalcDefenderMoves — BP (row 1)", () => {
-  it("renders BP on row 1 for damaging moves", () => {
-    mockGetMoveData.mockReturnValue(makeMoveData({ basePower: 80 }));
-    const computeReverseOutput = jest.fn().mockReturnValue(null);
     render(
       <CalcDefenderMoves
-        effectiveMoves={["Any Move", "", "", ""]}
-        computeReverseOutput={computeReverseOutput}
-        attackerHP={200}
-        defenderSpecies="Incineroar"
+        effectiveMoves={["", "", "", ""]}
+        defenderSpecies=""
         format={undefined}
         onPick={jest.fn()}
       />
     );
-    expect(screen.getByText("BP 80")).toBeInTheDocument();
+    expect(screen.getAllByText("+ Add move")).toHaveLength(4);
   });
 
-  it("omits BP for status moves (basePower 0)", () => {
-    mockGetMoveData.mockReturnValue(makeMoveData({ basePower: 0 }));
-    const computeReverseOutput = jest.fn().mockReturnValue(null);
+  it("renders move name for filled slots", () => {
     render(
       <CalcDefenderMoves
-        effectiveMoves={["Any Move", "", "", ""]}
-        computeReverseOutput={computeReverseOutput}
-        attackerHP={200}
-        defenderSpecies="Incineroar"
+        effectiveMoves={["Earthquake", "Flamethrower", "", ""]}
+        defenderSpecies="Garchomp"
         format={undefined}
         onPick={jest.fn()}
       />
     );
-    expect(screen.queryByText(/^BP/)).not.toBeInTheDocument();
+    expect(screen.getByText("Earthquake")).toBeInTheDocument();
+    expect(screen.getByText("Flamethrower")).toBeInTheDocument();
   });
-});
 
-describe("CalcDefenderMoves — accuracy (row 1)", () => {
-  it("renders accuracy on row 1 when accuracy is numeric and < 100", () => {
-    mockGetMoveData.mockReturnValue(makeMoveData({ accuracy: 70 }));
-    const computeReverseOutput = jest.fn().mockReturnValue(null);
+  it("renders type icon when move has type data", () => {
+    mockGetMoveData.mockImplementation((name: string) => {
+      if (name === "Earthquake") return { type: "Ground", basePower: 100, accuracy: 100 };
+      return null;
+    });
     render(
       <CalcDefenderMoves
-        effectiveMoves={["Any Move", "", "", ""]}
-        computeReverseOutput={computeReverseOutput}
-        attackerHP={200}
-        defenderSpecies="Incineroar"
+        effectiveMoves={["Earthquake", "", "", ""]}
+        defenderSpecies="Garchomp"
         format={undefined}
         onPick={jest.fn()}
       />
     );
-    expect(screen.getByText(/· 70% acc/)).toBeInTheDocument();
+    expect(screen.getByTestId("type-icon-Ground")).toBeInTheDocument();
   });
 
-  it("omits accuracy on row 1 when accuracy is true (always-hit)", () => {
-    mockGetMoveData.mockReturnValue(makeMoveData({ accuracy: true }));
-    const computeReverseOutput = jest.fn().mockReturnValue(null);
+  it("renders BP label for damaging moves", () => {
+    mockGetMoveData.mockReturnValue({ type: "Ground", basePower: 100, accuracy: 100 });
     render(
       <CalcDefenderMoves
-        effectiveMoves={["Any Move", "", "", ""]}
-        computeReverseOutput={computeReverseOutput}
-        attackerHP={200}
-        defenderSpecies="Incineroar"
+        effectiveMoves={["Earthquake", "", "", ""]}
+        defenderSpecies="Garchomp"
         format={undefined}
         onPick={jest.fn()}
       />
     );
-    expect(screen.queryByText(/% acc/)).not.toBeInTheDocument();
+    expect(screen.getByText("BP 100")).toBeInTheDocument();
   });
-});
 
-describe("CalcDefenderMoves — row 2 (damage / KO tier / HP range)", () => {
-  it("renders damage % on row 2 with value from output", () => {
-    mockGetVerdict.mockReturnValue("3HKO");
-    const computeReverseOutput = jest.fn().mockReturnValue({
-      minPercent: 34.0,
-      maxPercent: 40.2,
-      rolls: [66, 78],
-      defenderMaxHP: 194,
-      desc: "",
-    });
+  it("does NOT render BP for status moves (basePower 0)", () => {
+    mockGetMoveData.mockReturnValue({ type: "Normal", basePower: 0, accuracy: true });
     render(
       <CalcDefenderMoves
-        effectiveMoves={["Any Move", "", "", ""]}
-        computeReverseOutput={computeReverseOutput}
-        attackerHP={194}
-        defenderSpecies="Gholdengo"
+        effectiveMoves={["Thunder Wave", "", "", ""]}
+        defenderSpecies="Pikachu"
         format={undefined}
         onPick={jest.fn()}
       />
     );
-    expect(screen.getByText("34.0–40.2%")).toBeInTheDocument();
+    expect(screen.queryByText(/BP/)).not.toBeInTheDocument();
   });
 
-  it.each([
-    ["OHKO", 101, 120],
-    ["2HKO", 55, 65],
-    ["3HKO", 38, 42],
-  ] as const)(
-    "renders KO tier label '%s' on row 2",
-    (verdict, minPercent, maxPercent) => {
-      mockGetVerdict.mockReturnValue(verdict);
-      const computeReverseOutput = jest
-        .fn()
-        .mockReturnValue(makeOutput({ minPercent, maxPercent }));
-      renderMoves({
-        effectiveMoves: ["Flare Blitz", "", "", ""],
-        computeReverseOutput,
-      });
-      expect(screen.getByText(verdict)).toBeInTheDocument();
-    }
-  );
-
-  it("renders '4HKO+' when verdict is null but maxPercent > 0", () => {
-    mockGetVerdict.mockReturnValue(null);
-    const output = makeOutput({ minPercent: 24, maxPercent: 28 });
-    renderMoves({
-      effectiveMoves: ["Tackle", "", "", ""],
-      computeReverseOutput: jest.fn().mockReturnValue(output),
-    });
-    expect(screen.getByText("4HKO+")).toBeInTheDocument();
-  });
-
-  it("renders HP range on row 2 when attackerHP provided", () => {
-    mockGetVerdict.mockReturnValue("3HKO");
-    const computeReverseOutput = jest.fn().mockReturnValue({
-      minPercent: 34.0,
-      maxPercent: 40.2,
-      rolls: [66, 78],
-      defenderMaxHP: 194,
-      desc: "",
-    });
+  it("provides correct aria-label for filled move slots", () => {
+    mockGetMoveData.mockReturnValue({ type: "Ground", basePower: 100, accuracy: 100 });
     render(
       <CalcDefenderMoves
-        effectiveMoves={["Any Move", "", "", ""]}
-        computeReverseOutput={computeReverseOutput}
-        attackerHP={194}
-        defenderSpecies="Gholdengo"
+        effectiveMoves={["Earthquake", "", "", ""]}
+        defenderSpecies="Garchomp"
         format={undefined}
         onPick={jest.fn()}
       />
     );
-    expect(screen.getByText(/66–78 \/ 194 HP/)).toBeInTheDocument();
+    expect(screen.getByLabelText("Change move: Earthquake")).toBeInTheDocument();
   });
 
-  it("does not render row 2 when output is null", () => {
-    const computeReverseOutput = jest.fn().mockReturnValue(null);
+  it("provides 'Add move' aria-label for empty slots", () => {
     render(
       <CalcDefenderMoves
-        effectiveMoves={["Any Move", "", "", ""]}
-        computeReverseOutput={computeReverseOutput}
-        attackerHP={194}
-        defenderSpecies="Gholdengo"
+        effectiveMoves={["", "", "", ""]}
+        defenderSpecies=""
         format={undefined}
         onPick={jest.fn()}
       />
     );
-    // Row 2 contains the damage range (X.X–Y.Y%) and KO tier — neither should appear
-    expect(screen.queryByText(/\d+\.\d+–\d+\.\d+%/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/HKO/)).not.toBeInTheDocument();
-  });
-
-  it("does NOT render row 2 for empty slot", () => {
-    const output = makeOutput();
-    renderMoves({
-      effectiveMoves: ["", "", "", ""],
-      computeReverseOutput: jest.fn().mockReturnValue(output),
-    });
-    expect(screen.queryByText(/HKO/)).not.toBeInTheDocument();
-  });
-
-  it("renders raw damage roll range when rolls are present", () => {
-    mockGetVerdict.mockReturnValue("2HKO");
-    const output = makeOutput({
-      rolls: [
-        80, 85, 90, 95, 100, 105, 110, 115, 120, 125, 130, 135, 140, 145, 150,
-        155,
-      ],
-      minPercent: 45,
-      maxPercent: 55,
-    });
-    renderMoves({
-      effectiveMoves: ["Moonblast", "", "", ""],
-      computeReverseOutput: jest.fn().mockReturnValue(output),
-    });
-    expect(screen.getByText(/80.*155/)).toBeInTheDocument();
-  });
-
-  it("does NOT append HP when attackerHP is null", () => {
-    mockGetVerdict.mockReturnValue("2HKO");
-    const output = makeOutput({ rolls: [80, 155] });
-    renderMoves({
-      effectiveMoves: ["Moonblast", "", "", ""],
-      computeReverseOutput: jest.fn().mockReturnValue(output),
-      attackerHP: null,
-    });
-    expect(screen.queryByText(/\/ \d+ HP/)).not.toBeInTheDocument();
-  });
-});
-
-describe("CalcDefenderMoves — extra notes on row 2 (debuff / pivot)", () => {
-  it("renders pivot note on row 2 for U-turn", () => {
-    const computeReverseOutput = jest.fn().mockReturnValue({
-      minPercent: 8.2,
-      maxPercent: 9.7,
-      rolls: [16, 19],
-      defenderMaxHP: 194,
-      desc: "",
-    });
-    render(
-      <CalcDefenderMoves
-        effectiveMoves={["U-turn", "", "", ""]}
-        computeReverseOutput={computeReverseOutput}
-        attackerHP={194}
-        defenderSpecies="Gholdengo"
-        format={undefined}
-        onPick={jest.fn()}
-      />
-    );
-    expect(screen.getByText(/· pivots out/)).toBeInTheDocument();
-  });
-
-  it("renders SpA drop note on row 2 for Draco Meteor", () => {
-    const computeReverseOutput = jest.fn().mockReturnValue({
-      minPercent: 55.0,
-      maxPercent: 65.0,
-      rolls: [107, 126],
-      defenderMaxHP: 194,
-      desc: "",
-    });
-    render(
-      <CalcDefenderMoves
-        effectiveMoves={["Draco Meteor", "", "", ""]}
-        computeReverseOutput={computeReverseOutput}
-        attackerHP={194}
-        defenderSpecies="Gholdengo"
-        format={undefined}
-        onPick={jest.fn()}
-      />
-    );
-    expect(screen.getByText(/· −2 SpA after/)).toBeInTheDocument();
-  });
-
-  it.each([
-    ["Leaf Storm", "−2 SpA after"],
-    ["Overheat", "−2 SpA after"],
-    ["Psycho Boost", "−2 SpA after"],
-    ["Glacial Lance", "−2 SpA after"],
-  ] as const)(
-    "%s shows '−2 SpA after' note on row 2",
-    (moveName, expectedNote) => {
-      mockGetVerdict.mockReturnValue("2HKO");
-      const output = makeOutput();
-      renderMoves({
-        effectiveMoves: [moveName, "", "", ""],
-        computeReverseOutput: jest.fn().mockReturnValue(output),
-      });
-      expect(screen.getByText(new RegExp(expectedNote.replace(/[−+]/g, "."))));
-    }
-  );
-
-  it.each([
-    ["Close Combat", "−1 Def/SpD after"],
-    ["Superpower", "−1 Def/SpD after"],
-  ] as const)(
-    "%s shows '−1 Def/SpD after' note on row 2",
-    (moveName, expectedNote) => {
-      mockGetVerdict.mockReturnValue("2HKO");
-      const output = makeOutput();
-      renderMoves({
-        effectiveMoves: [moveName, "", "", ""],
-        computeReverseOutput: jest.fn().mockReturnValue(output),
-      });
-      expect(screen.getByText(new RegExp(expectedNote.replace(/[−+]/g, "."))));
-    }
-  );
-
-  it.each([
-    ["Volt Switch", "pivots out"],
-    ["Flip Turn", "pivots out"],
-    ["Parting Shot", "pivots out"],
-    ["Teleport", "pivots out"],
-  ] as const)(
-    "%s shows 'pivots out' note on row 2",
-    (moveName, expectedNote) => {
-      mockGetVerdict.mockReturnValue("2HKO");
-      const output = makeOutput();
-      renderMoves({
-        effectiveMoves: [moveName, "", "", ""],
-        computeReverseOutput: jest.fn().mockReturnValue(output),
-      });
-      expect(screen.getByText(new RegExp(expectedNote)));
-    }
-  );
-
-  it("shows no extra note for a standard move", () => {
-    mockGetVerdict.mockReturnValue("2HKO");
-    const output = makeOutput();
-    renderMoves({
-      effectiveMoves: ["Flamethrower", "", "", ""],
-      computeReverseOutput: jest.fn().mockReturnValue(output),
-    });
-    expect(screen.queryByText(/SpA after/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/pivots out/)).not.toBeInTheDocument();
-  });
-});
-
-describe("CalcDefenderMoves — computeReverseOutput calls", () => {
-  it("calls computeReverseOutput with the move name for each filled slot", () => {
-    const computeReverseOutput = jest.fn().mockReturnValue(null);
-    renderMoves({
-      effectiveMoves: ["Moonblast", "Psychic", "", ""],
-      computeReverseOutput,
-    });
-    expect(computeReverseOutput).toHaveBeenCalledWith("Moonblast");
-    expect(computeReverseOutput).toHaveBeenCalledWith("Psychic");
-  });
-
-  it("does NOT call computeReverseOutput for empty slots", () => {
-    const computeReverseOutput = jest.fn().mockReturnValue(null);
-    renderMoves({
-      effectiveMoves: ["Moonblast", "", "", ""],
-      computeReverseOutput,
-    });
-    // Only called once (for Moonblast), not for the 3 empty slots
-    expect(computeReverseOutput).toHaveBeenCalledTimes(1);
-  });
-
-  it("calls computeReverseOutput for all 4 slots when all are filled", () => {
-    const computeReverseOutput = jest.fn().mockReturnValue(null);
-    renderMoves({
-      effectiveMoves: ["Moonblast", "Psychic", "Icy Wind", "Protect"],
-      computeReverseOutput,
-    });
-    expect(computeReverseOutput).toHaveBeenCalledTimes(4);
-  });
-});
-
-describe("CalcDefenderMoves — picking a move", () => {
-  it("calls onPick with slotIdx=0 and move name when picking in slot 0", () => {
-    const onPick = jest.fn();
-    renderMoves({ effectiveMoves: ["", "", "", ""], onPick });
-    // Click the first pick-flamethrower button (slot 0's picker)
-    const pickButtons = screen.getAllByText("pick-flamethrower");
-    fireEvent.click(pickButtons[0]);
-    expect(onPick).toHaveBeenCalledWith(0, "Flamethrower");
-  });
-
-  it("calls onPick with slotIdx=2 when picking in slot 2", () => {
-    const onPick = jest.fn();
-    renderMoves({ effectiveMoves: ["", "", "", ""], onPick });
-    const pickButtons = screen.getAllByText("pick-flamethrower");
-    fireEvent.click(pickButtons[2]);
-    expect(onPick).toHaveBeenCalledWith(2, "Flamethrower");
-  });
-
-  it.each([0, 1, 2, 3] as const)(
-    "onPick is called with slotIdx=%i",
-    (slotIdx) => {
-      const onPick = jest.fn();
-      renderMoves({ effectiveMoves: ["", "", "", ""], onPick });
-      const pickButtons = screen.getAllByText("pick-flamethrower");
-      fireEvent.click(pickButtons[slotIdx]);
-      expect(onPick).toHaveBeenCalledWith(slotIdx, "Flamethrower");
-    }
-  );
-});
-
-describe("CalcDefenderMoves — OHKO tile style", () => {
-  it("the tile trigger button gets OHKO class when koTierLabel is OHKO", () => {
-    mockGetVerdict.mockReturnValue("OHKO");
-    const output = makeOutput({ minPercent: 110, maxPercent: 130 });
-    const { container } = renderMoves({
-      effectiveMoves: ["Moonblast", "", "", ""],
-      computeReverseOutput: jest.fn().mockReturnValue(output),
-    });
-    // The tile button should have the dmv-tile--ohko class
-    const ohkoTile = container.querySelector(".dmv-tile--ohko");
-    expect(ohkoTile).toBeInTheDocument();
-  });
-
-  it("tile does NOT have OHKO class for non-OHKO tiers", () => {
-    mockGetVerdict.mockReturnValue("2HKO");
-    const output = makeOutput({ minPercent: 55, maxPercent: 65 });
-    const { container } = renderMoves({
-      effectiveMoves: ["Moonblast", "", "", ""],
-      computeReverseOutput: jest.fn().mockReturnValue(output),
-    });
-    expect(container.querySelector(".dmv-tile--ohko")).not.toBeInTheDocument();
-  });
-});
-
-describe("CalcDefenderMoves — KO pill not shown when maxPercent is 0", () => {
-  it("no KO pill when maxPercent is 0 (zero damage)", () => {
-    mockGetVerdict.mockReturnValue(null);
-    const output = makeOutput({ minPercent: 0, maxPercent: 0, rolls: [] });
-    renderMoves({
-      effectiveMoves: ["Protect", "", "", ""],
-      computeReverseOutput: jest.fn().mockReturnValue(output),
-    });
-    expect(screen.queryByText(/HKO/)).not.toBeInTheDocument();
+    expect(screen.getAllByLabelText("Add move")).toHaveLength(4);
   });
 });

--- a/apps/web/src/components/team-builder/v2/__tests__/calc-defender-stats.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/calc-defender-stats.test.tsx
@@ -181,6 +181,7 @@ function renderComponent(props: RenderProps = {}) {
       setDefenderEv={setDefenderEv}
       setDefenderBoost={setDefenderBoost}
       setDefenderHpPercent={setDefenderHpPercent}
+      setDefenderNature={jest.fn()}
     />
   );
 

--- a/apps/web/src/components/team-builder/v2/__tests__/calc-defender-stats.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/calc-defender-stats.test.tsx
@@ -154,12 +154,14 @@ interface RenderProps {
   setDefenderEv?: jest.Mock;
   setDefenderBoost?: jest.Mock;
   setDefenderHpPercent?: jest.Mock;
+  setDefenderNature?: jest.Mock;
 }
 
 function renderComponent(props: RenderProps = {}) {
   const setDefenderEv = props.setDefenderEv ?? jest.fn();
   const setDefenderBoost = props.setDefenderBoost ?? jest.fn();
   const setDefenderHpPercent = props.setDefenderHpPercent ?? jest.fn();
+  const setDefenderNature = props.setDefenderNature ?? jest.fn();
 
   // Resolve format: caller may explicitly pass UNDEFINED_FORMAT to mean undefined.
   const resolvedFormat: GameFormat | undefined =
@@ -181,7 +183,7 @@ function renderComponent(props: RenderProps = {}) {
       setDefenderEv={setDefenderEv}
       setDefenderBoost={setDefenderBoost}
       setDefenderHpPercent={setDefenderHpPercent}
-      setDefenderNature={jest.fn()}
+      setDefenderNature={setDefenderNature}
     />
   );
 
@@ -190,6 +192,7 @@ function renderComponent(props: RenderProps = {}) {
     setDefenderEv,
     setDefenderBoost,
     setDefenderHpPercent,
+    setDefenderNature,
   };
 }
 
@@ -668,5 +671,31 @@ describe("CalcDefenderStats — breakpoint ticks", () => {
   it("does not call findStatBreakpoints when nature is neutral", () => {
     renderComponent({ defenderNature: "Hardy" });
     expect(mockFindStatBreakpoints).not.toHaveBeenCalled();
+  });
+});
+
+describe("CalcDefenderStats — nature cycling interaction", () => {
+  it("calls setDefenderNature when a non-HP stat label is clicked", () => {
+    const setDefenderNature = jest.fn();
+    renderComponent({ defenderNature: "Hardy", setDefenderNature });
+    // Click the "Atk" button which has aria-label "Cycle nature for Atk"
+    const atkButton = screen.getByLabelText("Cycle nature for Atk");
+    fireEvent.click(atkButton);
+    expect(setDefenderNature).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not allow clicking the HP stat label (disabled)", () => {
+    const setDefenderNature = jest.fn();
+    renderComponent({ defenderNature: "Hardy", setDefenderNature });
+    // HP buttons should be disabled
+    const hpLabels = screen.getAllByText("HP");
+    const hpButton = hpLabels.find(
+      (el) => el.tagName.toLowerCase() === "button"
+    );
+    if (hpButton) {
+      expect(hpButton).toBeDisabled();
+    }
+    // setDefenderNature should not have been called
+    expect(setDefenderNature).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/team-builder/v2/__tests__/calc-defender-stats.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/calc-defender-stats.test.tsx
@@ -6,7 +6,7 @@
  * Covers:
  *   - Static render: stat labels, base stats
  *   - No-species fallback (default 50 base stats)
- *   - Nature chevrons (▲ boosted / ▽ reduced) on correct rows
+ *   - Nature chevrons (▴ boosted / ▾ reduced) on correct rows
  *   - EV text input display (nature suffix, raw number)
  *   - EV text input: commit on blur, clamp, snap to step
  *   - EV text input: Enter key commits, Escape reverts
@@ -271,25 +271,25 @@ describe("CalcDefenderStats — no-species fallback", () => {
 // =============================================================================
 
 describe("CalcDefenderStats — nature chevrons", () => {
-  it("renders ▲ on Atk row and ▽ on SpA row for Adamant nature", () => {
+  it("renders ▴ on Atk row and ▾ on SpA row for Adamant nature", () => {
     renderComponent({ defenderNature: "Adamant" }); // +Atk / −SpA
-    const upChevrons = screen.getAllByText("▲");
+    const upChevrons = screen.getAllByText("▴");
     expect(upChevrons).toHaveLength(1);
-    const downChevrons = screen.getAllByText("▽");
+    const downChevrons = screen.getAllByText("▾");
     expect(downChevrons).toHaveLength(1);
   });
 
   it("renders no nature chevrons for Hardy (neutral nature)", () => {
     renderComponent({ defenderNature: "Hardy" });
-    expect(screen.queryByText("▲")).not.toBeInTheDocument();
-    expect(screen.queryByText("▽")).not.toBeInTheDocument();
+    expect(screen.queryByText("▴")).not.toBeInTheDocument();
+    expect(screen.queryByText("▾")).not.toBeInTheDocument();
   });
 
   it("uses Hardy as default when defenderNature is empty string", () => {
     renderComponent({ defenderNature: "" });
     // No nature chevrons — defaults to Hardy which is neutral
-    expect(screen.queryByText("▲")).not.toBeInTheDocument();
-    expect(screen.queryByText("▽")).not.toBeInTheDocument();
+    expect(screen.queryByText("▴")).not.toBeInTheDocument();
+    expect(screen.queryByText("▾")).not.toBeInTheDocument();
   });
 
   it.each([
@@ -298,16 +298,16 @@ describe("CalcDefenderStats — nature chevrons", () => {
     ["Timid", "Spe", "Atk"], // +Spe / −Atk
     ["Bold", "Def", "Atk"], // +Def / −Atk
   ])(
-    "%s nature shows ▲ on %s row and ▽ on %s row",
+    "%s nature shows ▴ on %s row and ▾ on %s row",
     (nature, boostedLabel, reducedLabel) => {
       renderComponent({ defenderNature: nature });
-      expect(screen.getAllByText("▲")).toHaveLength(1);
-      expect(screen.getAllByText("▽")).toHaveLength(1);
+      expect(screen.getAllByText("▴")).toHaveLength(1);
+      expect(screen.getAllByText("▾")).toHaveLength(1);
       // Verify the chevron is adjacent to the correct label text
       const boostedEl = screen.getByText(boostedLabel);
-      expect(boostedEl.closest("span")?.textContent).toContain("▲");
+      expect(boostedEl.closest("button")?.textContent).toContain("▴");
       const reducedEl = screen.getByText(reducedLabel);
-      expect(reducedEl.closest("span")?.textContent).toContain("▽");
+      expect(reducedEl.closest("button")?.textContent).toContain("▾");
     }
   );
 });
@@ -592,15 +592,15 @@ describe("CalcDefenderStats — HP slider", () => {
     expect(hpSlider).toHaveAttribute("max", "100");
   });
 
-  it("renders the current/max HP readout (x/y HP)", () => {
+  it("renders the current/max HP readout (x/y)", () => {
     // HP% = 100, so currentHP = maxHP
     renderComponent({
       defenderHpPercent: 100,
       defenderEvs: makeDefaultEvs({ hp: 0 }),
       defenderIvs: makeDefaultIvs({ hp: 31 }),
     });
-    // The readout should contain "/ ... HP"
-    const readout = screen.getByText(/\/.*HP/);
+    // The readout should contain "num/num" format
+    const readout = screen.getByText(/\d+\/\d+/);
     expect(readout).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/team-builder/v2/__tests__/calc-field-block.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/calc-field-block.test.tsx
@@ -218,10 +218,10 @@ describe("CalcFieldBlock — basic render", () => {
     expect(screen.getByText("Sides")).toBeInTheDocument();
   });
 
-  it("renders Yours and Theirs side cards", () => {
+  it("renders Ours and Theirs side headings", () => {
     renderBlock();
-    expect(screen.getByText(/▸ Yours/i)).toBeInTheDocument();
-    expect(screen.getByText(/▸ Theirs/i)).toBeInTheDocument();
+    expect(screen.getByText(/Ours/i)).toBeInTheDocument();
+    expect(screen.getByText(/Theirs/i)).toBeInTheDocument();
   });
 });
 
@@ -300,7 +300,7 @@ describe("CalcFieldBlock — weather chips", () => {
       inferredWeather: "Sun",
       attackerAbility: "Drought",
     });
-    expect(screen.getByText("↳ inferred from Drought")).toBeInTheDocument();
+    expect(screen.getByText("↳ Drought")).toBeInTheDocument();
   });
 
   it("does NOT show inferred badge when explicit weather is set", () => {
@@ -344,7 +344,7 @@ describe("CalcFieldBlock — terrain chips", () => {
       inferredTerrain: "Electric",
       attackerAbility: "Hadron Engine",
     });
-    expect(screen.getByText("↳ inferred from Hadron Engine")).toBeInTheDocument();
+    expect(screen.getByText("↳ Hadron Engine")).toBeInTheDocument();
   });
 });
 
@@ -418,23 +418,13 @@ describe("CalcFieldBlock — fairy aura toggle", () => {
 // =============================================================================
 
 describe("CalcFieldBlock — Yours side toggles", () => {
-  it("calls setAttackerSide with tailwind patch when Tailwind clicked on Yours side", () => {
-    const setAttackerSide = jest.fn();
-    renderBlock({
-      attackerSide: makeSideState({ tailwind: false }),
-      setAttackerSide,
-    });
-    fireEvent.click(screen.getAllByRole("button", { name: /^tailwind$/i })[0]);
-    expect(setAttackerSide).toHaveBeenCalledWith({ tailwind: true });
-  });
-
   it("calls setAttackerSide with reflect patch when Reflect clicked on Yours side", () => {
     const setAttackerSide = jest.fn();
     renderBlock({
       attackerSide: makeSideState({ reflect: false }),
       setAttackerSide,
     });
-    fireEvent.click(screen.getAllByRole("button", { name: /^reflect$/i })[0]);
+    fireEvent.click(screen.getByRole("switch", { name: /reflect \(ours\)/i }));
     expect(setAttackerSide).toHaveBeenCalledWith({ reflect: true });
   });
 
@@ -444,7 +434,7 @@ describe("CalcFieldBlock — Yours side toggles", () => {
       attackerSide: makeSideState({ lightScreen: false }),
       setAttackerSide,
     });
-    fireEvent.click(screen.getAllByRole("button", { name: /^light screen$/i })[0]);
+    fireEvent.click(screen.getByRole("switch", { name: /light screen \(ours\)/i }));
     expect(setAttackerSide).toHaveBeenCalledWith({ lightScreen: true });
   });
 
@@ -454,21 +444,20 @@ describe("CalcFieldBlock — Yours side toggles", () => {
       attackerSide: makeSideState({ helpingHand: false }),
       setAttackerSide,
     });
-    fireEvent.click(screen.getAllByRole("button", { name: /^helping hand$/i })[0]);
+    fireEvent.click(screen.getByRole("switch", { name: /helping hand \(ours\)/i }));
     expect(setAttackerSide).toHaveBeenCalledWith({ helpingHand: true });
   });
 });
 
 describe("CalcFieldBlock — Theirs side toggles", () => {
-  it("calls setDefenderSide with tailwind patch when Tailwind clicked on Theirs side", () => {
+  it("calls setDefenderSide with reflect patch when Reflect clicked on Theirs side", () => {
     const setDefenderSide = jest.fn();
     renderBlock({
-      defenderSide: makeSideState({ tailwind: false }),
+      defenderSide: makeSideState({ reflect: false }),
       setDefenderSide,
     });
-    // "Tailwind" appears in both side cards; second button is Theirs
-    fireEvent.click(screen.getAllByRole("button", { name: /^tailwind$/i })[1]);
-    expect(setDefenderSide).toHaveBeenCalledWith({ tailwind: true });
+    fireEvent.click(screen.getByRole("switch", { name: /reflect \(theirs\)/i }));
+    expect(setDefenderSide).toHaveBeenCalledWith({ reflect: true });
   });
 
   it("calls setDefenderSide with stealthRock patch when Stealth Rock clicked on Theirs side", () => {
@@ -477,8 +466,7 @@ describe("CalcFieldBlock — Theirs side toggles", () => {
       defenderSide: makeSideState({ stealthRock: false }),
       setDefenderSide,
     });
-    // "Stealth Rock" appears in both side cards; second button is Theirs
-    fireEvent.click(screen.getAllByRole("button", { name: /^stealth rock$/i })[1]);
+    fireEvent.click(screen.getByRole("switch", { name: /stealth rock \(theirs\)/i }));
     expect(setDefenderSide).toHaveBeenCalledWith({ stealthRock: true });
   });
 });
@@ -488,41 +476,36 @@ describe("CalcFieldBlock — Theirs side toggles", () => {
 // =============================================================================
 
 describe("CalcFieldBlock — symmetric side card fields", () => {
-  it("renders Tailwind on both sides", () => {
-    renderBlock();
-    expect(screen.getAllByRole("button", { name: /^tailwind$/i })).toHaveLength(2);
-  });
-
   it("renders Reflect on both sides", () => {
     renderBlock();
-    expect(screen.getAllByRole("button", { name: /^reflect$/i })).toHaveLength(2);
+    expect(screen.getByRole("switch", { name: /reflect \(ours\)/i })).toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: /reflect \(theirs\)/i })).toBeInTheDocument();
   });
 
   it("renders Light Screen on both sides", () => {
     renderBlock();
-    expect(screen.getAllByRole("button", { name: /^light screen$/i })).toHaveLength(2);
+    expect(screen.getByRole("switch", { name: /light screen \(ours\)/i })).toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: /light screen \(theirs\)/i })).toBeInTheDocument();
   });
 
   it("renders Aurora Veil on both sides", () => {
     renderBlock({ attackerSide: makeSideState({ auroraVeil: true }) });
-    const buttons = screen.getAllByRole("button", { name: /aurora veil/i });
-    expect(buttons).toHaveLength(2);
-    expect(buttons[0]).toHaveAttribute("aria-pressed", "true"); // Yours active
-    expect(buttons[1]).toHaveAttribute("aria-pressed", "false"); // Theirs inactive
+    const ours = screen.getByRole("switch", { name: /aurora veil \(ours\)/i });
+    const theirs = screen.getByRole("switch", { name: /aurora veil \(theirs\)/i });
+    expect(ours).toBeChecked();
+    expect(theirs).not.toBeChecked();
   });
 
-  it("renders Stealth Rock on both sides (was previously Theirs only)", () => {
+  it("renders Stealth Rock on both sides", () => {
     renderBlock({ attackerSide: makeSideState({ stealthRock: true }) });
-    const srButtons = screen.getAllByRole("button", { name: /^stealth rock$/i });
-    expect(srButtons).toHaveLength(2);
-    expect(srButtons[0]).toHaveAttribute("aria-pressed", "true");
+    const ours = screen.getByRole("switch", { name: /stealth rock \(ours\)/i });
+    expect(ours).toBeChecked();
   });
 
-  it("renders Helping Hand on both sides (was previously Yours only)", () => {
+  it("renders Helping Hand on both sides", () => {
     renderBlock({ defenderSide: makeSideState({ helpingHand: true }) });
-    const hhButtons = screen.getAllByRole("button", { name: /^helping hand$/i });
-    expect(hhButtons).toHaveLength(2);
-    expect(hhButtons[1]).toHaveAttribute("aria-pressed", "true");
+    const theirs = screen.getByRole("switch", { name: /helping hand \(theirs\)/i });
+    expect(theirs).toBeChecked();
   });
 });
 
@@ -584,11 +567,10 @@ describe("CalcFieldBlock — ally alive toggle", () => {
 // =============================================================================
 
 describe("CalcFieldBlock — fainted stepper", () => {
-  it("renders Fainted label in side cards", () => {
+  it("renders Knocked Out label in side grid", () => {
     renderBlock();
-    const faintedLabels = screen.getAllByText("Fainted");
-    // One per side card (plus possibly ally toggle if allyAlive=false)
-    expect(faintedLabels.length).toBeGreaterThanOrEqual(2);
+    const labels = screen.getAllByText("Knocked Out");
+    expect(labels.length).toBeGreaterThanOrEqual(1);
   });
 
   it("clicking fainted '5' in Yours calls setFaintedYours(5)", () => {
@@ -607,28 +589,36 @@ describe("CalcFieldBlock — fainted stepper", () => {
 // Tests — active state styling
 // =============================================================================
 
-describe("CalcFieldBlock — active state aria-pressed", () => {
+describe("CalcFieldBlock — active state aria-checked", () => {
   it.each([
-    [false, "false"],
-    [true, "true"],
+    [false, false],
+    [true, true],
   ] as const)(
-    "tailwind=%s → Tailwind button aria-pressed=%s on Yours side",
-    (tailwind, expected) => {
-      renderBlock({ attackerSide: makeSideState({ tailwind }) });
-      const twBtns = screen.getAllByRole("button", { name: /^tailwind$/i });
-      expect(twBtns[0]).toHaveAttribute("aria-pressed", expected);
+    "reflect=%s → Reflect switch checked=%s on Ours side",
+    (reflect, expected) => {
+      renderBlock({ attackerSide: makeSideState({ reflect }) });
+      const sw = screen.getByRole("switch", { name: /reflect \(ours\)/i });
+      if (expected) {
+        expect(sw).toBeChecked();
+      } else {
+        expect(sw).not.toBeChecked();
+      }
     }
   );
 
   it.each([
-    [false, "false"],
-    [true, "true"],
+    [false, false],
+    [true, true],
   ] as const)(
-    "stealthRock=%s → Stealth Rock button aria-pressed=%s on Theirs side",
+    "stealthRock=%s → Stealth Rock switch checked=%s on Theirs side",
     (stealthRock, expected) => {
       renderBlock({ defenderSide: makeSideState({ stealthRock }) });
-      const srBtns = screen.getAllByRole("button", { name: /^stealth rock$/i });
-      expect(srBtns[1]).toHaveAttribute("aria-pressed", expected);
+      const sw = screen.getByRole("switch", { name: /stealth rock \(theirs\)/i });
+      if (expected) {
+        expect(sw).toBeChecked();
+      } else {
+        expect(sw).not.toBeChecked();
+      }
     }
   );
 });

--- a/apps/web/src/components/team-builder/v2/__tests__/dockbar.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/dockbar.test.tsx
@@ -10,52 +10,25 @@
  *
  * Tests verify:
  *   - Each pill renders and fires onOpen with the correct key
- *   - aria-pressed reflects the active drawer
- *   - weakCount colour (destructive vs muted)
- *   - coveredCount colour (emerald vs muted)
- *   - fastest display (number vs em-dash when 0)
- *   - defenderSpecies present → "vs <species>"; absent → "no target"
- *   - calcVerdict (OHKO/2HKO/3HKO) renders in text-primary; absent + defender → "—"
+ *   - aria-pressed reflects the active drawer (supporting both legacy and split state)
  *   - Chevron direction: active pill shows ▾, inactive shows ▴
+ *   - Defender species sublabel in calc pill
  */
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 
-import { type CalcOutput } from "../../use-calc-state";
 import { Dockbar, type DockbarProps } from "../dock/dockbar";
 
 // =============================================================================
 // Fixtures
 // =============================================================================
 
-/** Produces a CalcOutput whose getVerdict() result is "OHKO" (min >= 100). */
-function ohko(): CalcOutput {
-  return { minPercent: 110, maxPercent: 120, desc: "", rolls: [], defenderMaxHP: 100 };
-}
-
-/** Produces a CalcOutput whose getVerdict() result is "2HKO" (max >= 50, min < 100). */
-function twoHko(): CalcOutput {
-  return { minPercent: 45, maxPercent: 55, desc: "", rolls: [], defenderMaxHP: 100 };
-}
-
-/** Produces a CalcOutput whose getVerdict() result is "3HKO" (max >= 34, max < 50). */
-function threeHko(): CalcOutput {
-  return { minPercent: 30, maxPercent: 40, desc: "", rolls: [], defenderMaxHP: 100 };
-}
-
-/** Produces a CalcOutput whose getVerdict() result is null (max < 34). */
-function fourHkoPlus(): CalcOutput {
-  return { minPercent: 10, maxPercent: 25, desc: "", rolls: [], defenderMaxHP: 100 };
-}
-
 function makeProps(overrides: Partial<DockbarProps> = {}): DockbarProps {
   return {
     drawer: null,
     onOpen: jest.fn(),
-    weakCount: 0,
-    coveredCount: 0,
     fastest: 0,
     defenderSpecies: "",
     moveCalcOutputs: [null, null, null, null],
@@ -120,7 +93,7 @@ describe("Dockbar — click handlers", () => {
 });
 
 // =============================================================================
-// Tests — aria-pressed (active drawer)
+// Tests — aria-pressed (active drawer via legacy prop)
 // =============================================================================
 
 describe("Dockbar — aria-pressed reflects active drawer", () => {
@@ -156,91 +129,41 @@ describe("Dockbar — aria-pressed reflects active drawer", () => {
 });
 
 // =============================================================================
+// Tests — split state (sideDrawer / bottomDrawer)
+// =============================================================================
+
+describe("Dockbar — split drawer state", () => {
+  it("uses sideDrawer for speed active state", () => {
+    render(<Dockbar {...makeProps({ sideDrawer: "speed" })} />);
+    expect(screen.getByTitle("Speed tier ladder")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("uses sideDrawer for calc active state", () => {
+    render(<Dockbar {...makeProps({ sideDrawer: "calc" })} />);
+    expect(screen.getByTitle("Damage calc")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("uses bottomDrawer for matchups active state", () => {
+    render(<Dockbar {...makeProps({ bottomDrawer: "matchups" })} />);
+    expect(screen.getByTitle("Defensive type matchups")).toHaveAttribute("aria-pressed", "true");
+  });
+});
+
+// =============================================================================
 // Tests — chevron direction
 // =============================================================================
 
 describe("Dockbar — chevron direction", () => {
   it("active matchups pill shows ▾ chevron", () => {
-    const { container } = render(<Dockbar {...makeProps({ drawer: "matchups" })} />);
+    render(<Dockbar {...makeProps({ drawer: "matchups" })} />);
     const matchupsBtn = screen.getByTitle("Defensive type matchups");
-    // ▾ is present inside the active button
     expect(matchupsBtn.textContent).toContain("▾");
-    void container; // suppress unused warning
   });
 
   it("inactive matchups pill shows ▴ chevron", () => {
     render(<Dockbar {...makeProps({ drawer: "speed" })} />);
     const matchupsBtn = screen.getByTitle("Defensive type matchups");
     expect(matchupsBtn.textContent).toContain("▴");
-  });
-});
-
-// =============================================================================
-// Tests — weakCount display
-// =============================================================================
-
-describe("Dockbar — weakCount colour", () => {
-  it("renders the weak count as a number", () => {
-    render(<Dockbar {...makeProps({ weakCount: 3 })} />);
-    expect(screen.getByText("3")).toBeInTheDocument();
-  });
-
-  it("applies text-destructive when weakCount > 0", () => {
-    render(<Dockbar {...makeProps({ weakCount: 2 })} />);
-    const el = screen.getByText("2");
-    expect(el.className).toContain("text-destructive");
-  });
-
-  it("does NOT apply text-destructive when weakCount is 0", () => {
-    render(<Dockbar {...makeProps({ weakCount: 0 })} />);
-    // "0" appears — find the one inside the matchups pill
-    const zeroEls = screen.getAllByText("0");
-    // At least the first one (weakCount) should use muted colour
-    expect(zeroEls[0].className).not.toContain("text-destructive");
-  });
-});
-
-// =============================================================================
-// Tests — coveredCount display
-// =============================================================================
-
-describe("Dockbar — coveredCount colour", () => {
-  it("renders the covered count", () => {
-    render(<Dockbar {...makeProps({ coveredCount: 5 })} />);
-    expect(screen.getByText("5")).toBeInTheDocument();
-  });
-
-  it("applies emerald colour class when coveredCount > 0", () => {
-    render(<Dockbar {...makeProps({ coveredCount: 4 })} />);
-    const el = screen.getByText("4");
-    expect(el.className).toContain("text-emerald-600");
-  });
-
-  it("does NOT apply emerald colour when coveredCount is 0", () => {
-    render(<Dockbar {...makeProps({ coveredCount: 0, weakCount: 1 })} />);
-    // Find "0" that's the covered count — second "0" element if weakCount=1→"1"
-    const zeroEls = screen.getAllByText("0");
-    for (const el of zeroEls) {
-      expect(el.className).not.toContain("text-emerald-600");
-    }
-  });
-});
-
-// =============================================================================
-// Tests — fastest display
-// =============================================================================
-
-describe("Dockbar — fastest speed tier", () => {
-  it("displays the fastest number when > 0", () => {
-    render(<Dockbar {...makeProps({ fastest: 135 })} />);
-    expect(screen.getByText("135")).toBeInTheDocument();
-  });
-
-  it("displays em-dash when fastest is 0", () => {
-    render(<Dockbar {...makeProps({ fastest: 0 })} />);
-    // The speed pill shows "—" when no fastest
-    const speedPill = screen.getByTitle("Speed tier ladder");
-    expect(speedPill.textContent).toContain("—");
   });
 });
 
@@ -258,101 +181,4 @@ describe("Dockbar — defender species sublabel", () => {
     render(<Dockbar {...makeProps({ defenderSpecies: "" })} />);
     expect(screen.getByText("no target")).toBeInTheDocument();
   });
-});
-
-// =============================================================================
-// Tests — calc verdict display
-// =============================================================================
-
-describe("Dockbar — calc verdict in pill", () => {
-  it("shows 'OHKO' verdict when move outputs include an OHKO", () => {
-    render(<Dockbar {...makeProps({
-      defenderSpecies: "Garchomp",
-      moveCalcOutputs: [ohko(), null, null, null],
-    })} />);
-    expect(screen.getByText("OHKO")).toBeInTheDocument();
-  });
-
-  it("shows '2HKO' verdict when move outputs include a 2HKO", () => {
-    render(<Dockbar {...makeProps({
-      defenderSpecies: "Garchomp",
-      moveCalcOutputs: [twoHko(), null, null, null],
-    })} />);
-    expect(screen.getByText("2HKO")).toBeInTheDocument();
-  });
-
-  it("shows '3HKO' verdict when move outputs include a 3HKO", () => {
-    render(<Dockbar {...makeProps({
-      defenderSpecies: "Garchomp",
-      moveCalcOutputs: [threeHko(), null, null, null],
-    })} />);
-    expect(screen.getByText("3HKO")).toBeInTheDocument();
-  });
-
-  it("shows 'OHKO' when OHKO is the best among mixed tiers", () => {
-    render(<Dockbar {...makeProps({
-      defenderSpecies: "Garchomp",
-      moveCalcOutputs: [threeHko(), ohko(), twoHko(), null],
-    })} />);
-    expect(screen.getByText("OHKO")).toBeInTheDocument();
-  });
-
-  it("does NOT show a verdict when all outputs are null", () => {
-    render(<Dockbar {...makeProps({
-      defenderSpecies: "Garchomp",
-      moveCalcOutputs: [null, null, null, null],
-    })} />);
-    expect(screen.queryByText("OHKO")).not.toBeInTheDocument();
-    expect(screen.queryByText("2HKO")).not.toBeInTheDocument();
-    expect(screen.queryByText("3HKO")).not.toBeInTheDocument();
-  });
-
-  it("does NOT show a verdict for 4HKO+ outputs (below threshold)", () => {
-    render(<Dockbar {...makeProps({
-      defenderSpecies: "Garchomp",
-      moveCalcOutputs: [fourHkoPlus(), null, null, null],
-    })} />);
-    expect(screen.queryByText("OHKO")).not.toBeInTheDocument();
-  });
-
-  it("shows '—' when defender is set but no calc verdict is computed", () => {
-    render(<Dockbar {...makeProps({
-      defenderSpecies: "Garchomp",
-      moveCalcOutputs: [null, null, null, null],
-    })} />);
-    const calcPill = screen.getByTitle("Damage calc");
-    expect(calcPill.textContent).toContain("—");
-  });
-
-  it("does NOT show '—' in calc pill when there is no defender species", () => {
-    render(<Dockbar {...makeProps({
-      defenderSpecies: "",
-      moveCalcOutputs: [null, null, null, null],
-    })} />);
-    // There should be no verdict '—' separator when there's no target
-    const calcPill = screen.getByTitle("Damage calc");
-    // "no target" is shown instead — '—' aside that is the speed pill's 0
-    expect(calcPill.textContent).toContain("no target");
-  });
-});
-
-// =============================================================================
-// Tests — parameterised verdict priority
-// =============================================================================
-
-describe("Dockbar — verdict priority parameterised", () => {
-  it.each([
-    ["OHKO wins over 2HKO", [ohko(), twoHko(), null, null] as (CalcOutput | null)[], "OHKO"],
-    ["OHKO wins over 3HKO", [threeHko(), ohko(), null, null] as (CalcOutput | null)[], "OHKO"],
-    ["2HKO wins over 3HKO", [threeHko(), twoHko(), null, null] as (CalcOutput | null)[], "2HKO"],
-  ])(
-    "%s",
-    (_label, outputs, expectedVerdict) => {
-      render(<Dockbar {...makeProps({
-        defenderSpecies: "Garchomp",
-        moveCalcOutputs: outputs,
-      })} />);
-      expect(screen.getByText(expectedVerdict)).toBeInTheDocument();
-    }
-  );
 });

--- a/apps/web/src/components/team-builder/v2/__tests__/heatmap-panel.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/heatmap-panel.test.tsx
@@ -163,10 +163,11 @@ describe("HeatmapPanel — with team", () => {
     expect(screen.getByTestId("heatmap-panel")).toBeInTheDocument();
   });
 
-  it("renders 'Defensive coverage' heading by default", () => {
+  it("renders 'Defensive' button as active by default", () => {
     const team = makeTeamPokemon([GARCHOMP]);
     render(<HeatmapPanel team={team} format={undefined} />);
-    expect(screen.getByText("Defensive coverage")).toBeInTheDocument();
+    const defBtn = screen.getByRole("button", { name: /defensive/i });
+    expect(defBtn).toHaveAttribute("aria-pressed", "true");
   });
 
   it("renders the TOTAL footer row", () => {
@@ -184,13 +185,13 @@ describe("HeatmapPanel — with team", () => {
 });
 
 describe("HeatmapPanel — mode toggle", () => {
-  it("switches to 'Offensive coverage' when clicking Offensive button", async () => {
+  it("switches to 'Offensive' active when clicking Offensive button", async () => {
     const user = userEvent.setup();
     const team = makeTeamPokemon([GARCHOMP]);
     render(<HeatmapPanel team={team} format={undefined} />);
 
     await user.click(screen.getByRole("button", { name: /offensive/i }));
-    expect(screen.getByText("Offensive coverage")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /offensive/i })).toHaveAttribute("aria-pressed", "true");
   });
 
   it("switches back to defensive when clicking Defensive button", async () => {
@@ -200,7 +201,7 @@ describe("HeatmapPanel — mode toggle", () => {
 
     await user.click(screen.getByRole("button", { name: /offensive/i }));
     await user.click(screen.getByRole("button", { name: /defensive/i }));
-    expect(screen.getByText("Defensive coverage")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /defensive/i })).toHaveAttribute("aria-pressed", "true");
   });
 
   it("Defensive button is aria-pressed=true by default", () => {
@@ -255,18 +256,18 @@ describe("HeatmapPanel — Tera toggle", () => {
   });
 });
 
-describe("HeatmapPanel — weak/resist counts", () => {
-  it("shows non-zero weak counts when a pokemon has weaknesses (mult >= 2)", () => {
+describe("HeatmapPanel — row summary", () => {
+  it("shows net score values when a pokemon has weaknesses", () => {
     // Make all types deal 2x to make the weak count predictable
     (mockEffectiveDefensiveMult as jest.Mock).mockReturnValue(2);
     const team = makeTeamPokemon([GARCHOMP]);
     render(<HeatmapPanel team={team} format={undefined} />);
 
-    // TOTAL row weakCount for that mon should be 18 (all 18 types at 2x)
+    // TOTAL row should be present
     expect(screen.getByText("TOTAL")).toBeInTheDocument();
-    // At least one "w" count that's non-zero (destructive color)
-    const wTokens = screen.getAllByText(/\d+w/);
-    expect(wTokens.length).toBeGreaterThan(0);
+    // Net scores for rows with all weaknesses will be negative numbers
+    const negativeScores = screen.getAllByText(/-\d+/);
+    expect(negativeScores.length).toBeGreaterThan(0);
   });
 });
 

--- a/apps/web/src/components/team-builder/v2/__tests__/identity-lane.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/identity-lane.test.tsx
@@ -427,12 +427,12 @@ describe("IdentityLane — basic render", () => {
   });
 });
 
-describe("IdentityLane — type pills (moved to RibDecorations)", () => {
-  it("does NOT render type pills inside identity-lane (they live in the rib now)", () => {
+describe("IdentityLane — type pills", () => {
+  it("renders type pills for the species types", () => {
     // mock returns ["Dragon", "Ground"]
     renderLane();
-    expect(screen.queryByTestId("type-pill-Dragon")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("type-pill-Ground")).not.toBeInTheDocument();
+    expect(screen.getByTestId("type-pill-Dragon")).toBeInTheDocument();
+    expect(screen.getByTestId("type-pill-Ground")).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/components/team-builder/v2/__tests__/mega-toggle.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/mega-toggle.test.tsx
@@ -24,10 +24,10 @@ describe("MegaToggle", () => {
     expect(button).toHaveAttribute("aria-pressed", "true");
   });
 
-  it("renders 'Base' when inactive and exposes aria-pressed=false", () => {
+  it("renders 'Mega' when inactive and exposes aria-pressed=false", () => {
     render(<MegaToggle active={false} onToggle={() => {}} />);
     const button = screen.getByRole("button");
-    expect(button).toHaveTextContent("Base");
+    expect(button).toHaveTextContent("Mega");
     expect(button).toHaveAttribute("aria-pressed", "false");
   });
 

--- a/apps/web/src/components/team-builder/v2/__tests__/moves-lane.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/moves-lane.test.tsx
@@ -178,6 +178,10 @@ jest.mock("../calc/calc-detail-card", () => ({
 type RowOutputs = readonly (null | {
   minPercent: number;
   maxPercent: number;
+  rolls?: number[];
+  koChance?: number | null;
+  desc?: string;
+  recoveryTier?: string | null;
 })[];
 const mockCalcContext: {
   calcEnabled: boolean;
@@ -447,8 +451,8 @@ describe("MovesLane — move tile display", () => {
 
   it("shows accuracy for a move with numeric accuracy", () => {
     renderLane({ move1: "Moonblast" });
-    // getMoveData returns accuracy: 100 → "100%"
-    expect(screen.getAllByText("100%").length).toBeGreaterThan(0);
+    // getMoveData returns accuracy: 100 → rendered as plain number
+    expect(screen.getAllByText("100").length).toBeGreaterThan(0);
   });
 
   it("shows '—' for accuracy when accuracy is true (always-hit)", () => {
@@ -640,11 +644,68 @@ describe("MovesLane — ghost mode (pokemon: null)", () => {
   });
 
   it("renders '+ Add move' as span elements, not buttons", () => {
-    const { container } = render(<MovesLane pokemon={null} />);
-    const spans = container.querySelectorAll("span.mvline-name");
-    expect(spans.length).toBe(4);
-    spans.forEach((span) => {
-      expect(span.tagName.toLowerCase()).toBe("span");
+    render(<MovesLane pokemon={null} />);
+    const addMoveSpans = screen.getAllByText("+ Add move");
+    expect(addMoveSpans.length).toBe(4);
+    addMoveSpans.forEach((el) => {
+      expect(el.tagName.toLowerCase()).toBe("span");
     });
+  });
+});
+
+describe("MovesLane — table headers", () => {
+  it("provides sr-only accessible labels for Type and Category column headers", () => {
+    renderLane();
+    const headers = screen.getAllByRole("columnheader");
+    const texts = headers.map((h) => h.textContent?.trim());
+    expect(texts).toContain("Type");
+    expect(texts).toContain("Category");
+  });
+});
+
+describe("MovesLane — inline calc display", () => {
+  beforeEach(() => {
+    (useCalcStateContext as jest.Mock).mockImplementation(() => mockCalcContext);
+    mockCalcContext.calcEnabled = false;
+    mockCalcContext.rowOutputs = [null, null, null, null];
+  });
+
+  afterEach(() => {
+    mockCalcContext.calcEnabled = false;
+    mockCalcContext.rowOutputs = [null, null, null, null];
+  });
+
+  it("shows damage percentage range and KO tier for a damaging move when calc is enabled", () => {
+    mockCalcContext.calcEnabled = true;
+    mockCalcContext.rowOutputs = [
+      { minPercent: 65.4, maxPercent: 77.2, rolls: [] },
+      null,
+      null,
+      null,
+    ];
+    renderLane({ move1: "Moonblast", move2: null, move3: null, move4: null });
+    expect(screen.getByText("65.4–77.2%")).toBeInTheDocument();
+    expect(screen.getByText("4HKO+")).toBeInTheDocument();
+  });
+
+  it("shows '—' placeholder for Status moves even when calc is enabled", () => {
+    (getMoveData as jest.Mock).mockReturnValueOnce({
+      type: "Normal",
+      category: "Status",
+      basePower: 0,
+      accuracy: true,
+      shortDesc: "User falls asleep.",
+    });
+    mockCalcContext.calcEnabled = true;
+    mockCalcContext.rowOutputs = [
+      { minPercent: 50.0, maxPercent: 60.0, rolls: [] },
+      null,
+      null,
+      null,
+    ];
+    renderLane({ move1: "Rest", move2: null, move3: null, move4: null });
+    // Status move: hasCalc = false → percentage cell shows "—" not a range
+    expect(screen.queryByText("50.0–60.0%")).not.toBeInTheDocument();
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
   });
 });

--- a/apps/web/src/components/team-builder/v2/__tests__/poke-row.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/poke-row.test.tsx
@@ -392,7 +392,7 @@ describe("PokeRow — empty slot", () => {
       expect(screen.queryByTestId("calc-column")).not.toBeInTheDocument();
     });
 
-    it("renders a ghost calc column when calc is enabled — keeps width parity with active rows", () => {
+    it("does not render the calc column for empty slots regardless of calc state", () => {
       mockUseCalcStateContext.mockReturnValue({ calcEnabled: true });
       render(
         <PokeRow
@@ -405,10 +405,7 @@ describe("PokeRow — empty slot", () => {
           onActivate={jest.fn()}
         />
       );
-      const calcCol = screen.getByTestId("calc-column");
-      expect(calcCol).toBeInTheDocument();
-      // Ghost mode is signaled by pokemon === null
-      expect(calcCol.dataset.ghost).toBe("true");
+      expect(screen.queryByTestId("calc-column")).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/components/team-builder/v2/__tests__/speed-tiers-panel-extra.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/speed-tiers-panel-extra.test.tsx
@@ -9,7 +9,7 @@
  * - Tier table row rendering
  */
 
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 

--- a/apps/web/src/components/team-builder/v2/__tests__/stats-lane.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/stats-lane.test.tsx
@@ -9,6 +9,26 @@ import { type Tables } from "@trainers/supabase";
 
 import { StatsLane } from "../lanes/stats-lane";
 
+jest.mock("../calc/calc-state-context", () => ({
+  CalcStateProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  useCalcStateContext: () => ({
+    defenderSpecies: "",
+    moveCalcOutputs: [null, null, null, null],
+    field: {
+      doubles: true,
+      tailwind: false,
+      foesAlive: 2,
+      allyAlive: 2,
+      atkTera: false,
+    },
+    setField: jest.fn(),
+    calcEnabled: false,
+  }),
+  useCalcEnabled: () => false,
+}));
+
 // CSS modules aren't processed by ts-jest — mock them as identity proxies so
 // every className lookup returns the property key (e.g. s.spreadRow → "spreadRow").
 
@@ -272,10 +292,10 @@ describe("StatsLane", () => {
   it("renders ▲ on Atk row for Adamant nature", () => {
     renderLane({ nature: "Adamant" });
     // ▲ should appear exactly once — on the Atk label
-    const upChevrons = screen.getAllByText("▲");
+    const upChevrons = screen.getAllByText("▴");
     expect(upChevrons).toHaveLength(1);
     // HP, Def, SpA, SpD, Spe rows should NOT have ▲
-    expect(screen.queryAllByText("▽")).toHaveLength(1); // SpA gets ▽ under Adamant
+    expect(screen.queryAllByText("▾")).toHaveLength(1); // SpA gets ▽ under Adamant
   });
 
   // ---------------------------------------------------------------------------
@@ -283,11 +303,11 @@ describe("StatsLane", () => {
   // ---------------------------------------------------------------------------
   it("renders ▽ on SpA row for Adamant nature, not on other rows", () => {
     renderLane({ nature: "Adamant" }); // Adamant: +Atk / −SpA
-    const downChevrons = screen.getAllByText("▽");
+    const downChevrons = screen.getAllByText("▾");
     expect(downChevrons).toHaveLength(1);
     // The ▽ should be near the SpA label — confirm SpA text is adjacent in DOM
     const spaLabel = screen.getByText("SpA");
-    expect(spaLabel.closest("span")?.textContent).toContain("▽");
+    expect(spaLabel.closest("button")?.textContent).toContain("▾");
   });
 
   // ---------------------------------------------------------------------------

--- a/apps/web/src/components/team-builder/v2/__tests__/stats-lane.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/stats-lane.test.tsx
@@ -599,6 +599,44 @@ describe("StatsLane", () => {
     const slider = screen.getByLabelText("Atk slider");
     expect(slider).not.toHaveAttribute("data-at-bump");
   });
+
+  // ---------------------------------------------------------------------------
+  // Regression: liveEvByStat must clear when the rendered Pokemon changes.
+  // Without the prevPokemonIdRef reset (stats-lane.tsx ~778), an in-flight
+  // slider draft from Pokemon A would contaminate Pokemon B's EV total when
+  // the lane swaps to a new slot. Verifies the render-time reset fires on
+  // pokemon.id change.
+  // ---------------------------------------------------------------------------
+  it("clears in-flight liveEvByStat when the lane swaps to a different pokemon", () => {
+    const pokemonA = makeGarchomp({ id: 1, ev_attack: 0 });
+    const pokemonB = makeGarchomp({ id: 2, ev_attack: 0 });
+
+    const { rerender } = render(
+      <StatsLane pokemon={pokemonA} format={VGC_FORMAT} onUpdate={jest.fn()} />
+    );
+
+    // Baseline: both Pokemon have all EVs at 0, so the chip starts at 0/508.
+    expect(screen.getByText("0/508")).toBeInTheDocument();
+
+    // Simulate a slider drag on Atk — handleSliderChange bubbles the live
+    // value via onLiveEv, which sets liveEvByStat in the lane.
+    const atkSlider = screen.getByLabelText("Atk slider");
+    fireEvent.change(atkSlider, { target: { value: "100" } });
+
+    // Live total now reflects the dragged value (100), not the prop value (0).
+    expect(screen.getByText("100/508")).toBeInTheDocument();
+
+    // Swap to a different pokemon (different id) without committing the drag.
+    rerender(
+      <StatsLane pokemon={pokemonB} format={VGC_FORMAT} onUpdate={jest.fn()} />
+    );
+
+    // If liveEvByStat were not cleared on pokemon swap, the chip would still
+    // show "100/508" because liveEvByStat['attack'] would override pokemon B's
+    // ev_attack=0. The reset wipes the draft, so we see B's true total.
+    expect(screen.getByText("0/508")).toBeInTheDocument();
+    expect(screen.queryByText("100/508")).not.toBeInTheDocument();
+  });
 });
 
 // =============================================================================

--- a/apps/web/src/components/team-builder/v2/__tests__/team-layout-toggle.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/team-layout-toggle.test.tsx
@@ -23,9 +23,9 @@ beforeEach(() => {
 });
 
 describe("TeamLayoutToggle", () => {
-  it("renders three buttons", () => {
+  it("renders two buttons", () => {
     render(<TeamLayoutToggle />);
-    expect(screen.getAllByRole("button")).toHaveLength(3);
+    expect(screen.getAllByRole("button")).toHaveLength(2);
   });
 
   it("marks the persisted mode as pressed", () => {
@@ -58,14 +58,14 @@ describe("TeamLayoutToggle", () => {
   });
 
   it("keeps the persisted button pressed even when auto-degraded", () => {
-    window.localStorage.setItem("tg.team-layout", "2x3");
+    window.localStorage.setItem("tg.team-layout", "2x3-vertical");
     setViewportWidth(1200); // below 1500 — degrades to 1x6
     render(<TeamLayoutToggle />);
     const persistedBtn = screen.getByLabelText(
-      /2 × 3 — mid-stacked per cell/
+      /2 × 3 — stacked per cell/
     );
     expect(persistedBtn).toHaveAttribute("aria-pressed", "true");
-    // Effective is 1x6, but user's pick (2x3) should still show pressed.
+    // Effective is 1x6, but user's pick (2x3-vertical) should still show pressed.
     const oneByBtn = screen.getByLabelText(/1 × 6 — full row layout/);
     expect(oneByBtn).toHaveAttribute("aria-pressed", "false");
   });

--- a/apps/web/src/components/team-builder/v2/__tests__/team-workspace-reorder.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/team-workspace-reorder.test.tsx
@@ -155,6 +155,8 @@ import { TeamWorkspaceV2 } from "../team-workspace-v2";
 // Fixtures
 // =============================================================================
 
+const MOCK_ALTS = [{ id: 1, username: "ash_ketchum", user_id: "u1", avatar_url: null, bio: null, is_public: true, tier: null, tier_expires_at: null, tier_started_at: null, created_at: null, updated_at: null }] as any;
+
 function makePokemon(
   id: number,
   species: string,
@@ -236,6 +238,7 @@ describe("TeamWorkspaceV2 — slot rendering", () => {
         team={TWO_POKEMON_TEAM}
         format={undefined}
         username="ash_ketchum"
+        alts={MOCK_ALTS}
       />
     );
 
@@ -250,6 +253,7 @@ describe("TeamWorkspaceV2 — slot rendering", () => {
         team={TWO_POKEMON_TEAM}
         format={undefined}
         username="ash_ketchum"
+        alts={MOCK_ALTS}
       />
     );
 
@@ -272,6 +276,7 @@ describe("TeamWorkspaceV2 — buildSlots position mapping", () => {
         team={team}
         format={undefined}
         username="ash_ketchum"
+        alts={MOCK_ALTS}
       />
     );
 
@@ -297,6 +302,7 @@ describe("TeamWorkspaceV2 — reorder success path", () => {
         team={TWO_POKEMON_TEAM}
         format={undefined}
         username="ash_ketchum"
+        alts={MOCK_ALTS}
       />
     );
 
@@ -313,6 +319,7 @@ describe("TeamWorkspaceV2 — empty team", () => {
         team={emptyTeam}
         format={undefined}
         username="ash_ketchum"
+        alts={MOCK_ALTS}
       />
     );
 
@@ -331,6 +338,7 @@ describe("TeamWorkspaceV2 — no duplicate slot IDs", () => {
         team={TWO_POKEMON_TEAM}
         format={undefined}
         username="ash_ketchum"
+        alts={MOCK_ALTS}
       />
     );
 
@@ -347,6 +355,7 @@ describe("TeamWorkspaceV2 — no duplicate slot IDs", () => {
         team={TWO_POKEMON_TEAM}
         format={undefined}
         username="ash_ketchum"
+        alts={MOCK_ALTS}
       />
     );
 
@@ -364,6 +373,7 @@ describe("TeamWorkspaceV2 — no duplicate slot IDs", () => {
         team={TWO_POKEMON_TEAM}
         format={undefined}
         username="ash_ketchum"
+        alts={MOCK_ALTS}
       />
     );
 

--- a/apps/web/src/components/team-builder/v2/__tests__/team-workspace-reorder.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/team-workspace-reorder.test.tsx
@@ -155,7 +155,7 @@ import { TeamWorkspaceV2 } from "../team-workspace-v2";
 // Fixtures
 // =============================================================================
 
-const MOCK_ALTS = [{ id: 1, username: "ash_ketchum", user_id: "u1", avatar_url: null, bio: null, is_public: true, tier: null, tier_expires_at: null, tier_started_at: null, created_at: null, updated_at: null }] as any;
+const MOCK_ALTS = [{ id: 1, username: "ash_ketchum", user_id: "u1", avatar_url: null, bio: null, is_public: true, tier: null, tier_expires_at: null, tier_started_at: null, created_at: null, updated_at: null }] as unknown as Tables<"alts">[];
 
 function makePokemon(
   id: number,

--- a/apps/web/src/components/team-builder/v2/__tests__/team-workspace-v2.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/team-workspace-v2.test.tsx
@@ -136,11 +136,19 @@ jest.mock("../../validation-hooks", () => ({
 // Controllable drawer state — default closed, tests can override
 const mockSetDrawer = jest.fn();
 const mockSetActiveIdx = jest.fn();
+const mockSetSideDrawer = jest.fn();
+const mockSetBottomDrawer = jest.fn();
 const mockBuilderState = {
   activeIdx: 0,
   setActiveIdx: mockSetActiveIdx,
   drawer: null as "matchups" | "speed" | "calc" | null,
   setDrawer: mockSetDrawer,
+  sideDrawer: null as "speed" | "calc" | null,
+  setSideDrawer: mockSetSideDrawer,
+  bottomDrawer: null as "matchups" | null,
+  setBottomDrawer: mockSetBottomDrawer,
+  sideWidthPx: 380,
+  setSideWidthPx: jest.fn(),
   field: { doubles: true, tailwind: false, foesAlive: 2, allyAlive: 2, atkTera: false },
   setField: jest.fn(),
   panelHeightPct: 40,
@@ -306,6 +314,8 @@ beforeEach(() => {
   jest.clearAllMocks();
   // Reset builder state to defaults
   mockBuilderState.drawer = null;
+  mockBuilderState.sideDrawer = null;
+  mockBuilderState.bottomDrawer = null;
   mockBuilderState.activeIdx = 0;
   mockBuilderState.attackerSlot = null;
   mockUseIsMobile.mockReturnValue(false);
@@ -788,6 +798,7 @@ describe("TeamWorkspaceV2 — mobile layout", () => {
 describe("TeamWorkspaceV2 — drawer panel", () => {
   it("renders the heatmap panel when drawer is 'matchups'", () => {
     mockBuilderState.drawer = "matchups";
+    mockBuilderState.bottomDrawer = "matchups";
 
     renderWorkspace();
 
@@ -797,6 +808,7 @@ describe("TeamWorkspaceV2 — drawer panel", () => {
 
   it("renders the speed tiers panel when drawer is 'speed'", () => {
     mockBuilderState.drawer = "speed";
+    mockBuilderState.sideDrawer = "speed";
 
     renderWorkspace();
 
@@ -806,6 +818,7 @@ describe("TeamWorkspaceV2 — drawer panel", () => {
 
   it("renders the calc bottom panel when drawer is 'calc' on desktop", () => {
     mockBuilderState.drawer = "calc";
+    mockBuilderState.sideDrawer = "calc";
     mockUseIsMobile.mockReturnValue(false);
 
     renderWorkspace();
@@ -813,18 +826,20 @@ describe("TeamWorkspaceV2 — drawer panel", () => {
     expect(screen.getByTestId("calc-bottom-panel")).toBeInTheDocument();
   });
 
-  it("renders the calc drawer (Sheet) instead of bottom panel on mobile", () => {
+  it("renders calc bottom panel on mobile when sideDrawer is 'calc'", () => {
     mockBuilderState.drawer = "calc";
+    mockBuilderState.sideDrawer = "calc";
     mockUseIsMobile.mockReturnValue(true);
 
     renderWorkspace();
 
-    expect(screen.getByTestId("calc-drawer")).toBeInTheDocument();
-    expect(screen.queryByTestId("calc-bottom-panel")).not.toBeInTheDocument();
+    expect(screen.getByTestId("calc-bottom-panel")).toBeInTheDocument();
   });
 
   it("renders no panel when drawer is null", () => {
     mockBuilderState.drawer = null;
+    mockBuilderState.sideDrawer = null;
+    mockBuilderState.bottomDrawer = null;
 
     renderWorkspace();
 
@@ -833,84 +848,41 @@ describe("TeamWorkspaceV2 — drawer panel", () => {
     expect(screen.queryByTestId("calc-bottom-panel")).not.toBeInTheDocument();
   });
 
-  it("shows 'DEFENSIVE' eyebrow when matchups drawer is open", () => {
-    mockBuilderState.drawer = "matchups";
-
-    renderWorkspace();
-
-    expect(screen.getByText("DEFENSIVE")).toBeInTheDocument();
-  });
-
-  it("shows 'SPEED' eyebrow when speed drawer is open", () => {
+  it("shows 'Speed Tiers' header when speed drawer is open", () => {
     mockBuilderState.drawer = "speed";
+    mockBuilderState.sideDrawer = "speed";
 
     renderWorkspace();
 
-    expect(screen.getByText("SPEED")).toBeInTheDocument();
+    expect(screen.getByText("Speed Tiers")).toBeInTheDocument();
   });
 
-  it("close button in panel header calls setDrawer(null)", async () => {
-    mockBuilderState.drawer = "matchups";
+  it("close button in side panel header calls setSideDrawer(null)", async () => {
+    mockBuilderState.drawer = "speed";
+    mockBuilderState.sideDrawer = "speed";
 
     const user = userEvent.setup();
     renderWorkspace();
 
-    await user.click(screen.getByRole("button", { name: /close panel/i }));
+    await user.click(screen.getByRole("button", { name: /close speed tiers/i }));
 
-    expect(mockSetDrawer).toHaveBeenCalledWith(null);
+    expect(mockSetSideDrawer).toHaveBeenCalledWith(null);
   });
 });
 
 // =============================================================================
-// resizer keyboard interactions
+// resizer — side panel
 // =============================================================================
 
-describe("TeamWorkspaceV2 — resizer keyboard", () => {
-  it.each([
-    ["ArrowUp", 5],
-    ["ArrowDown", -5],
-  ] as const)(
-    "%s adjusts panel height by ±5",
-    async (key, delta) => {
-      mockBuilderState.drawer = "matchups";
-      mockBuilderState.panelHeightPct = 40;
+describe("TeamWorkspaceV2 — side panel resizer", () => {
+  it("renders a vertical separator when side drawer is open", () => {
+    mockBuilderState.drawer = "speed";
+    mockBuilderState.sideDrawer = "speed";
 
-      const user = userEvent.setup();
-      renderWorkspace();
-
-      const resizer = screen.getByRole("separator", { name: /resize analytics panel/i });
-      resizer.focus();
-      await user.keyboard(`{${key}}`);
-
-      expect(mockBuilderState.setPanelHeightPct).toHaveBeenCalledWith(40 + delta);
-    }
-  );
-
-  it("Home key sets panel height to 20", async () => {
-    mockBuilderState.drawer = "matchups";
-    mockBuilderState.panelHeightPct = 60;
-
-    const user = userEvent.setup();
     renderWorkspace();
 
-    const resizer = screen.getByRole("separator", { name: /resize analytics panel/i });
-    resizer.focus();
-    await user.keyboard("{Home}");
-
-    expect(mockBuilderState.setPanelHeightPct).toHaveBeenCalledWith(20);
-  });
-
-  it("End key sets panel height to 80", async () => {
-    mockBuilderState.drawer = "matchups";
-    mockBuilderState.panelHeightPct = 40;
-
-    const user = userEvent.setup();
-    renderWorkspace();
-
-    const resizer = screen.getByRole("separator", { name: /resize analytics panel/i });
-    resizer.focus();
-    await user.keyboard("{End}");
-
-    expect(mockBuilderState.setPanelHeightPct).toHaveBeenCalledWith(80);
+    expect(
+      screen.getByRole("separator", { name: /resize side panel/i })
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/team-builder/v2/__tests__/team-workspace-v2.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/team-workspace-v2.test.tsx
@@ -287,7 +287,7 @@ function renderWorkspace(
   team: TeamWithPokemon = TWO_POKEMON_TEAM,
   format = undefined
 ) {
-  const alts = [{ id: 1, username: "ash_ketchum", user_id: "u1", avatar_url: null, bio: null, is_public: true, tier: null, tier_expires_at: null, tier_started_at: null, created_at: null, updated_at: null }] as any;
+  const alts = [{ id: 1, username: "ash_ketchum", user_id: "u1", avatar_url: null, bio: null, is_public: true, tier: null, tier_expires_at: null, tier_started_at: null, created_at: null, updated_at: null }] as unknown as Tables<"alts">[];
   return render(
     <TeamWorkspaceV2 team={team} format={format} username="ash_ketchum" alts={alts} />
   );

--- a/apps/web/src/components/team-builder/v2/__tests__/team-workspace-v2.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/team-workspace-v2.test.tsx
@@ -279,8 +279,9 @@ function renderWorkspace(
   team: TeamWithPokemon = TWO_POKEMON_TEAM,
   format = undefined
 ) {
+  const alts = [{ id: 1, username: "ash_ketchum", user_id: "u1", avatar_url: null, bio: null, is_public: true, tier: null, tier_expires_at: null, tier_started_at: null, created_at: null, updated_at: null }] as any;
   return render(
-    <TeamWorkspaceV2 team={team} format={format} username="ash_ketchum" />
+    <TeamWorkspaceV2 team={team} format={format} username="ash_ketchum" alts={alts} />
   );
 }
 

--- a/apps/web/src/components/team-builder/v2/__tests__/topbar.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/topbar.test.tsx
@@ -3,7 +3,7 @@
 /**
  * Tests for the Topbar component.
  * Verifies: Import button, Validate popover trigger, error/warning styling,
- * format badge rendering, filledCount display.
+ * format badge rendering.
  */
 
 import { render, screen } from "@testing-library/react";
@@ -118,7 +118,6 @@ const DEFAULT_FORMAT = {
 
 function renderTopbar(
   props: Partial<{
-    filledCount: number;
     format: typeof DEFAULT_FORMAT | undefined;
     validationErrors: ValidationError[];
     exportMenu: React.ReactNode;
@@ -136,7 +135,6 @@ function renderTopbar(
   const utils = render(
     <Topbar
       team={makeTeam()}
-      filledCount={props.filledCount ?? 2}
       format={props.format as GameFormat | undefined}
       username="ash_ketchum"
       alts={alts as any}

--- a/apps/web/src/components/team-builder/v2/__tests__/topbar.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/topbar.test.tsx
@@ -11,7 +11,7 @@ import userEvent from "@testing-library/user-event";
 import React from "react";
 
 import { type GameFormat } from "@trainers/pokemon";
-import { type TeamWithPokemon } from "@trainers/supabase";
+import { type Tables, type TeamWithPokemon } from "@trainers/supabase";
 
 // =============================================================================
 // Mocks
@@ -137,7 +137,7 @@ function renderTopbar(
       team={makeTeam()}
       format={props.format as GameFormat | undefined}
       username="ash_ketchum"
-      alts={alts as any}
+      alts={alts as unknown as Tables<"alts">[]}
       onOpenImport={onOpenImport}
       validationErrors={props.validationErrors ?? []}
       onJumpToPokemon={onJumpToPokemon}

--- a/apps/web/src/components/team-builder/v2/__tests__/topbar.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/topbar.test.tsx
@@ -271,3 +271,121 @@ describe("Topbar — exportMenu slot", () => {
     expect(screen.getByRole("button", { name: /import/i })).toBeInTheDocument();
   });
 });
+
+describe("Topbar — inline name editing", () => {
+  it("enters edit mode when the name button is clicked", async () => {
+    const user = userEvent.setup();
+    renderTopbar();
+    const nameBtn = screen.getByRole("button", { name: /edit team name/i });
+    await user.click(nameBtn);
+    // Should now show an input with the team name
+    expect(screen.getByDisplayValue("Test Team")).toBeInTheDocument();
+  });
+
+  it("commits name change on Enter and calls onNameChange", async () => {
+    const user = userEvent.setup();
+    const { onNameChange } = renderTopbar();
+    const nameBtn = screen.getByRole("button", { name: /edit team name/i });
+    await user.click(nameBtn);
+    const input = screen.getByDisplayValue("Test Team");
+    await user.clear(input);
+    await user.type(input, "New Name{Enter}");
+    expect(onNameChange).toHaveBeenCalledWith("New Name");
+  });
+
+  it("cancels editing on Escape and reverts to original name", async () => {
+    const user = userEvent.setup();
+    const { onNameChange } = renderTopbar();
+    const nameBtn = screen.getByRole("button", { name: /edit team name/i });
+    await user.click(nameBtn);
+    const input = screen.getByDisplayValue("Test Team");
+    await user.clear(input);
+    await user.type(input, "Temp Name{Escape}");
+    expect(onNameChange).not.toHaveBeenCalled();
+    // Should exit editing mode (button visible again)
+    expect(screen.getByRole("button", { name: /edit team name/i })).toBeInTheDocument();
+  });
+
+  it("does not call onNameChange when value is unchanged", async () => {
+    const user = userEvent.setup();
+    const { onNameChange } = renderTopbar();
+    const nameBtn = screen.getByRole("button", { name: /edit team name/i });
+    await user.click(nameBtn);
+    const input = screen.getByDisplayValue("Test Team");
+    // Press Enter without changing
+    await user.type(input, "{Enter}");
+    expect(onNameChange).not.toHaveBeenCalled();
+  });
+
+  it("does not call onNameChange when value is empty/whitespace only", async () => {
+    const user = userEvent.setup();
+    const { onNameChange } = renderTopbar();
+    const nameBtn = screen.getByRole("button", { name: /edit team name/i });
+    await user.click(nameBtn);
+    const input = screen.getByDisplayValue("Test Team");
+    await user.clear(input);
+    await user.type(input, "   {Enter}");
+    expect(onNameChange).not.toHaveBeenCalled();
+  });
+
+  it("commits name change on blur", async () => {
+    const user = userEvent.setup();
+    const { onNameChange } = renderTopbar();
+    const nameBtn = screen.getByRole("button", { name: /edit team name/i });
+    await user.click(nameBtn);
+    const input = screen.getByDisplayValue("Test Team");
+    await user.clear(input);
+    await user.type(input, "Blur Name");
+    await user.tab(); // blur
+    expect(onNameChange).toHaveBeenCalledWith("Blur Name");
+  });
+});
+
+describe("Topbar — format picker", () => {
+  it("renders changeable format badge when onFormatChange is provided", () => {
+    const onFormatChange = jest.fn().mockResolvedValue(undefined);
+    const alts = [
+      { id: 1, username: "ash_ketchum", user_id: "u1", avatar_url: null, bio: null, is_public: true, tier: null, tier_expires_at: null, tier_started_at: null, created_at: null, updated_at: null },
+    ];
+    render(
+      <Topbar
+        team={makeTeam()}
+        format={DEFAULT_FORMAT as unknown as GameFormat}
+        username="ash_ketchum"
+        alts={alts as unknown as Tables<"alts">[]}
+        onOpenImport={jest.fn()}
+        validationErrors={[]}
+        onJumpToPokemon={jest.fn()}
+        onValidate={jest.fn()}
+        onNameChange={jest.fn().mockResolvedValue(undefined)}
+        onFormatChange={onFormatChange}
+      />
+    );
+    // Format badge should be present
+    expect(screen.getByText("VGC 2026 Reg I")).toBeInTheDocument();
+  });
+
+  it("renders multiple alts dropdown when onAltChange and multiple alts provided", () => {
+    const onAltChange = jest.fn().mockResolvedValue(undefined);
+    const alts = [
+      { id: 1, username: "ash_ketchum", user_id: "u1", avatar_url: null, bio: null, is_public: true, tier: null, tier_expires_at: null, tier_started_at: null, created_at: null, updated_at: null },
+      { id: 2, username: "gary_oak", user_id: "u1", avatar_url: null, bio: null, is_public: true, tier: null, tier_expires_at: null, tier_started_at: null, created_at: null, updated_at: null },
+    ];
+    render(
+      <Topbar
+        team={makeTeam()}
+        format={DEFAULT_FORMAT as unknown as GameFormat}
+        username="ash_ketchum"
+        alts={alts as unknown as Tables<"alts">[]}
+        onOpenImport={jest.fn()}
+        validationErrors={[]}
+        onJumpToPokemon={jest.fn()}
+        onValidate={jest.fn()}
+        onNameChange={jest.fn().mockResolvedValue(undefined)}
+        onAltChange={onAltChange}
+      />
+    );
+    // Should show the "Switch alt" button
+    expect(screen.getByRole("button", { name: /switch alt/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/team-builder/v2/__tests__/topbar.test.tsx
+++ b/apps/web/src/components/team-builder/v2/__tests__/topbar.test.tsx
@@ -51,6 +51,10 @@ jest.mock("@/components/dashboard/page-header", () => ({
   ),
 }));
 
+jest.mock("@/components/dashboard/notifications-popover", () => ({
+  NotificationsPopover: () => <button data-testid="notifications">Notifications</button>,
+}));
+
 // =============================================================================
 // Import after mocks
 // =============================================================================
@@ -123,6 +127,11 @@ function renderTopbar(
   const onOpenImport = jest.fn();
   const onJumpToPokemon = jest.fn();
   const onValidate = jest.fn();
+  const onNameChange = jest.fn().mockResolvedValue(undefined);
+
+  const alts = [
+    { id: 1, username: "ash_ketchum", user_id: "u1", avatar_url: null, bio: null, is_public: true, tier: null, tier_expires_at: null, tier_started_at: null, created_at: null, updated_at: null },
+  ];
 
   const utils = render(
     <Topbar
@@ -130,15 +139,17 @@ function renderTopbar(
       filledCount={props.filledCount ?? 2}
       format={props.format as GameFormat | undefined}
       username="ash_ketchum"
+      alts={alts as any}
       onOpenImport={onOpenImport}
       validationErrors={props.validationErrors ?? []}
       onJumpToPokemon={onJumpToPokemon}
       onValidate={onValidate}
+      onNameChange={onNameChange}
       exportMenu={props.exportMenu}
     />
   );
 
-  return { ...utils, onOpenImport, onJumpToPokemon, onValidate };
+  return { ...utils, onOpenImport, onJumpToPokemon, onValidate, onNameChange };
 }
 
 // =============================================================================
@@ -146,20 +157,16 @@ function renderTopbar(
 // =============================================================================
 
 describe("Topbar — basic render", () => {
-  it("renders the team name in the input", () => {
+  it("renders the team name as an editable button", () => {
     renderTopbar();
-    expect(screen.getByDisplayValue("Test Team")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /edit team name/i })).toBeInTheDocument();
+    expect(screen.getByText("Test Team")).toBeInTheDocument();
   });
 
-  it("renders a link to the teams page with the username", () => {
+  it("renders a link to the teams page with the username (single alt)", () => {
     renderTopbar();
     const link = screen.getByRole("link", { name: "ash_ketchum" });
     expect(link).toHaveAttribute("href", "/dashboard/alts/ash_ketchum/teams");
-  });
-
-  it("renders the filled count stat block", () => {
-    renderTopbar({ filledCount: 4 });
-    expect(screen.getByText("4/6")).toBeInTheDocument();
   });
 
   it("renders the Import button", () => {

--- a/apps/web/src/components/team-builder/v2/__tests__/use-builder-state.test.ts
+++ b/apps/web/src/components/team-builder/v2/__tests__/use-builder-state.test.ts
@@ -24,9 +24,9 @@ describe("useBuilderState — ephemeral state defaults", () => {
     expect(result.current.activeIdx).toBe(0);
   });
 
-  it("starts with drawer=null", () => {
+  it("starts with drawer='speed' (sideDrawer defaults to speed)", () => {
     const { result } = renderHook(() => useBuilderState());
-    expect(result.current.drawer).toBe(null);
+    expect(result.current.drawer).toBe("speed");
   });
 
   it("setActiveIdx updates the value", () => {
@@ -39,6 +39,10 @@ describe("useBuilderState — ephemeral state defaults", () => {
 
   it("setDrawer updates the drawer value", () => {
     const { result } = renderHook(() => useBuilderState());
+    // Clear sideDrawer first (default is "speed"), then set matchups via bottomDrawer
+    act(() => {
+      result.current.setDrawer(null);
+    });
     act(() => {
       result.current.setDrawer("matchups");
     });

--- a/apps/web/src/components/team-builder/v2/calc/calc-bottom-panel.tsx
+++ b/apps/web/src/components/team-builder/v2/calc/calc-bottom-panel.tsx
@@ -119,7 +119,7 @@ export function CalcBottomPanel({
         />
 
         {/* Defender stats */}
-        <div className="border-b border-dashed border-border px-2 py-1.5">
+        <div className="border-b border-dashed border-border px-3 py-1.5">
           <CalcDefenderStats
             defenderSpecies={effectiveDefenderSpecies}
             defenderNature={calc.defenderNature}
@@ -135,7 +135,7 @@ export function CalcBottomPanel({
         </div>
 
         {/* Defender moves */}
-        <div className="border-b border-dashed border-border p-2">
+        <div className="border-b border-dashed border-border px-3 py-2">
           <CalcDefenderMoves
             effectiveMoves={effectiveMoves}
             defenderSpecies={calc.defenderSpecies}

--- a/apps/web/src/components/team-builder/v2/calc/calc-bottom-panel.tsx
+++ b/apps/web/src/components/team-builder/v2/calc/calc-bottom-panel.tsx
@@ -131,6 +131,7 @@ export function CalcBottomPanel({
             setDefenderEv={calc.setDefenderEv}
             setDefenderBoost={calc.setDefenderBoost}
             setDefenderHpPercent={calc.setDefenderHpPercent}
+            setDefenderNature={calc.setDefenderNature}
           />
         </div>
 

--- a/apps/web/src/components/team-builder/v2/calc/calc-defender-header.tsx
+++ b/apps/web/src/components/team-builder/v2/calc/calc-defender-header.tsx
@@ -124,7 +124,7 @@ export function DefenderMonHeader({
   return (
     <div className="flex w-full flex-col border-b border-dashed border-border">
       {/* Sprite + Meta fields — centered together, fixed height to avoid layout shift */}
-      <div className="flex min-h-[160px] min-w-0 flex-row items-center justify-center gap-2 px-2.5 py-2">
+      <div className="flex min-h-[160px] min-w-0 flex-row items-center justify-center gap-2 px-3 py-2">
         {/* Sprite — left of form */}
         <div className="shrink-0">
           <Sprite

--- a/apps/web/src/components/team-builder/v2/calc/calc-defender-moves.tsx
+++ b/apps/web/src/components/team-builder/v2/calc/calc-defender-moves.tsx
@@ -56,7 +56,7 @@ function DefenderMoveTile({
   const moveType = moveData?.type ?? null;
 
   // Accuracy note
-  const accuracy =
+  const _accuracy =
     moveData?.accuracy === true || !moveData?.accuracy
       ? null
       : (moveData.accuracy as number);

--- a/apps/web/src/components/team-builder/v2/calc/calc-defender-stats.tsx
+++ b/apps/web/src/components/team-builder/v2/calc/calc-defender-stats.tsx
@@ -462,7 +462,7 @@ export function CalcDefenderStats({
           style={{ height: 6 }}
         />
         <span className="w-[72px] text-right font-mono text-[10px] text-muted-foreground">
-          {currentHP}/{maxHP} HP
+          {currentHP}/{maxHP}
         </span>
         <span className="w-8 text-right font-mono text-[10px] font-semibold text-muted-foreground">
           {defenderHpPercent}%

--- a/apps/web/src/components/team-builder/v2/calc/calc-defender-stats.tsx
+++ b/apps/web/src/components/team-builder/v2/calc/calc-defender-stats.tsx
@@ -179,7 +179,7 @@ function cycleNature(
 
   // Currently boosted → switch to reduced
   if (currentBoost === longStat) {
-    const boost = pickFreshPartner(longStat, null, DEFAULT_BOOST_FOR_REDUCE);
+    const boost = pickFreshPartner(longStat, currentReduce, DEFAULT_BOOST_FOR_REDUCE);
     return findNatureFor(boost, longStat);
   }
 

--- a/apps/web/src/components/team-builder/v2/calc/calc-defender-stats.tsx
+++ b/apps/web/src/components/team-builder/v2/calc/calc-defender-stats.tsx
@@ -446,7 +446,7 @@ export function CalcDefenderStats({
       </div>
 
       {/* ── HP% slider ────────────────────────────────────────────── */}
-      <div className="mt-1 flex items-center gap-2">
+      <div className="mt-1 flex items-center gap-2 px-1">
         <span className="w-5 font-mono text-[9.5px] font-semibold text-rose-500 dark:text-rose-400">
           HP
         </span>

--- a/apps/web/src/components/team-builder/v2/calc/calc-defender-stats.tsx
+++ b/apps/web/src/components/team-builder/v2/calc/calc-defender-stats.tsx
@@ -340,6 +340,7 @@ function DefenderStatRow({
         type="button"
         onClick={onNatureClick}
         disabled={statKey === "hp"}
+        aria-label={statKey !== "hp" ? `Cycle nature for ${label}` : undefined}
         className={cn(spreadLabelClass, statKey !== "hp" && "cursor-pointer hover:opacity-70")}
       >
         {label}

--- a/apps/web/src/components/team-builder/v2/calc/calc-defender-stats.tsx
+++ b/apps/web/src/components/team-builder/v2/calc/calc-defender-stats.tsx
@@ -446,7 +446,7 @@ export function CalcDefenderStats({
       </div>
 
       {/* ── HP% slider ────────────────────────────────────────────── */}
-      <div className="mt-1 flex items-center gap-2 px-1">
+      <div className="mt-2 flex items-center gap-2 px-2 pb-1">
         <span className="w-5 font-mono text-[9.5px] font-semibold text-rose-500 dark:text-rose-400">
           HP
         </span>

--- a/apps/web/src/components/team-builder/v2/calc/calc-defender-stats.tsx
+++ b/apps/web/src/components/team-builder/v2/calc/calc-defender-stats.tsx
@@ -343,13 +343,9 @@ function DefenderStatRow({
         className={cn(spreadLabelClass, statKey !== "hp" && "cursor-pointer hover:opacity-70")}
       >
         {label}
-        <span className="inline-block w-[9px] text-[9px] font-black tracking-tighter">
-          {isNatureBoosted && (
-            <span className="text-red-600 dark:text-red-400">▲</span>
-          )}
-          {isNatureReduced && (
-            <span className="text-sky-600 dark:text-sky-400">▽</span>
-          )}
+        <span className="inline-block w-[9px] text-[7px] leading-none">
+          {isNatureBoosted && "▲"}
+          {isNatureReduced && "▼"}
         </span>
       </button>
 

--- a/apps/web/src/components/team-builder/v2/calc/calc-defender-stats.tsx
+++ b/apps/web/src/components/team-builder/v2/calc/calc-defender-stats.tsx
@@ -29,9 +29,9 @@ import {
 } from "../../calc-stat-helpers";
 import { StatBumpsOverlay, StatVizBar } from "../stat-viz-bar";
 import { StageDropdown } from "./stage-dropdown";
-const spreadRowClass = "grid grid-cols-[32px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_36px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted";
-const spreadRowWithStageClass = "grid grid-cols-[32px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_32px_36px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted";
-const spreadLabelClass = "text-[9.5px] font-semibold uppercase tracking-[0.06em] font-mono text-left whitespace-nowrap overflow-hidden flex items-center gap-px";
+const spreadRowClass = "grid grid-cols-[40px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_36px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted";
+const spreadRowWithStageClass = "grid grid-cols-[40px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_32px_36px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted";
+const spreadLabelClass = "text-[9.5px] font-semibold uppercase tracking-[0.06em] font-mono text-left whitespace-nowrap flex items-center gap-px";
 const spreadBaseClass = "font-mono text-[9.5px] text-muted-foreground text-right tabular-nums";
 const spreadSliderWrapClass = "relative h-3.5";
 const spreadSliderTrackClass = "absolute top-1/2 left-0 right-0 h-[3px] bg-muted-foreground/40 rounded-full -translate-y-1/2 pointer-events-none";
@@ -53,6 +53,7 @@ export interface CalcDefenderStatsProps {
   setDefenderEv: (stat: keyof DefenderEvs, v: number) => void;
   setDefenderBoost: (stat: keyof DefenderBoosts, v: number) => void;
   setDefenderHpPercent: (v: number) => void;
+  setDefenderNature: (v: string) => void;
 }
 
 // =============================================================================
@@ -95,6 +96,109 @@ function totalDefenderEvs(evs: DefenderEvs): number {
 }
 
 // =============================================================================
+// Nature cycling helpers
+// =============================================================================
+
+type NatureStat =
+  | "attack"
+  | "defense"
+  | "specialAttack"
+  | "specialDefense"
+  | "speed";
+
+const SHORT_TO_LONG: Record<string, NatureStat> = {
+  atk: "attack",
+  def: "defense",
+  spa: "specialAttack",
+  spd: "specialDefense",
+  spe: "speed",
+};
+
+/** Default − stat when user clicks to boost. */
+const DEFAULT_REDUCE_FOR_BOOST: Record<NatureStat, NatureStat> = {
+  attack: "specialAttack",
+  defense: "specialAttack",
+  specialAttack: "attack",
+  specialDefense: "attack",
+  speed: "specialAttack",
+};
+
+/** Default + stat when user clicks to reduce. */
+const DEFAULT_BOOST_FOR_REDUCE: Record<NatureStat, NatureStat> = {
+  attack: "specialAttack",
+  defense: "specialAttack",
+  specialAttack: "attack",
+  specialDefense: "attack",
+  speed: "attack",
+};
+
+const ALL_NATURE_STATS: NatureStat[] = [
+  "attack",
+  "defense",
+  "specialAttack",
+  "specialDefense",
+  "speed",
+];
+
+const NEUTRAL_NATURE = "Serious";
+
+function findNatureFor(boost: NatureStat, reduce: NatureStat): string | null {
+  for (const [name, eff] of Object.entries(NATURE_EFFECTS)) {
+    if (eff.boost === boost && eff.reduce === reduce) return name;
+  }
+  return null;
+}
+
+function pickFreshPartner(
+  mover: NatureStat,
+  avoid: NatureStat | null,
+  defaults: Record<NatureStat, NatureStat>
+): NatureStat {
+  const def = defaults[mover];
+  if (def !== avoid) return def;
+  return ALL_NATURE_STATS.find((s) => s !== mover && s !== avoid) ?? def;
+}
+
+/**
+ * Cycle a stat's nature influence on click:
+ * neutral → boosted → reduced → neutral
+ *
+ * HP cannot have nature effects — returns null (no change).
+ */
+function cycleNature(
+  currentNature: string,
+  statKey: string
+): string | null {
+  if (statKey === "hp") return null;
+  const longStat = SHORT_TO_LONG[statKey] ?? (statKey as NatureStat);
+  if (!ALL_NATURE_STATS.includes(longStat)) return null;
+
+  const current = NATURE_EFFECTS[currentNature] ?? {};
+  const currentBoost = current.boost ?? null;
+  const currentReduce = current.reduce ?? null;
+
+  // Currently boosted → switch to reduced
+  if (currentBoost === longStat) {
+    const boost = pickFreshPartner(longStat, null, DEFAULT_BOOST_FOR_REDUCE);
+    return findNatureFor(boost, longStat);
+  }
+
+  // Currently reduced → switch to neutral
+  if (currentReduce === longStat) {
+    return NEUTRAL_NATURE;
+  }
+
+  // Currently neutral → switch to boosted
+  let reduce: NatureStat;
+  if (currentReduce && currentReduce !== longStat) {
+    reduce = currentReduce;
+  } else {
+    reduce = pickFreshPartner(longStat, currentBoost, DEFAULT_REDUCE_FOR_BOOST);
+  }
+  return findNatureFor(longStat, reduce);
+}
+
+// =============================================================================
 // DefenderStatRow — one horizontal stat row
 // =============================================================================
 
@@ -119,6 +223,7 @@ interface DefenderStatRowProps {
   boost: number;
   setDefenderEv: (stat: keyof DefenderEvs, v: number) => void;
   setDefenderBoost: (stat: keyof DefenderBoosts, v: number) => void;
+  onNatureClick: () => void;
 }
 
 function DefenderStatRow({
@@ -140,6 +245,7 @@ function DefenderStatRow({
   boost,
   setDefenderEv,
   setDefenderBoost,
+  onNatureClick,
 }: DefenderStatRowProps) {
   const colorClass = STAT_COLOR_CLASS[statKey as keyof typeof STAT_COLOR_CLASS] ?? "";
 
@@ -229,20 +335,23 @@ function DefenderStatRow({
         colorClass
       )}
     >
-      {/* Col 1: Stat label */}
-      <span className={spreadLabelClass}>
+      {/* Col 1: Stat label — clickable to cycle nature */}
+      <button
+        type="button"
+        onClick={onNatureClick}
+        disabled={statKey === "hp"}
+        className={cn(spreadLabelClass, statKey !== "hp" && "cursor-pointer hover:opacity-70")}
+      >
         {label}
-        {isNatureBoosted && (
-          <span className="text-[9px] font-black tracking-tighter text-red-600 dark:text-red-400">
-            ▲
-          </span>
-        )}
-        {isNatureReduced && (
-          <span className="text-[9px] font-black tracking-tighter text-sky-600 dark:text-sky-400">
-            ▽
-          </span>
-        )}
-      </span>
+        <span className="inline-block w-[9px] text-[9px] font-black tracking-tighter">
+          {isNatureBoosted && (
+            <span className="text-red-600 dark:text-red-400">▲</span>
+          )}
+          {isNatureReduced && (
+            <span className="text-sky-600 dark:text-sky-400">▽</span>
+          )}
+        </span>
+      </button>
 
       {/* Col 2: Base stat */}
       <span className={spreadBaseClass}>{base}</span>
@@ -338,6 +447,7 @@ export function CalcDefenderStats({
   setDefenderEv,
   setDefenderBoost,
   setDefenderHpPercent,
+  setDefenderNature,
 }: CalcDefenderStatsProps) {
   const isChampions = isChampionsFormat(format);
 
@@ -440,6 +550,10 @@ export function CalcDefenderStats({
               boost={boost}
               setDefenderEv={setDefenderEv}
               setDefenderBoost={setDefenderBoost}
+              onNatureClick={() => {
+                const newNature = cycleNature(nature, row.evKey);
+                if (newNature) setDefenderNature(newNature);
+              }}
             />
           );
         })}

--- a/apps/web/src/components/team-builder/v2/calc/calc-defender-stats.tsx
+++ b/apps/web/src/components/team-builder/v2/calc/calc-defender-stats.tsx
@@ -344,8 +344,8 @@ function DefenderStatRow({
       >
         {label}
         <span className="inline-block w-[9px] text-[7px] leading-none">
-          {isNatureBoosted && "▲"}
-          {isNatureReduced && "▼"}
+          {isNatureBoosted && "▴"}
+          {isNatureReduced && "▾"}
         </span>
       </button>
 

--- a/apps/web/src/components/team-builder/v2/calc/calc-drawer.tsx
+++ b/apps/web/src/components/team-builder/v2/calc/calc-drawer.tsx
@@ -162,33 +162,35 @@ function CalcDrawerContent({
         teammates={teammates}
       />
 
-      <CalcFieldBlock
-        gameType={calc.gameType}
-        setGameType={handleGameTypeChange}
-        attackerSide={calc.attackerSide}
-        setAttackerSide={calc.setAttackerSide}
-        defenderSide={calc.defenderSide}
-        setDefenderSide={calc.setDefenderSide}
-        field={{
-          weather: calc.weather,
-          terrain: calc.terrain,
-          gravity: calc.gravity,
-          fairyAura: calc.fairyAura,
-        }}
-        setField={{
-          setWeather: calc.setWeather,
-          setTerrain: calc.setTerrain,
-          setGravity: calc.setGravity,
-          setFairyAura: calc.setFairyAura,
-        }}
-        doubles={{ foesAlive: field.foesAlive, allyAlive: field.allyAlive }}
-        setDoubles={{
-          setFoesAlive: handleSetFoesAlive,
-          setAllyAlive: handleSetAllyAlive,
-        }}
-        fainted={{ yours: faintedYours, theirs: faintedTheirs }}
-        setFainted={{ setYours: setFaintedYours, setTheirs: setFaintedTheirs }}
-      />
+      <div className="px-3 py-2">
+        <CalcFieldBlock
+          gameType={calc.gameType}
+          setGameType={handleGameTypeChange}
+          attackerSide={calc.attackerSide}
+          setAttackerSide={calc.setAttackerSide}
+          defenderSide={calc.defenderSide}
+          setDefenderSide={calc.setDefenderSide}
+          field={{
+            weather: calc.weather,
+            terrain: calc.terrain,
+            gravity: calc.gravity,
+            fairyAura: calc.fairyAura,
+          }}
+          setField={{
+            setWeather: calc.setWeather,
+            setTerrain: calc.setTerrain,
+            setGravity: calc.setGravity,
+            setFairyAura: calc.setFairyAura,
+          }}
+          doubles={{ foesAlive: field.foesAlive, allyAlive: field.allyAlive }}
+          setDoubles={{
+            setFoesAlive: handleSetFoesAlive,
+            setAllyAlive: handleSetAllyAlive,
+          }}
+          fainted={{ yours: faintedYours, theirs: faintedTheirs }}
+          setFainted={{ setYours: setFaintedYours, setTheirs: setFaintedTheirs }}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/team-builder/v2/calc/calc-field-block.tsx
+++ b/apps/web/src/components/team-builder/v2/calc/calc-field-block.tsx
@@ -277,7 +277,7 @@ export function CalcFieldBlock({
       </div>
 
       {/* Conditions: weather, terrain, gravity, fairy aura */}
-      <fieldset className="rounded-lg border border-border/60 px-2.5 py-2">
+      <fieldset className="rounded-lg border border-border/60 px-3 py-2">
         <legend className="px-1 font-mono text-[9px] font-bold uppercase tracking-[0.12em] text-muted-foreground">
           Conditions
         </legend>
@@ -363,7 +363,7 @@ export function CalcFieldBlock({
       )}
 
       {/* Sides — mirrored Ours | Label | Theirs grid */}
-      <fieldset className="rounded-lg border border-border/60 px-2.5 py-2">
+      <fieldset className="rounded-lg border border-border/60 px-3 py-2">
         <legend className="px-1 font-mono text-[9px] font-bold uppercase tracking-[0.12em] text-muted-foreground">
           Sides
         </legend>

--- a/apps/web/src/components/team-builder/v2/calc/calc-field-block.tsx
+++ b/apps/web/src/components/team-builder/v2/calc/calc-field-block.tsx
@@ -187,11 +187,11 @@ function SideSwitchRow({
   return (
     <>
       <div className="flex justify-end">
-        <Switch size="sm" checked={yours} onCheckedChange={onToggleYours} />
+        <Switch size="sm" checked={yours} onCheckedChange={onToggleYours} aria-label={`${label} (ours)`} />
       </div>
       <span className="text-center text-[11px]">{label}</span>
       <div className="flex justify-start">
-        <Switch size="sm" checked={theirs} onCheckedChange={onToggleTheirs} />
+        <Switch size="sm" checked={theirs} onCheckedChange={onToggleTheirs} aria-label={`${label} (theirs)`} />
       </div>
     </>
   );

--- a/apps/web/src/components/team-builder/v2/calc/calc-field-block.tsx
+++ b/apps/web/src/components/team-builder/v2/calc/calc-field-block.tsx
@@ -168,73 +168,43 @@ function ToggleBtn({ active, onClick, children }: ToggleBtnProps) {
 }
 
 // =============================================================================
-// SideColumn — one column within the combined Sides card
+// SideMirrorRow — a single row in the mirrored Ours | Label | Theirs grid
 // =============================================================================
 
-interface SideColumnProps {
-  title: "Yours" | "Theirs";
-  color: "primary" | "destructive";
-  side: BaseSideState;
-  onUpdate: (patch: Partial<BaseSideState>) => void;
-  fainted: number;
-  setFainted: (n: number) => void;
-}
-
-function SideRow({ label, active, onToggle }: { label: string; active: boolean; onToggle: () => void }) {
+function SideSwitchRow({
+  label,
+  yours,
+  theirs,
+  onToggleYours,
+  onToggleTheirs,
+}: {
+  label: string;
+  yours: boolean;
+  theirs: boolean;
+  onToggleYours: () => void;
+  onToggleTheirs: () => void;
+}) {
   return (
-    <div className="flex items-center justify-between">
-      <span className="text-xs text-foreground">{label}</span>
-      <Switch checked={active} onCheckedChange={onToggle} />
-    </div>
+    <>
+      <div className="flex justify-end">
+        <Switch size="sm" checked={yours} onCheckedChange={onToggleYours} />
+      </div>
+      <span className="text-center text-[11px]">{label}</span>
+      <div className="flex justify-start">
+        <Switch size="sm" checked={theirs} onCheckedChange={onToggleTheirs} />
+      </div>
+    </>
   );
 }
 
-function SideColumn({ title, color, side, onUpdate, fainted, setFainted }: SideColumnProps) {
+function SideSectionLabel({ label }: { label: string }) {
   return (
-    <div className="flex flex-col gap-1.5">
-      <div
-        className={cn(
-          "font-mono text-[9px] font-bold uppercase tracking-[0.12em]",
-          color === "primary" ? "text-primary" : "text-destructive"
-        )}
-      >
-        {title}
-      </div>
-
-      {/* Boosts */}
-      <SideRow label="Helping Hand" active={side.helpingHand} onToggle={() => onUpdate({ helpingHand: !side.helpingHand })} />
-      <SideRow label="Friend Guard" active={side.friendGuard} onToggle={() => onUpdate({ friendGuard: !side.friendGuard })} />
-      <SideRow label="Salt Cure" active={side.saltCure} onToggle={() => onUpdate({ saltCure: !side.saltCure })} />
-      <div className="flex items-center justify-between">
-        <span className="text-xs text-foreground">Knocked Out</span>
-        <Stepper<(typeof FAINTED_OPTIONS)[number]>
-          options={FAINTED_OPTIONS}
-          value={fainted as (typeof FAINTED_OPTIONS)[number]}
-          onChange={setFainted}
-        />
-      </div>
-
-      {/* Screens */}
-      <div className="flex flex-col gap-1">
-        <span className="font-mono text-[8.5px] uppercase tracking-wide text-muted-foreground/70">Screens</span>
-        <SideRow label="Reflect" active={side.reflect} onToggle={() => onUpdate({ reflect: !side.reflect })} />
-        <SideRow label="Light Screen" active={side.lightScreen} onToggle={() => onUpdate({ lightScreen: !side.lightScreen })} />
-        <SideRow label="Aurora Veil" active={side.auroraVeil} onToggle={() => onUpdate({ auroraVeil: !side.auroraVeil })} />
-      </div>
-
-      {/* Hazards */}
-      <div className="flex flex-col gap-1">
-        <span className="font-mono text-[8.5px] uppercase tracking-wide text-muted-foreground/70">Hazards</span>
-        <SideRow label="Stealth Rock" active={side.stealthRock} onToggle={() => onUpdate({ stealthRock: !side.stealthRock })} />
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-foreground">Spikes</span>
-          <Stepper<0 | 1 | 2 | 3>
-            options={[0, 1, 2, 3] as const}
-            value={side.spikes}
-            onChange={(v) => onUpdate({ spikes: v })}
-          />
-        </div>
-      </div>
+    <div className="col-span-3 flex items-center gap-2 pt-1">
+      <div className="flex-1 border-t border-dashed border-border/40" />
+      <span className="font-mono text-[8.5px] uppercase tracking-wide text-muted-foreground/70">
+        {label}
+      </span>
+      <div className="flex-1 border-t border-dashed border-border/40" />
     </div>
   );
 }
@@ -392,29 +362,111 @@ export function CalcFieldBlock({
         </div>
       )}
 
-      {/* Sides — stacked vertically */}
+      {/* Sides — mirrored Ours | Label | Theirs grid */}
       <fieldset className="rounded-lg border border-border/60 px-2.5 py-2">
         <legend className="px-1 font-mono text-[9px] font-bold uppercase tracking-[0.12em] text-muted-foreground">
           Sides
         </legend>
-        <div className="flex flex-col gap-4">
-          <SideColumn
-            title="Yours"
-            color="primary"
-            side={attackerSide}
-            onUpdate={setAttackerSide}
-            fainted={faintedYours}
-            setFainted={setFaintedYours}
+        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-x-1 gap-y-0.5">
+          {/* Header */}
+          <span className="text-muted-foreground text-right text-[10px] font-semibold uppercase tracking-wider">
+            Ours
+          </span>
+          <span />
+          <span className="text-muted-foreground text-[10px] font-semibold uppercase tracking-wider">
+            Theirs
+          </span>
+
+          {/* Boosts */}
+          <SideSwitchRow
+            label="Helping Hand"
+            yours={attackerSide.helpingHand}
+            theirs={defenderSide.helpingHand}
+            onToggleYours={() => setAttackerSide({ helpingHand: !attackerSide.helpingHand })}
+            onToggleTheirs={() => setDefenderSide({ helpingHand: !defenderSide.helpingHand })}
           />
-          <div className="border-t border-border/40" />
-          <SideColumn
-            title="Theirs"
-            color="destructive"
-            side={defenderSide}
-            onUpdate={setDefenderSide}
-            fainted={faintedTheirs}
-            setFainted={setFaintedTheirs}
+          <SideSwitchRow
+            label="Friend Guard"
+            yours={attackerSide.friendGuard}
+            theirs={defenderSide.friendGuard}
+            onToggleYours={() => setAttackerSide({ friendGuard: !attackerSide.friendGuard })}
+            onToggleTheirs={() => setDefenderSide({ friendGuard: !defenderSide.friendGuard })}
           />
+          <SideSwitchRow
+            label="Salt Cure"
+            yours={attackerSide.saltCure}
+            theirs={defenderSide.saltCure}
+            onToggleYours={() => setAttackerSide({ saltCure: !attackerSide.saltCure })}
+            onToggleTheirs={() => setDefenderSide({ saltCure: !defenderSide.saltCure })}
+          />
+
+          {/* Knocked Out */}
+          <div className="flex justify-end">
+            <Stepper<(typeof FAINTED_OPTIONS)[number]>
+              options={FAINTED_OPTIONS}
+              value={faintedYours as (typeof FAINTED_OPTIONS)[number]}
+              onChange={setFaintedYours}
+            />
+          </div>
+          <span className="text-center text-[11px]">Knocked Out</span>
+          <div className="flex justify-start">
+            <Stepper<(typeof FAINTED_OPTIONS)[number]>
+              options={FAINTED_OPTIONS}
+              value={faintedTheirs as (typeof FAINTED_OPTIONS)[number]}
+              onChange={setFaintedTheirs}
+            />
+          </div>
+
+          {/* Screens */}
+          <SideSectionLabel label="Screens" />
+          <SideSwitchRow
+            label="Reflect"
+            yours={attackerSide.reflect}
+            theirs={defenderSide.reflect}
+            onToggleYours={() => setAttackerSide({ reflect: !attackerSide.reflect })}
+            onToggleTheirs={() => setDefenderSide({ reflect: !defenderSide.reflect })}
+          />
+          <SideSwitchRow
+            label="Light Screen"
+            yours={attackerSide.lightScreen}
+            theirs={defenderSide.lightScreen}
+            onToggleYours={() => setAttackerSide({ lightScreen: !attackerSide.lightScreen })}
+            onToggleTheirs={() => setDefenderSide({ lightScreen: !defenderSide.lightScreen })}
+          />
+          <SideSwitchRow
+            label="Aurora Veil"
+            yours={attackerSide.auroraVeil}
+            theirs={defenderSide.auroraVeil}
+            onToggleYours={() => setAttackerSide({ auroraVeil: !attackerSide.auroraVeil })}
+            onToggleTheirs={() => setDefenderSide({ auroraVeil: !defenderSide.auroraVeil })}
+          />
+
+          {/* Hazards */}
+          <SideSectionLabel label="Hazards" />
+          <SideSwitchRow
+            label="Stealth Rock"
+            yours={attackerSide.stealthRock}
+            theirs={defenderSide.stealthRock}
+            onToggleYours={() => setAttackerSide({ stealthRock: !attackerSide.stealthRock })}
+            onToggleTheirs={() => setDefenderSide({ stealthRock: !defenderSide.stealthRock })}
+          />
+
+          {/* Spikes */}
+          <div className="flex justify-end">
+            <Stepper<0 | 1 | 2 | 3>
+              options={[0, 1, 2, 3] as const}
+              value={attackerSide.spikes}
+              onChange={(v) => setAttackerSide({ spikes: v })}
+            />
+          </div>
+          <span className="text-center text-[11px]">Spikes</span>
+          <div className="flex justify-start">
+            <Stepper<0 | 1 | 2 | 3>
+              options={[0, 1, 2, 3] as const}
+              value={defenderSide.spikes}
+              onChange={(v) => setDefenderSide({ spikes: v })}
+            />
+          </div>
         </div>
       </fieldset>
     </div>

--- a/apps/web/src/components/team-builder/v2/dock/dockbar.tsx
+++ b/apps/web/src/components/team-builder/v2/dock/dockbar.tsx
@@ -96,7 +96,7 @@ export function Dockbar({
   onOpen,
   sideDrawer,
   bottomDrawer,
-  fastest,
+  fastest: _fastest,
   defenderSpecies,
   moveCalcOutputs,
 }: DockbarProps) {
@@ -106,7 +106,7 @@ export function Dockbar({
   const isSpeedActive = sideDrawer !== undefined ? sideDrawer === "speed" : drawer === "speed";
   const isCalcActive = sideDrawer !== undefined ? sideDrawer === "calc" : drawer === "calc";
 
-  const calcVerdict = getWorstCaseVerdict(moveCalcOutputs);
+  const _calcVerdict = getWorstCaseVerdict(moveCalcOutputs);
   const calcSubLabel = defenderSpecies
     ? `vs ${defenderSpecies}`
     : "no target";

--- a/apps/web/src/components/team-builder/v2/dock/heatmap-panel.tsx
+++ b/apps/web/src/components/team-builder/v2/dock/heatmap-panel.tsx
@@ -189,7 +189,7 @@ function cellClass(mult: number, mode: CoverageMode): string {
 }
 
 // 3-letter type abbreviations for column headers
-const TYPE_ABBR: Record<PokemonType, string> = {
+const _TYPE_ABBR: Record<PokemonType, string> = {
   Normal: "NOR",
   Fire: "FIR",
   Water: "WAT",

--- a/apps/web/src/components/team-builder/v2/dock/speed-tiers-panel.tsx
+++ b/apps/web/src/components/team-builder/v2/dock/speed-tiers-panel.tsx
@@ -53,6 +53,8 @@ interface SideModifiers {
   unburden: boolean;
   stage: number;
   status: "healthy" | "paralyzed";
+  /** Custom EV override (0-252 for VGC, 0-32 for Champions). null = use defaults. */
+  evs: number | null;
 }
 
 type SortDir = "desc" | "asc";
@@ -100,6 +102,7 @@ const DEFAULT_YOURS: SideModifiers = {
   unburden: false,
   stage: 0,
   status: "healthy",
+  evs: null,
 };
 
 const DEFAULT_THEIRS: SideModifiers = {
@@ -108,6 +111,7 @@ const DEFAULT_THEIRS: SideModifiers = {
   unburden: false,
   stage: 0,
   status: "healthy",
+  evs: null,
 };
 
 const DEFAULT_TOGGLE: ToggleState = {
@@ -287,6 +291,7 @@ function teamMonToScored(
 /**
  * Score a meta mon — compute min (0 EVs, -nature) and max (max EVs, +nature)
  * speeds with THEIRS modifiers applied.
+ * When custom EVs are set, all three columns use that EV value with different natures.
  */
 function metaToScored(
   entry: MetaSpeedEntry,
@@ -295,17 +300,23 @@ function metaToScored(
 ): ScoredMon {
   const champions = isChampionsFormat(format);
   const b = entry.base;
+  const customEvs = toggle.theirs.evs;
 
   // Compute raw min/neutral/max stat values
+  // If custom EVs are set, all three columns use that EV with -/neutral/+ nature
+  const minEvs = customEvs ?? 0;
+  const neutralEvs = customEvs ?? (champions ? 32 : 252);
+  const maxEvs = customEvs ?? (champions ? 32 : 252);
+
   const rawMin = champions
-    ? calculateChampionsStat(b, 0, 0.9)
-    : calculateStat(b, 31, 0, 50, 0.9);
+    ? calculateChampionsStat(b, minEvs, 0.9)
+    : calculateStat(b, 31, minEvs, 50, 0.9);
   const rawNeutral = champions
-    ? calculateChampionsStat(b, 32, 1.0)
-    : calculateStat(b, 31, 252, 50, 1.0);
+    ? calculateChampionsStat(b, neutralEvs, 1.0)
+    : calculateStat(b, 31, neutralEvs, 50, 1.0);
   const rawMax = champions
-    ? calculateChampionsStat(b, 32, 1.1)
-    : calculateStat(b, 31, 252, 50, 1.1);
+    ? calculateChampionsStat(b, maxEvs, 1.1)
+    : calculateStat(b, 31, maxEvs, 50, 1.1);
 
   // Apply THEIRS modifiers to all three
   const theirsMods = buildSpeedMods(toggle.theirs, toggle.weather, entry.speedAbility);
@@ -765,6 +776,68 @@ export function SpeedTiersPanel({
                     setToggle((prev) => ({
                       ...prev,
                       theirs: { ...prev.theirs, stage: prev.theirs.stage + 1 },
+                    }))
+                  }
+                  className="hover:bg-muted text-foreground flex items-center justify-center text-xs disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  +
+                </button>
+              </div>
+            </div>
+
+            {/* EVs — only theirs side has input, ours is empty */}
+            <div />
+            <span className="text-center text-[11px]">EVs</span>
+            <div className="flex justify-start">
+              <div className="bg-card grid grid-cols-[20px_40px_20px] overflow-hidden rounded-md border">
+                <button
+                  type="button"
+                  disabled={toggle.theirs.evs === null || toggle.theirs.evs <= 0}
+                  onClick={() =>
+                    setToggle((prev) => ({
+                      ...prev,
+                      theirs: {
+                        ...prev.theirs,
+                        evs: Math.max(0, (prev.theirs.evs ?? maxEv) - 4),
+                      },
+                    }))
+                  }
+                  className="hover:bg-muted text-foreground flex items-center justify-center text-xs disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  −
+                </button>
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  value={toggle.theirs.evs ?? ""}
+                  placeholder={String(maxEv)}
+                  onChange={(e) => {
+                    const raw = e.target.value.replace(/[^0-9]/g, "");
+                    if (raw === "") {
+                      setToggle((prev) => ({
+                        ...prev,
+                        theirs: { ...prev.theirs, evs: null },
+                      }));
+                      return;
+                    }
+                    const val = Math.min(maxEv, Math.max(0, Number(raw)));
+                    setToggle((prev) => ({
+                      ...prev,
+                      theirs: { ...prev.theirs, evs: val },
+                    }));
+                  }}
+                  className="text-foreground bg-transparent text-center font-mono text-[10px] font-semibold outline-none w-full [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                />
+                <button
+                  type="button"
+                  disabled={toggle.theirs.evs !== null && toggle.theirs.evs >= maxEv}
+                  onClick={() =>
+                    setToggle((prev) => ({
+                      ...prev,
+                      theirs: {
+                        ...prev.theirs,
+                        evs: Math.min(maxEv, (prev.theirs.evs ?? maxEv) + 4),
+                      },
                     }))
                   }
                   className="hover:bg-muted text-foreground flex items-center justify-center text-xs disabled:cursor-not-allowed disabled:opacity-40"

--- a/apps/web/src/components/team-builder/v2/dock/speed-tiers-panel.tsx
+++ b/apps/web/src/components/team-builder/v2/dock/speed-tiers-panel.tsx
@@ -570,7 +570,10 @@ export function SpeedTiersPanel({
     }));
   }
 
-  const maxEv = isChampionsFormat(format) ? 32 : 252;
+  const champions = isChampionsFormat(format);
+  const maxEv = champions ? 32 : 252;
+  const evStep = champions ? 1 : 4;
+  const evLabel = champions ? "SP" : "EVs";
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -787,18 +790,19 @@ export function SpeedTiersPanel({
 
             {/* EVs — only theirs side has input, ours is empty */}
             <div />
-            <span className="text-center text-[11px]">EVs</span>
+            <span className="text-center text-[11px]">{evLabel}</span>
             <div className="flex justify-start">
               <div className="bg-card grid grid-cols-[20px_40px_20px] overflow-hidden rounded-md border">
                 <button
                   type="button"
+                  aria-label={`Decrease speed ${evLabel}`}
                   disabled={toggle.theirs.evs === null || toggle.theirs.evs <= 0}
                   onClick={() =>
                     setToggle((prev) => ({
                       ...prev,
                       theirs: {
                         ...prev.theirs,
-                        evs: Math.max(0, (prev.theirs.evs ?? maxEv) - 4),
+                        evs: Math.max(0, (prev.theirs.evs ?? maxEv) - evStep),
                       },
                     }))
                   }
@@ -809,6 +813,7 @@ export function SpeedTiersPanel({
                 <input
                   type="text"
                   inputMode="numeric"
+                  aria-label={`Speed ${evLabel} override`}
                   value={toggle.theirs.evs ?? ""}
                   placeholder={String(maxEv)}
                   onChange={(e) => {
@@ -830,13 +835,14 @@ export function SpeedTiersPanel({
                 />
                 <button
                   type="button"
+                  aria-label={`Increase speed ${evLabel}`}
                   disabled={toggle.theirs.evs !== null && toggle.theirs.evs >= maxEv}
                   onClick={() =>
                     setToggle((prev) => ({
                       ...prev,
                       theirs: {
                         ...prev.theirs,
-                        evs: Math.min(maxEv, (prev.theirs.evs ?? maxEv) + 4),
+                        evs: Math.min(maxEv, (prev.theirs.evs ?? maxEv) + evStep),
                       },
                     }))
                   }

--- a/apps/web/src/components/team-builder/v2/dock/speed-tiers-panel.tsx
+++ b/apps/web/src/components/team-builder/v2/dock/speed-tiers-panel.tsx
@@ -134,6 +134,12 @@ const WEATHER_LABELS: Record<Weather, string> = {
 const STAGE_MIN = -6;
 const STAGE_MAX = 6;
 
+/**
+ * Sentinel for the render-time state-reset pattern (see react-patterns.md).
+ * Module-scoped so its identity is stable across renders.
+ */
+const UNINITIALIZED_FORMAT_ID = Symbol("uninitialized-format-id");
+
 const SPEED_ABILITY_LOOKUP: Partial<Record<string, SpeedAbility>> = {
   Chlorophyll: "chlorophyll",
   "Swift Swim": "swift-swim",
@@ -505,6 +511,36 @@ export function SpeedTiersPanel({
   format,
 }: SpeedTiersPanelProps) {
   const [toggle, setToggle] = useState<ToggleState>(DEFAULT_TOGGLE);
+  const [prevFormatId, setPrevFormatId] = useState<
+    string | undefined | typeof UNINITIALIZED_FORMAT_ID
+  >(UNINITIALIZED_FORMAT_ID);
+
+  // Format can change (user switches VGC → Champions). Different formats have
+  // different max EVs (VGC 252 vs Champions 32), so a stale 100-EV override
+  // would otherwise pass out-of-range to calculateChampionsStat. Clamp on
+  // change using the render-time sentinel pattern from react-patterns.md.
+  const currentFormatId = format?.id;
+  if (currentFormatId !== prevFormatId) {
+    setPrevFormatId(currentFormatId);
+    if (format) {
+      const newMaxEv = isChampionsFormat(format) ? 32 : 252;
+      setToggle((prev) => {
+        const yoursEvs = prev.yours.evs;
+        const theirsEvs = prev.theirs.evs;
+        const clampedYours =
+          yoursEvs != null && yoursEvs > newMaxEv ? newMaxEv : yoursEvs;
+        const clampedTheirs =
+          theirsEvs != null && theirsEvs > newMaxEv ? newMaxEv : theirsEvs;
+        if (clampedYours === yoursEvs && clampedTheirs === theirsEvs)
+          return prev;
+        return {
+          ...prev,
+          yours: { ...prev.yours, evs: clampedYours },
+          theirs: { ...prev.theirs, evs: clampedTheirs },
+        };
+      });
+    }
+  }
 
   if (!format) {
     return (

--- a/apps/web/src/components/team-builder/v2/lanes/active-row.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/active-row.tsx
@@ -140,7 +140,10 @@ export function ActiveRow({
       )}
       style={borderColor ? {
         borderColor,
-        boxShadow: `0 0 0 1px ${borderColor}33, 0 8px 28px -16px ${borderColor}66`,
+        boxShadow: [
+          `0 0 0 1px color-mix(in oklch, ${borderColor} 20%, transparent)`,
+          `0 8px 28px -16px color-mix(in oklch, ${borderColor} 40%, transparent)`,
+        ].join(", "),
       } : undefined}
     >
       {/* RIB LEFT — slot number + drag handle */}

--- a/apps/web/src/components/team-builder/v2/lanes/calc-reverse-card.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/calc-reverse-card.tsx
@@ -92,21 +92,24 @@ export function CalcReverseColumn({ pokemon, teammates }: CalcReverseColumnProps
                 <Tooltip key={i}>
                   <TooltipTrigger
                     render={
-                      <button
-                        type="button"
-                        aria-label={m.hasCalc && m.desc ? `Copy damage calc for ${m.moveName}` : undefined}
-                        className={cn(
-                          "flex items-center gap-1 py-px",
-                          m.hasCalc && m.desc && "cursor-pointer hover:bg-muted/50 rounded"
-                        )}
-                        onClick={() => {
-                          if (m.hasCalc && m.desc) {
-                            navigator.clipboard.writeText(m.desc).catch(() => {
+                      m.hasCalc && m.desc ? (
+                        <button
+                          type="button"
+                          aria-label={`Copy damage calc for ${m.moveName}`}
+                          className="flex items-center gap-1 py-px cursor-pointer hover:bg-muted/50 rounded"
+                          onClick={async () => {
+                            try {
+                              await navigator.clipboard.writeText(m.desc!);
+                            } catch {
                               toast.error("Couldn't copy to clipboard");
-                            });
-                          }
-                        }}
-                      />
+                            }
+                          }}
+                        />
+                      ) : (
+                        <span
+                          className="flex items-center gap-1 py-px"
+                        />
+                      )
                     }
                   >
                     {/* Bullet + Type icon */}
@@ -185,19 +188,24 @@ export function CalcReverseColumn({ pokemon, teammates }: CalcReverseColumnProps
           <Tooltip key={i}>
             <TooltipTrigger
               render={
-                <button
-                  type="button"
-                  aria-label={m.hasCalc && m.desc ? `Copy damage calc for ${m.moveName}` : undefined}
-                  className={cn(
-                    "flex items-center shrink-0",
-                    m.hasCalc && m.desc && "cursor-pointer hover:bg-muted/50 rounded"
-                  )}
-                  onClick={() => {
-                    if (m.hasCalc && m.desc) {
-                      void navigator.clipboard.writeText(m.desc);
-                    }
-                  }}
-                />
+                m.hasCalc && m.desc ? (
+                  <button
+                    type="button"
+                    aria-label={`Copy damage calc for ${m.moveName}`}
+                    className="flex items-center shrink-0 cursor-pointer hover:bg-muted/50 rounded"
+                    onClick={async () => {
+                      try {
+                        await navigator.clipboard.writeText(m.desc!);
+                      } catch {
+                        toast.error("Couldn't copy to clipboard");
+                      }
+                    }}
+                  />
+                ) : (
+                  <span
+                    className="flex items-center shrink-0"
+                  />
+                )
               }
             >
             {/* Bullet separator */}

--- a/apps/web/src/components/team-builder/v2/lanes/calc-reverse-card.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/calc-reverse-card.tsx
@@ -10,7 +10,6 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 
 import { useCalcStateContext } from "../calc/calc-state-context";
 import { useDefenderMoves } from "../calc/use-defender-moves";
-import { type CalcOutput } from "../../use-calc-state";
 import { TypeSymbolIcon } from "../../type-symbol-icon";
 import { getDisplayRangeAndKoTier } from "./calc-display-helpers";
 import { useTeamLayoutMode } from "../use-team-layout";

--- a/apps/web/src/components/team-builder/v2/lanes/calc-reverse-card.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/calc-reverse-card.tsx
@@ -90,14 +90,16 @@ export function CalcReverseColumn({ pokemon, teammates }: CalcReverseColumnProps
                 <Tooltip key={i}>
                   <TooltipTrigger
                     render={
-                      <div
+                      <button
+                        type="button"
+                        aria-label={m.hasCalc && m.desc ? `Copy damage calc for ${m.moveName}` : undefined}
                         className={cn(
                           "flex items-center gap-1 py-px",
                           m.hasCalc && m.desc && "cursor-pointer hover:bg-muted/50 rounded"
                         )}
                         onClick={() => {
                           if (m.hasCalc && m.desc) {
-                            navigator.clipboard.writeText(m.desc);
+                            void navigator.clipboard.writeText(m.desc);
                           }
                         }}
                       />
@@ -179,14 +181,16 @@ export function CalcReverseColumn({ pokemon, teammates }: CalcReverseColumnProps
           <Tooltip key={i}>
             <TooltipTrigger
               render={
-                <div
+                <button
+                  type="button"
+                  aria-label={m.hasCalc && m.desc ? `Copy damage calc for ${m.moveName}` : undefined}
                   className={cn(
                     "flex items-center shrink-0",
                     m.hasCalc && m.desc && "cursor-pointer hover:bg-muted/50 rounded"
                   )}
                   onClick={() => {
                     if (m.hasCalc && m.desc) {
-                      navigator.clipboard.writeText(m.desc);
+                      void navigator.clipboard.writeText(m.desc);
                     }
                   }}
                 />

--- a/apps/web/src/components/team-builder/v2/lanes/calc-reverse-card.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/calc-reverse-card.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { toast } from "sonner";
+
 import { getMoveData } from "@trainers/pokemon";
 import { type Tables } from "@trainers/supabase";
 
@@ -99,7 +101,9 @@ export function CalcReverseColumn({ pokemon, teammates }: CalcReverseColumnProps
                         )}
                         onClick={() => {
                           if (m.hasCalc && m.desc) {
-                            void navigator.clipboard.writeText(m.desc);
+                            navigator.clipboard.writeText(m.desc).catch(() => {
+                              toast.error("Couldn't copy to clipboard");
+                            });
                           }
                         }}
                       />

--- a/apps/web/src/components/team-builder/v2/lanes/identity/cells/item-cell.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/identity/cells/item-cell.tsx
@@ -67,10 +67,15 @@ export function ItemCell({
     }
   };
 
+  const isMegaActive =
+    pokemon.species != null &&
+    pokemon.species !== getCanonicalBaseSpecies(pokemon.species);
+
   const megaChip = isMegaStone ? (
     <span
       role="button"
       tabIndex={0}
+      aria-pressed={isMegaActive}
       onClick={(e) => {
         e.stopPropagation();
         handleMegaToggle();

--- a/apps/web/src/components/team-builder/v2/lanes/identity/cells/type-cell.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/identity/cells/type-cell.tsx
@@ -5,7 +5,7 @@ import { type PokemonType } from "@trainers/pokemon";
 import { cn } from "@/lib/utils";
 
 import { TypePill } from "../../../type-pill";
-import { type CellVariant } from "./identity-cell-shared";
+import { cellClasses, type CellVariant } from "./identity-cell-shared";
 
 // =============================================================================
 // TypeCell — read-only display of the Pokémon's types in the form section
@@ -37,11 +37,9 @@ export function TypeCell({ types, variant }: TypeCellProps) {
 
   // variant === "grid" — MidStack / Vertical layout
   return (
-    <div className="grid w-full min-w-0 cursor-default grid-cols-[56px_minmax(0,1fr)] items-baseline gap-2 rounded-[5px] border-0 bg-transparent px-1.5 py-1 text-left transition-colors">
-      <span className="overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-muted-foreground">
-        TYPE
-      </span>
-      <span className="flex min-w-0 items-center gap-1 overflow-hidden text-ellipsis whitespace-nowrap text-xs text-foreground">
+    <div className={cn(cellClasses.midFormCell, "cursor-default hover:bg-transparent")}>
+      <span className={cellClasses.midFormLbl}>TYPE</span>
+      <span className={cn(cellClasses.midFormVal, "items-center")}>
         {types.length > 0 ? (
           types.map((t) => <TypePill key={t} t={t} size={18} />)
         ) : (

--- a/apps/web/src/components/team-builder/v2/lanes/identity/identity-lane-ghost.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/identity/identity-lane-ghost.tsx
@@ -211,12 +211,12 @@ function FormRowsGhost() {
         </div>
       ))}
       {/* Type row — two circle placeholders matching TypePill size */}
-      <div className={cn("grid grid-cols-[60px_minmax(0,1fr)] items-center gap-1.5 px-1 py-[3px] rounded cursor-pointer bg-transparent text-left w-full transition-colors hover:bg-muted", "cursor-default")}>
+      <div className={cn("grid grid-cols-[60px_minmax(0,1fr)] items-center gap-1.5 px-1 py-[3px] rounded cursor-pointer bg-transparent text-left w-full transition-colors hover:bg-muted", "cursor-default hover:bg-transparent")}>
         <span className={"text-[9px] font-bold tracking-[0.08em] uppercase text-muted-foreground font-mono whitespace-nowrap overflow-hidden text-ellipsis shrink-0"}>Type</span>
-        <span className={cn("text-[11.5px] text-foreground overflow-hidden text-ellipsis whitespace-nowrap min-w-0", "flex items-center gap-1")}>
+        <div className={cn("text-[11.5px] text-foreground overflow-hidden text-ellipsis whitespace-nowrap min-w-0", "flex items-center gap-1")}>
           <div className="bg-muted/40 size-[18px] rounded-full" />
           <div className="bg-muted/40 size-[18px] rounded-full" />
-        </span>
+        </div>
       </div>
     </>
   );
@@ -238,6 +238,13 @@ function MidFormRowsGhost() {
           </span>
         </div>
       ))}
+      <div className={cn(cellClasses.midFormCell, "cursor-default hover:bg-transparent")}>
+        <span className={cellClasses.midFormLbl}>Type</span>
+        <div className={cn(cellClasses.midFormVal, "items-center")}>
+          <div className="bg-muted/40 size-[18px] rounded-full" />
+          <div className="bg-muted/40 size-[18px] rounded-full" />
+        </div>
+      </div>
     </>
   );
 }

--- a/apps/web/src/components/team-builder/v2/lanes/identity/use-identity-state.ts
+++ b/apps/web/src/components/team-builder/v2/lanes/identity/use-identity-state.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 import {
   NATURE_EFFECTS,
@@ -33,9 +33,11 @@ export function useIdentityState(
 
   // Sync draft when the upstream nickname changes (e.g. switching Pokémon)
   const incomingNickname = pokemon.nickname ?? "";
-  useEffect(() => {
+  const [prevNickname, setPrevNickname] = useState(incomingNickname);
+  if (prevNickname !== incomingNickname) {
+    setPrevNickname(incomingNickname);
     setNickDraft(incomingNickname);
-  }, [incomingNickname]);
+  }
 
   // ── Derived data ───────────────────────────────────────────────────────────
 

--- a/apps/web/src/components/team-builder/v2/lanes/moves-lane.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/moves-lane.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { useRef, useState, type ReactNode } from "react";
+import { toast } from "sonner";
 
 import { getMoveData, type GameFormat } from "@trainers/pokemon";
 import { type Tables, type TablesUpdate } from "@trainers/supabase";
@@ -149,12 +150,17 @@ function CalcDescTooltip({ desc, children }: { desc: string; children: ReactNode
 
 function CalcCopyButton({ desc }: { desc: string }) {
   const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   function handleCopy(e: React.MouseEvent) {
     e.stopPropagation();
-    void navigator.clipboard.writeText(desc);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
+    navigator.clipboard.writeText(desc).then(() => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      setCopied(true);
+      timerRef.current = setTimeout(() => setCopied(false), 1500);
+    }).catch(() => {
+      toast.error("Couldn't copy to clipboard");
+    });
   }
 
   return (

--- a/apps/web/src/components/team-builder/v2/lanes/moves-lane.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/moves-lane.tsx
@@ -543,7 +543,7 @@ function MovesLaneReal({
   onUpdate,
   fieldErrors,
 }: MovesLaneRealProps) {
-  const calc = useCalcStateContext();
+  const _calc = useCalcStateContext();
   function handlePick(slotKey: MoveSlot, name: string) {
     onUpdate({ [slotKey]: name });
   }

--- a/apps/web/src/components/team-builder/v2/lanes/moves-lane.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/moves-lane.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { toast } from "sonner";
 
 import { getMoveData, type GameFormat } from "@trainers/pokemon";
@@ -152,15 +152,23 @@ function CalcCopyButton({ desc }: { desc: string }) {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  function handleCopy(e: React.MouseEvent) {
+  // Clear timer on unmount to avoid setting state on an unmounted component
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  async function handleCopy(e: React.MouseEvent) {
     e.stopPropagation();
-    navigator.clipboard.writeText(desc).then(() => {
+    try {
+      await navigator.clipboard.writeText(desc);
       if (timerRef.current) clearTimeout(timerRef.current);
       setCopied(true);
       timerRef.current = setTimeout(() => setCopied(false), 1500);
-    }).catch(() => {
+    } catch {
       toast.error("Couldn't copy to clipboard");
-    });
+    }
   }
 
   return (

--- a/apps/web/src/components/team-builder/v2/lanes/moves-lane.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/moves-lane.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 
 import { getMoveData, type GameFormat } from "@trainers/pokemon";
 import { type Tables, type TablesUpdate } from "@trainers/supabase";
@@ -150,15 +150,12 @@ function CalcDescTooltip({ desc, children }: { desc: string; children: ReactNode
 function CalcCopyButton({ desc }: { desc: string }) {
   const [copied, setCopied] = useState(false);
 
-  const handleCopy = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      navigator.clipboard.writeText(desc);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    },
-    [desc]
-  );
+  function handleCopy(e: React.MouseEvent) {
+    e.stopPropagation();
+    void navigator.clipboard.writeText(desc);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
 
   return (
     <CalcDescTooltip desc={desc}>
@@ -447,8 +444,8 @@ function MovesLaneTileGhost() {
   return (
     <TableHeader>
       <TableRow className="border-none">
-        <TableHead className="!h-auto w-6 border-none p-0 pb-0.5" />
-        <TableHead className="!h-auto w-8 border-none p-0 pb-0.5" />
+        <TableHead className="!h-auto w-6 border-none p-0 pb-0.5"><span className="sr-only">Type</span></TableHead>
+        <TableHead className="!h-auto w-8 border-none p-0 pb-0.5"><span className="sr-only">Category</span></TableHead>
         <TableHead className="text-muted-foreground !h-auto border-none p-0 pb-0.5 text-[9.5px] font-medium tracking-[0.04em] uppercase">
           NAME
         </TableHead>
@@ -488,7 +485,7 @@ function MovesLaneTileGhost() {
 function MovesLaneGhost() {
   const calcEnabled = useCalcEnabled();
   return (
-    <div className={cn("border-border/60 flex min-w-0 flex-1 flex-col border-r border-dashed px-3 py-1 transition-[padding,flex] duration-300 ease-in-out")}>
+    <div className={cn("flex min-w-0 flex-1 flex-col px-3 py-1 transition-[padding,flex] duration-300 ease-in-out")}>
       <Table className="w-full border-separate border-spacing-y-[3px]">
         <MovesLaneTileGhost />
         <TableBody>

--- a/apps/web/src/components/team-builder/v2/lanes/stats-lane.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/stats-lane.tsx
@@ -597,8 +597,8 @@ function StatRow({
       >
         {label}
         <span className="inline-block w-[9px] text-[7px] leading-none">
-          {isNatureBoosted && "▲"}
-          {isNatureReduced && "▼"}
+          {isNatureBoosted && "▴"}
+          {isNatureReduced && "▾"}
         </span>
       </button>
 

--- a/apps/web/src/components/team-builder/v2/lanes/stats-lane.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/stats-lane.tsx
@@ -351,10 +351,6 @@ function StatRow({
     budget.total,
     budget.perStat
   );
-  const [investBudgetState, setInvestBudgetState] = useState(investBudget);
-  if (investBudgetState !== investBudget) {
-    setInvestBudgetState(investBudget);
-  }
   const investBudgetRef = useRef(investBudget);
   // Update ref in an effect to avoid "Cannot access refs during render"
   useEffect(() => {
@@ -586,7 +582,6 @@ function StatRow({
       <button
         type="button"
         onClick={() => {
-          if (statKey === "hp") return;
           // Cycle: neutral → "+" → "−" → neutral
           let suffix: "+" | "-" | null;
           if (isNatureBoosted) suffix = "-";
@@ -600,6 +595,7 @@ function StatRow({
           if (newNature) onUpdate({ nature: newNature });
         }}
         disabled={statKey === "hp"}
+        aria-label={statKey !== "hp" ? `Cycle nature for ${label}` : undefined}
         className={cn("text-[9.5px] font-semibold uppercase tracking-[0.06em] font-mono text-left whitespace-nowrap flex items-center gap-px", labelTextClass, statKey !== "hp" && "cursor-pointer hover:opacity-70")}
       >
         {label}
@@ -782,9 +778,11 @@ export function StatsLane({
     Partial<Record<StatKey, number>>
   >({});
   const currentPokemonId = pokemon?.id ?? null;
-  const prevPokemonIdRef = useRef<number | null>(currentPokemonId);
-  if (currentPokemonId !== prevPokemonIdRef.current) {
-    prevPokemonIdRef.current = currentPokemonId;
+  const [prevPokemonId, setPrevPokemonId] = useState<number | null>(
+    currentPokemonId
+  );
+  if (prevPokemonId !== currentPokemonId) {
+    setPrevPokemonId(currentPokemonId);
     setLiveEvByStat({});
   }
 

--- a/apps/web/src/components/team-builder/v2/lanes/stats-lane.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/stats-lane.tsx
@@ -596,13 +596,9 @@ function StatRow({
         className={cn("text-[9.5px] font-semibold uppercase tracking-[0.06em] font-mono text-left whitespace-nowrap flex items-center gap-px", labelTextClass, statKey !== "hp" && "cursor-pointer hover:opacity-70")}
       >
         {label}
-        <span className="inline-block w-[9px] text-[9px] font-black tracking-tighter">
-          {isNatureBoosted && (
-            <span className="text-emerald-600 dark:text-emerald-400">▲</span>
-          )}
-          {isNatureReduced && (
-            <span className="text-rose-600 dark:text-rose-400">▽</span>
-          )}
+        <span className="inline-block w-[9px] text-[7px] leading-none">
+          {isNatureBoosted && "▲"}
+          {isNatureReduced && "▼"}
         </span>
       </button>
 

--- a/apps/web/src/components/team-builder/v2/lanes/stats-lane.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/stats-lane.tsx
@@ -774,12 +774,10 @@ export function StatsLane({
   const [liveEvByStat, setLiveEvByStat] = useState<
     Partial<Record<StatKey, number>>
   >({});
-  const [prevPokemonId, setPrevPokemonId] = useState<
-    number | null | typeof UNINITIALIZED
-  >(UNINITIALIZED);
   const currentPokemonId = pokemon?.id ?? null;
-  if (currentPokemonId !== prevPokemonId) {
-    setPrevPokemonId(currentPokemonId);
+  const prevPokemonIdRef = useRef<number | null>(currentPokemonId);
+  if (currentPokemonId !== prevPokemonIdRef.current) {
+    prevPokemonIdRef.current = currentPokemonId;
     setLiveEvByStat({});
   }
 

--- a/apps/web/src/components/team-builder/v2/lanes/stats-lane.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/stats-lane.tsx
@@ -761,6 +761,14 @@ export function StatsLane({
   const [liveEvByStat, setLiveEvByStat] = useState<
     Partial<Record<StatKey, number>>
   >({});
+  const [prevPokemonId, setPrevPokemonId] = useState<
+    number | null | typeof UNINITIALIZED
+  >(UNINITIALIZED);
+  const currentPokemonId = pokemon?.id ?? null;
+  if (currentPokemonId !== prevPokemonId) {
+    setPrevPokemonId(currentPokemonId);
+    setLiveEvByStat({});
+  }
 
   // Match the active format so empty slots line up with filled ones — same
   // grid (with-IV vs without), same investment header (SP vs EVs), same total

--- a/apps/web/src/components/team-builder/v2/lanes/stats-lane.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/stats-lane.tsx
@@ -564,30 +564,47 @@ function StatRow({
       className={cn(
         showIv
           ? showBoostCol
-            ? "grid grid-cols-[32px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_40px_36px_56px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
-            : "grid grid-cols-[32px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_40px_36px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
+            ? "grid grid-cols-[40px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_40px_36px_56px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
+            : "grid grid-cols-[40px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_40px_36px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
           : showBoostCol
-            ? "grid grid-cols-[32px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_36px_56px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
-            : "grid grid-cols-[32px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_36px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted",
+            ? "grid grid-cols-[40px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_36px_56px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
+            : "grid grid-cols-[40px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_36px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted",
         statColorClass
       )}
     >
       {/* Col 1: Stat label, color-coded, with nature chevron.
           Matches the +/− nature label colours in IdentityLane:
-          boost = emerald, reduce = rose. */}
-      <span className={cn("text-[9.5px] font-semibold uppercase tracking-[0.06em] font-mono text-left whitespace-nowrap overflow-hidden flex items-center gap-px", labelTextClass)}>
+          boost = emerald, reduce = rose.
+          Clickable to cycle nature: neutral → boost → reduce → neutral. */}
+      <button
+        type="button"
+        onClick={() => {
+          if (statKey === "hp") return;
+          // Cycle: neutral → "+" → "−" → neutral
+          let suffix: "+" | "-" | null;
+          if (isNatureBoosted) suffix = "-";
+          else if (isNatureReduced) suffix = null;
+          else suffix = "+";
+          const newNature = computeNatureForSuffix({
+            currentNature: nature,
+            statKey,
+            suffix,
+          });
+          if (newNature) onUpdate({ nature: newNature });
+        }}
+        disabled={statKey === "hp"}
+        className={cn("text-[9.5px] font-semibold uppercase tracking-[0.06em] font-mono text-left whitespace-nowrap flex items-center gap-px", labelTextClass, statKey !== "hp" && "cursor-pointer hover:opacity-70")}
+      >
         {label}
-        {isNatureBoosted && (
-          <span className="text-[9px] font-black tracking-tighter text-emerald-600 dark:text-emerald-400">
-            ▲
-          </span>
-        )}
-        {isNatureReduced && (
-          <span className="text-[9px] font-black tracking-tighter text-rose-600 dark:text-rose-400">
-            ▽
-          </span>
-        )}
-      </span>
+        <span className="inline-block w-[9px] text-[9px] font-black tracking-tighter">
+          {isNatureBoosted && (
+            <span className="text-emerald-600 dark:text-emerald-400">▲</span>
+          )}
+          {isNatureReduced && (
+            <span className="text-rose-600 dark:text-rose-400">▽</span>
+          )}
+        </span>
+      </button>
 
       {/* Col 2: Base stat number, muted mono */}
       <span className={"font-mono text-[9.5px] text-muted-foreground text-right tabular-nums"}>{base}</span>
@@ -791,11 +808,11 @@ export function StatsLane({
             "mb-0.5 py-0",
             showIv
               ? calcEnabled
-                ? "grid grid-cols-[32px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_40px_36px_56px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
-                : "grid grid-cols-[32px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_40px_36px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
+                ? "grid grid-cols-[40px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_40px_36px_56px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
+                : "grid grid-cols-[40px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_40px_36px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
               : calcEnabled
-                ? "grid grid-cols-[32px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_36px_56px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
-                : "grid grid-cols-[32px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_36px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
+                ? "grid grid-cols-[40px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_36px_56px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
+                : "grid grid-cols-[40px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_36px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
           )}
         >
           <span />
@@ -823,15 +840,15 @@ export function StatsLane({
             className={cn(
               showIv
                 ? calcEnabled
-                  ? "grid grid-cols-[32px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_40px_36px_56px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
-                  : "grid grid-cols-[32px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_40px_36px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
+                  ? "grid grid-cols-[40px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_40px_36px_56px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
+                  : "grid grid-cols-[40px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_40px_36px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
                 : calcEnabled
-                  ? "grid grid-cols-[32px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_36px_56px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
-                  : "grid grid-cols-[32px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_36px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted",
+                  ? "grid grid-cols-[40px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_36px_56px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
+                  : "grid grid-cols-[40px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_36px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted",
               colorClass
             )}
           >
-            <span className={cn("text-[9.5px] font-semibold uppercase tracking-[0.06em] font-mono text-left whitespace-nowrap overflow-hidden flex items-center gap-px", "opacity-30")}>{label}</span>
+            <span className={cn("text-[9.5px] font-semibold uppercase tracking-[0.06em] font-mono text-left whitespace-nowrap flex items-center gap-px", "opacity-30")}>{label}</span>
             <span className={cn("font-mono text-[9.5px] text-muted-foreground text-right tabular-nums", "opacity-25")}>—</span>
             <div className={"h-2 bg-muted rounded-full overflow-hidden relative min-w-0"} />
             <div className="border-border/30 h-[18px] w-9 rounded border border-dashed" />
@@ -895,11 +912,11 @@ export function StatsLane({
           "mb-0.5",
           showIv
             ? calcEnabled
-              ? "grid grid-cols-[32px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_40px_36px_56px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
-              : "grid grid-cols-[32px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_40px_36px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
+              ? "grid grid-cols-[40px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_40px_36px_56px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
+              : "grid grid-cols-[40px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_40px_36px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
             : calcEnabled
-              ? "grid grid-cols-[32px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_36px_56px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
-              : "grid grid-cols-[32px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_36px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted",
+              ? "grid grid-cols-[40px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_36px_56px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted"
+              : "grid grid-cols-[40px_30px_minmax(30px,0.8fr)_40px_minmax(60px,1.6fr)_36px] gap-1.5 items-center px-1 py-0.5 rounded hover:bg-muted",
           "py-0"
         )}
       >

--- a/apps/web/src/components/team-builder/v2/lanes/stats-lane.tsx
+++ b/apps/web/src/components/team-builder/v2/lanes/stats-lane.tsx
@@ -351,8 +351,15 @@ function StatRow({
     budget.total,
     budget.perStat
   );
+  const [investBudgetState, setInvestBudgetState] = useState(investBudget);
+  if (investBudgetState !== investBudget) {
+    setInvestBudgetState(investBudget);
+  }
   const investBudgetRef = useRef(investBudget);
-  investBudgetRef.current = investBudget;
+  // Update ref in an effect to avoid "Cannot access refs during render"
+  useEffect(() => {
+    investBudgetRef.current = investBudget;
+  });
 
   // --- EV draft + debounced commit ---
   // Slider/keyboard updates the local draft synchronously for snappy UI;

--- a/apps/web/src/components/team-builder/v2/team-layout-toggle.tsx
+++ b/apps/web/src/components/team-builder/v2/team-layout-toggle.tsx
@@ -21,7 +21,7 @@ function Icon1x6() {
 }
 
 // 2×3 — mid-stack layout: two columns, cells show a horizontal bar per row
-function Icon2x3() {
+function _Icon2x3() {
   return (
     <svg viewBox="0 0 16 16" aria-hidden className="size-3.5">
       <rect x="2" y="3" width="5" height="2" fill="currentColor" />

--- a/apps/web/src/components/team-builder/v2/team-workspace-v2.tsx
+++ b/apps/web/src/components/team-builder/v2/team-workspace-v2.tsx
@@ -523,7 +523,6 @@ export function TeamWorkspaceV2({
     setReorderIds(null);
   }
 
-  const filledCount = slots.filter(Boolean).length;
 
   // Pre-compute dock-pill summaries once here so DockbarConnected never runs
   // getTeamFastestSpeed on every EV slider tick.
@@ -564,7 +563,6 @@ export function TeamWorkspaceV2({
         >
           <Topbar
             team={team}
-            filledCount={filledCount}
             format={format}
             username={username}
             alts={alts}

--- a/apps/web/src/components/team-builder/v2/team-workspace-v2.tsx
+++ b/apps/web/src/components/team-builder/v2/team-workspace-v2.tsx
@@ -38,6 +38,7 @@ import {
   addPokemonToTeamAction,
   removePokemonFromTeamAction,
   reorderTeamPokemonAction,
+  transferTeamAction,
   updatePokemonAction,
   updateTeamAction,
 } from "@/actions/teams";
@@ -105,6 +106,7 @@ interface TeamWorkspaceV2Props {
   team: TeamWithPokemon;
   format: GameFormat | undefined;
   username: string;
+  alts: Tables<"alts">[];
 }
 
 // =============================================================================
@@ -255,6 +257,7 @@ export function TeamWorkspaceV2({
   team,
   format,
   username,
+  alts,
 }: TeamWorkspaceV2Props) {
   const router = useRouter();
   const state = useBuilderState();
@@ -564,10 +567,19 @@ export function TeamWorkspaceV2({
             filledCount={filledCount}
             format={format}
             username={username}
+            alts={alts}
             onOpenImport={() => setImportOpen(true)}
             validationErrors={validationErrors}
             onJumpToPokemon={handleJumpToPokemon}
             onValidate={validate}
+            onNameChange={async (name) => {
+              const result = await updateTeamAction(team.id, { name });
+              if (!result.success) {
+                toast.error(result.error ?? "Failed to rename team.");
+                return;
+              }
+              router.refresh();
+            }}
             onFormatChange={async (formatId) => {
               const result = await updateTeamAction(team.id, {
                 format: formatId,
@@ -576,6 +588,20 @@ export function TeamWorkspaceV2({
                 toast.error(result.error ?? "Failed to update format.");
                 return;
               }
+              router.refresh();
+            }}
+            onAltChange={async (altId) => {
+              const targetAlt = alts.find((a) => a.id === altId);
+              if (!targetAlt) return;
+              const result = await transferTeamAction(team.id, altId);
+              if (!result.success) {
+                toast.error(result.error ?? "Failed to transfer team.");
+                return;
+              }
+              toast.success(`Team transferred to ${targetAlt.username}.`);
+              router.push(
+                `/dashboard/alts/${targetAlt.username}/teams/${team.id}`
+              );
               router.refresh();
             }}
             exportMenu={<ExportMenu team={team} />}

--- a/apps/web/src/components/team-builder/v2/team-workspace-v2.tsx
+++ b/apps/web/src/components/team-builder/v2/team-workspace-v2.tsx
@@ -600,7 +600,6 @@ export function TeamWorkspaceV2({
               router.push(
                 `/dashboard/alts/${targetAlt.username}/teams/${team.id}`
               );
-              router.refresh();
             }}
             exportMenu={<ExportMenu team={team} />}
           />

--- a/apps/web/src/components/team-builder/v2/topbar.tsx
+++ b/apps/web/src/components/team-builder/v2/topbar.tsx
@@ -1,20 +1,29 @@
 "use client";
 
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useRef, useState } from "react";
 import Link from "next/link";
+import { ChevronDownIcon, CheckIcon } from "lucide-react";
 
 import { getActiveFormats, type GameFormat } from "@trainers/pokemon";
-import { type TeamWithPokemon } from "@trainers/supabase";
+import { type TeamWithPokemon, type Tables } from "@trainers/supabase";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuGroup,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { PageHeader } from "@/components/dashboard/page-header";
+import { NotificationsPopover } from "@/components/dashboard/notifications-popover";
 import { cn } from "@/lib/utils";
 
 import { type ValidationError } from "../validation-hooks";
@@ -23,47 +32,121 @@ import { ValidationPopover } from "./validation/validation-popover";
 
 const ACTIVE_FORMATS = getActiveFormats();
 
+// =============================================================================
+// Props
+// =============================================================================
+
 interface TopbarProps {
   team: TeamWithPokemon;
   filledCount: number;
   format: GameFormat | undefined;
   username: string;
+  alts: Tables<"alts">[];
   onOpenImport: () => void;
   validationErrors: ValidationError[];
   onJumpToPokemon: (pokemonId: number) => void;
   onValidate: () => void;
+  onNameChange: (name: string) => Promise<void>;
   onFormatChange?: (formatId: string) => Promise<void>;
+  onAltChange?: (altId: number) => Promise<void>;
   exportMenu?: ReactNode;
 }
 
-interface StatBlockProps {
-  label: string;
-  value: string;
+// =============================================================================
+// Inline editable team name
+// =============================================================================
+
+interface EditableNameProps {
+  defaultValue: string;
+  onSave: (name: string) => Promise<void>;
 }
 
-function StatBlock({ label, value }: StatBlockProps) {
+function EditableName({ defaultValue, onSave }: EditableNameProps) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(defaultValue);
+  const [saving, setSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  async function commit() {
+    const trimmed = value.trim();
+    if (!trimmed || trimmed === defaultValue) {
+      setValue(defaultValue);
+      setEditing(false);
+      return;
+    }
+    setSaving(true);
+    await onSave(trimmed);
+    setSaving(false);
+    setEditing(false);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      commit();
+    } else if (e.key === "Escape") {
+      setValue(defaultValue);
+      setEditing(false);
+    }
+  }
+
+  if (editing) {
+    return (
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onBlur={commit}
+        onKeyDown={handleKeyDown}
+        disabled={saving}
+        autoFocus
+        className={cn(
+          "h-7 w-36 rounded-md border border-border bg-background px-2 text-sm font-semibold shadow-xs outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring sm:w-44 md:w-56",
+          saving && "opacity-60"
+        )}
+        aria-label="Team name"
+      />
+    );
+  }
+
   return (
-    <div className="flex items-center gap-1.5">
-      <span className="font-mono text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-        {label}
-      </span>
-      <span className="font-mono text-xs font-semibold leading-none">
-        {value}
-      </span>
-    </div>
+    <button
+      type="button"
+      onClick={() => setEditing(true)}
+      className="flex h-7 max-w-36 items-center gap-1 rounded-md px-2 text-sm font-semibold transition-colors hover:bg-accent sm:max-w-44 md:max-w-56"
+      aria-label="Edit team name"
+    >
+      <span className="truncate">{defaultValue}</span>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        className="size-3 shrink-0 text-muted-foreground"
+      >
+        <path d="M13.488 2.513a1.75 1.75 0 0 0-2.475 0L3.22 10.306a1 1 0 0 0-.26.445l-.836 3.04a.25.25 0 0 0 .305.305l3.04-.836a1 1 0 0 0 .445-.26l7.793-7.793a1.75 1.75 0 0 0 0-2.475l-.219-.219Z" />
+      </svg>
+    </button>
   );
 }
+
+// =============================================================================
+// Topbar
+// =============================================================================
 
 export function Topbar({
   team,
   filledCount,
   format,
   username,
+  alts,
   onOpenImport,
   validationErrors,
   onJumpToPokemon,
   onValidate,
+  onNameChange,
   onFormatChange,
+  onAltChange,
   exportMenu,
 }: TopbarProps) {
   const teamsUrl = `/dashboard/alts/${username}/teams`;
@@ -105,6 +188,11 @@ export function Topbar({
       ? [format, ...ACTIVE_FORMATS]
       : ACTIVE_FORMATS;
 
+  const currentAlt = alts.find((a) => a.username === username);
+  const hasMultipleAlts = alts.length > 1;
+
+  // ─── Format badge / selector ────────────────────────────────────────────────
+
   const formatBadge = onFormatChange ? (
     <Popover open={formatOpen} onOpenChange={setFormatOpen}>
       <PopoverTrigger
@@ -112,7 +200,7 @@ export function Topbar({
           <button
             type="button"
             disabled={formatPending}
-            className="ml-2 shrink-0"
+            className="shrink-0"
             aria-label="Change format"
           />
         }
@@ -130,12 +218,12 @@ export function Topbar({
               {format.label}
             </>
           ) : (
-            <span className="text-muted-foreground">Set format…</span>
+            <span className="text-muted-foreground">Set format...</span>
           )}
         </Badge>
       </PopoverTrigger>
       <PopoverContent side="bottom" align="start" className="w-auto p-3">
-        <p className="mb-2 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
           Format
         </p>
         <div className="flex flex-wrap gap-1.5">
@@ -159,36 +247,92 @@ export function Topbar({
       </PopoverContent>
     </Popover>
   ) : format ? (
-    <Badge variant="secondary" className="ml-2 shrink-0">
+    <Badge variant="secondary" className="shrink-0">
       <span className="mr-1 inline-block size-1.5 rounded-full bg-primary" />
       {format.label}
     </Badge>
   ) : null;
 
+  // ─── Render ─────────────────────────────────────────────────────────────────
+
   return (
-    <PageHeader>
-      <Link
-        href={teamsUrl}
-        className="hidden text-sm text-muted-foreground transition-colors hover:text-foreground sm:inline"
-      >
-        {username}
-      </Link>
-      <span className="hidden text-muted-foreground sm:inline">/</span>
-      <Input
-        defaultValue={team.name}
-        readOnly
-        className="h-7 w-28 border-transparent bg-transparent px-1.5 text-sm font-medium shadow-none focus-visible:border-border focus-visible:ring-0 sm:w-32 md:w-44"
-        aria-label="Team name"
-      />
+    <PageHeader hideNotifications>
+      {/* Left: Owner + Format (labeled, inline) */}
+      <div className="hidden items-center gap-4 sm:flex">
+        <div className="flex items-center gap-1.5">
+          <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            Owner
+          </span>
+          {hasMultipleAlts && onAltChange ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-0.5 text-sm font-medium transition-colors hover:text-primary"
+                    aria-label="Switch alt"
+                  />
+                }
+              >
+                {username}
+                <ChevronDownIcon className="size-3" />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" sideOffset={6} className="min-w-60">
+                <DropdownMenuGroup>
+                  <DropdownMenuLabel>Team owner</DropdownMenuLabel>
+                  {alts.map((alt) => (
+                    <DropdownMenuItem
+                      key={alt.id}
+                      onClick={() => {
+                        if (alt.id !== currentAlt?.id) {
+                          onAltChange(alt.id);
+                        }
+                      }}
+                      className={cn(
+                        "gap-2 py-2 text-sm",
+                        alt.id === currentAlt?.id && "font-medium"
+                      )}
+                    >
+                      {alt.id === currentAlt?.id && (
+                        <CheckIcon className="size-4 text-primary" />
+                      )}
+                      <span className={cn(alt.id !== currentAlt?.id && "pl-6")}>
+                        {alt.username}
+                      </span>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : (
+            <Link
+              href={teamsUrl}
+              className="text-sm font-medium transition-colors hover:text-primary"
+            >
+              {username}
+            </Link>
+          )}
+        </div>
 
-      {formatBadge}
-
-      <div className="hidden items-center gap-3 lg:flex">
-        <StatBlock label="Slots" value={`${filledCount}/6`} />
-        <StatBlock label="Record" value="—·—" />
-        <StatBlock label="WR" value="—%" />
+        <div className="flex items-center gap-1.5">
+          <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            Format
+          </span>
+          {formatBadge}
+        </div>
       </div>
 
+      {/* Center: Team name (absolutely centered, with label) */}
+      <div className="absolute inset-x-0 flex items-center justify-center pointer-events-none">
+        <div className="pointer-events-auto flex items-center gap-1.5">
+          <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            Team
+          </span>
+          <EditableName defaultValue={team.name} onSave={onNameChange} />
+        </div>
+      </div>
+
+      {/* Right: Actions (flush with far right / notifications) */}
       <div className="ml-auto flex items-center gap-1">
         <TeamLayoutToggle />
         <Button
@@ -239,6 +383,7 @@ export function Topbar({
             />
           </PopoverContent>
         </Popover>
+        <NotificationsPopover />
       </div>
     </PageHeader>
   );

--- a/apps/web/src/components/team-builder/v2/topbar.tsx
+++ b/apps/web/src/components/team-builder/v2/topbar.tsx
@@ -38,7 +38,6 @@ const ACTIVE_FORMATS = getActiveFormats();
 
 interface TopbarProps {
   team: TeamWithPokemon;
-  filledCount: number;
   format: GameFormat | undefined;
   username: string;
   alts: Tables<"alts">[];
@@ -75,9 +74,12 @@ function EditableName({ defaultValue, onSave }: EditableNameProps) {
       return;
     }
     setSaving(true);
-    await onSave(trimmed);
-    setSaving(false);
-    setEditing(false);
+    try {
+      await onSave(trimmed);
+      setEditing(false);
+    } finally {
+      setSaving(false);
+    }
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
@@ -136,7 +138,6 @@ function EditableName({ defaultValue, onSave }: EditableNameProps) {
 
 export function Topbar({
   team,
-  filledCount,
   format,
   username,
   alts,

--- a/apps/web/src/components/team-builder/v2/topbar.tsx
+++ b/apps/web/src/components/team-builder/v2/topbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { type ReactNode, useRef, useState } from "react";
 import Link from "next/link";
 import { ChevronDownIcon, CheckIcon } from "lucide-react";
 
@@ -65,13 +65,15 @@ function EditableName({ defaultValue, onSave }: EditableNameProps) {
   const [value, setValue] = useState(defaultValue);
   const [saving, setSaving] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const [prevDefault, setPrevDefault] = useState(defaultValue);
 
-  // Sync local value when defaultValue changes externally (e.g. after save)
-  useEffect(() => {
+  // Sync local value when defaultValue changes externally (render-time reset)
+  if (prevDefault !== defaultValue) {
+    setPrevDefault(defaultValue);
     if (!editing) {
       setValue(defaultValue);
     }
-  }, [defaultValue, editing]);
+  }
 
   async function commit() {
     const trimmed = value.trim();

--- a/apps/web/src/components/team-builder/v2/topbar.tsx
+++ b/apps/web/src/components/team-builder/v2/topbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ReactNode, useRef, useState } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { ChevronDownIcon, CheckIcon } from "lucide-react";
 
@@ -65,6 +65,13 @@ function EditableName({ defaultValue, onSave }: EditableNameProps) {
   const [value, setValue] = useState(defaultValue);
   const [saving, setSaving] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // Sync local value when defaultValue changes externally (e.g. after save)
+  useEffect(() => {
+    if (!editing) {
+      setValue(defaultValue);
+    }
+  }, [defaultValue, editing]);
 
   async function commit() {
     const trimmed = value.trim();

--- a/apps/web/src/components/team-builder/v2/topbar.tsx
+++ b/apps/web/src/components/team-builder/v2/topbar.tsx
@@ -94,7 +94,7 @@ function EditableName({ defaultValue, onSave }: EditableNameProps) {
   function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === "Enter") {
       e.preventDefault();
-      commit();
+      void commit();
     } else if (e.key === "Escape") {
       setValue(defaultValue);
       setEditing(false);
@@ -108,7 +108,7 @@ function EditableName({ defaultValue, onSave }: EditableNameProps) {
         type="text"
         value={value}
         onChange={(e) => setValue(e.target.value)}
-        onBlur={commit}
+        onBlur={() => void commit()}
         onKeyDown={handleKeyDown}
         disabled={saving}
         autoFocus
@@ -133,6 +133,8 @@ function EditableName({ defaultValue, onSave }: EditableNameProps) {
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 16 16"
         fill="currentColor"
+        aria-hidden="true"
+        focusable="false"
         className="size-3 shrink-0 text-muted-foreground"
       >
         <path d="M13.488 2.513a1.75 1.75 0 0 0-2.475 0L3.22 10.306a1 1 0 0 0-.26.445l-.836 3.04a.25.25 0 0 0 .305.305l3.04-.836a1 1 0 0 0 .445-.26l7.793-7.793a1.75 1.75 0 0 0 0-2.475l-.219-.219Z" />

--- a/apps/web/src/components/team-builder/v2/use-builder-state.ts
+++ b/apps/web/src/components/team-builder/v2/use-builder-state.ts
@@ -195,6 +195,7 @@ export function useBuilderState(): BuilderState {
   // Hydrate persisted values from localStorage after mount to avoid
   // hydration mismatches (server renders defaults, client must match).
   useEffect(() => {
+    /* eslint-disable react-hooks/set-state-in-effect */
     const persistedPanel = readPersisted(PANEL_HEIGHT_STORAGE_KEY, (raw) => {
       const n = clampPanelHeight(Number(raw));
       return Number.isNaN(Number(raw)) ? null : n;
@@ -232,6 +233,7 @@ export function useBuilderState(): BuilderState {
     );
     if (persistedFaintedTheirs !== null)
       setFaintedTheirsState(persistedFaintedTheirs);
+    /* eslint-enable react-hooks/set-state-in-effect */
   }, []);
 
   function setPanelHeightPct(n: number) {

--- a/apps/web/src/components/tournament/__tests__/register-modal.test.tsx
+++ b/apps/web/src/components/tournament/__tests__/register-modal.test.tsx
@@ -545,6 +545,168 @@ describe("RegisterModal", () => {
   });
 
   // ========================================================================
+  // Multi-alt form rendering
+  // ========================================================================
+
+  describe("multi-alt form", () => {
+    const mockAlt2 = {
+      id: 2,
+      username: "gary_oak",
+      display_name: "Gary Oak",
+      avatar_url: null,
+      first_name: "Gary",
+      last_name: "Oak",
+      country: "US",
+    };
+
+    beforeEach(() => {
+      mockGetCurrentUserAltsAction.mockResolvedValue({
+        success: true,
+        data: [mockAlt, mockAlt2],
+      });
+    });
+
+    it("renders alt selection dropdown when multiple alts are available", async () => {
+      render(<RegisterModal {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Register as")).toBeInTheDocument();
+      });
+    });
+
+    it("shows confirm registration button in multi-alt mode", async () => {
+      render(<RegisterModal {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /confirm registration/i })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("renders the form successfully with multiple alts", async () => {
+      render(<RegisterModal {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Register as")).toBeInTheDocument();
+      });
+
+      // The select trigger (combobox) should be present for alt selection
+      expect(screen.getByRole("combobox")).toBeInTheDocument();
+    });
+  });
+
+  // ========================================================================
+  // Edit mode
+  // ========================================================================
+
+  describe("edit mode", () => {
+    beforeEach(() => {
+      mockGetRegistrationDetailsAction.mockResolvedValue({
+        success: true,
+        data: {
+          id: 200,
+          alt_id: 1,
+          in_game_name: "AshTheChamp",
+          display_name_option: "shortened",
+          show_country_flag: true,
+        },
+      });
+    });
+
+    it("renders in edit mode and shows Save Changes button", async () => {
+      render(<RegisterModal {...defaultProps} mode="edit" />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /save changes/i })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("submits updated preferences in edit mode", async () => {
+      const user = userEvent.setup();
+      mockUpdateRegistrationAction.mockResolvedValue({ success: true });
+
+      render(<RegisterModal {...defaultProps} mode="edit" />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /save changes/i })
+        ).toBeInTheDocument();
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: /save changes/i })
+      );
+
+      await waitFor(() => {
+        expect(mockUpdateRegistrationAction).toHaveBeenCalledWith(
+          200,
+          42,
+          expect.objectContaining({
+            displayNameOption: "shortened",
+            showCountryFlag: true,
+          })
+        );
+      });
+    });
+
+    it("shows error when update fails", async () => {
+      const user = userEvent.setup();
+      mockUpdateRegistrationAction.mockResolvedValue({
+        success: false,
+        error: "Update failed",
+      });
+
+      render(<RegisterModal {...defaultProps} mode="edit" />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /save changes/i })
+        ).toBeInTheDocument();
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: /save changes/i })
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Update failed")).toBeInTheDocument();
+      });
+    });
+  });
+
+  // ========================================================================
+  // Loading / empty states
+  // ========================================================================
+
+  describe("loading and empty states", () => {
+    it("shows loading spinner while data is being fetched", () => {
+      // Make the action never resolve to keep loading state
+      mockGetCurrentUserAltsAction.mockReturnValue(new Promise(() => {}));
+
+      render(<RegisterModal {...defaultProps} />);
+
+      // Loading spinner should be present (animate-spin)
+      expect(document.querySelector(".animate-spin")).toBeInTheDocument();
+    });
+
+    it("shows no profiles message when alts array is empty", async () => {
+      mockGetCurrentUserAltsAction.mockResolvedValue({
+        success: true,
+        data: [],
+      });
+
+      render(<RegisterModal {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("No player profiles found.")).toBeInTheDocument();
+      });
+    });
+  });
+
+  // ========================================================================
   // isCapacityError helper
   // ========================================================================
 

--- a/apps/web/src/components/tournament/__tests__/sidebar-realtime.test.tsx
+++ b/apps/web/src/components/tournament/__tests__/sidebar-realtime.test.tsx
@@ -36,6 +36,11 @@ const mockSupabase = {
 // Mocks — must be declared before imports
 // --------------------------------------------------------------------------
 
+// Mock @tanstack/react-query (useQuery used for user teams)
+jest.mock("@tanstack/react-query", () => ({
+  useQuery: jest.fn(() => ({ data: [], isLoading: false })),
+}));
+
 jest.mock("@/lib/supabase", () => ({
   useSupabase: () => mockSupabase,
   useSupabaseQuery: (_queryFn: unknown, _deps: unknown) => ({

--- a/apps/web/src/components/tournament/__tests__/tournament-sidebar-card.test.tsx
+++ b/apps/web/src/components/tournament/__tests__/tournament-sidebar-card.test.tsx
@@ -5,6 +5,11 @@ import { TournamentSidebarCard } from "../tournament-sidebar-card";
 // Mocks
 // ---------------------------------------------------------------------------
 
+// Mock @tanstack/react-query useQuery (used for user teams)
+jest.mock("@tanstack/react-query", () => ({
+  useQuery: jest.fn(() => ({ data: [], isLoading: false })),
+}));
+
 const mockChannel = {
   on: jest.fn().mockReturnThis(),
   subscribe: jest.fn((cb) => {

--- a/apps/web/src/components/tournament/register-modal.tsx
+++ b/apps/web/src/components/tournament/register-modal.tsx
@@ -556,7 +556,21 @@ function RegisterModalBody({
                   <FormItem>
                     <FormLabel>Register as</FormLabel>
                     <Select
-                      onValueChange={field.onChange}
+                      onValueChange={(value) => {
+                        field.onChange(value);
+
+                        const nextAlt = alts.find(
+                          (alt) => alt.id.toString() === value
+                        );
+
+                        if (!nextAlt?.first_name) {
+                          form.setValue("displayNameOption", "username");
+                        }
+
+                        if (!nextAlt?.country) {
+                          form.setValue("showCountryFlag", false);
+                        }
+                      }}
                       value={field.value}
                       disabled={isEditMode}
                     >

--- a/apps/web/src/components/tournament/register-modal.tsx
+++ b/apps/web/src/components/tournament/register-modal.tsx
@@ -76,6 +76,17 @@ export interface RegisterModalProps {
   onSuccess?: () => void;
 }
 
+interface RegisterModalBodyProps {
+  onOpenChange: (open: boolean) => void;
+  tournamentId: number;
+  tournamentSlug: string;
+  tournamentName: string;
+  startDate?: string | null;
+  isFull: boolean;
+  mode?: "register" | "edit";
+  onSuccess?: () => void;
+}
+
 // --------------------------------------------------------------------------
 // Helpers
 // --------------------------------------------------------------------------
@@ -161,11 +172,10 @@ const registrationSchema = z.object({
 type RegistrationFormData = z.infer<typeof registrationSchema>;
 
 // --------------------------------------------------------------------------
-// Component
+// RegisterModalBody (internal — only mounts when dialog is open)
 // --------------------------------------------------------------------------
 
-export function RegisterModal({
-  open,
+function RegisterModalBody({
   onOpenChange,
   tournamentId,
   tournamentSlug,
@@ -174,7 +184,7 @@ export function RegisterModal({
   isFull,
   mode = "register",
   onSuccess,
-}: RegisterModalProps) {
+}: RegisterModalBodyProps) {
   const isEditMode = mode === "edit";
   const router = useRouter();
   const { isAuthenticated } = useAuthContext();
@@ -208,10 +218,16 @@ export function RegisterModal({
   const selectedAlt = alts.find((a) => a.id.toString() === selectedAltId);
   const hasName = !!selectedAlt?.first_name;
 
-  // Load alts + teams when dialog opens
+  // Redirect unauthenticated users to sign-in
   useEffect(() => {
-    if (!open) return;
+    if (!isAuthenticated) {
+      onOpenChange(false);
+      router.push(`/sign-in?redirect=/tournaments/${tournamentSlug}`);
+    }
+  }, [isAuthenticated, onOpenChange, router, tournamentSlug]);
 
+  // Load alts + registration data on mount
+  useEffect(() => {
     let cancelled = false;
 
     async function loadData() {
@@ -264,27 +280,7 @@ export function RegisterModal({
     return () => {
       cancelled = true;
     };
-  }, [open, form, isEditMode, tournamentId]);
-
-  // Redirect unauthenticated users to sign-in when modal opens
-  useEffect(() => {
-    if (open && !isAuthenticated) {
-      onOpenChange(false);
-      router.push(`/sign-in?redirect=/tournaments/${tournamentSlug}`);
-    }
-  }, [open, isAuthenticated, onOpenChange, router, tournamentSlug]);
-
-  // Reset form when dialog closes
-  useEffect(() => {
-    if (!open) {
-      form.reset();
-      setError(null);
-      setAlts([]);
-      setRegistrationSuccess(null);
-      setTournamentFullError(false);
-      setEditRegistrationId(null);
-    }
-  }, [open, form]);
+  }, [form, isEditMode, tournamentId]);
 
   // --------------------------------------------------------------------------
   // Submit
@@ -350,445 +346,478 @@ export function RegisterModal({
   // --------------------------------------------------------------------------
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>
-            {isEditMode
-              ? "Edit Registration"
-              : isFull
-                ? "Join Waitlist"
-                : "Register for Tournament"}
-          </DialogTitle>
-          <DialogDescription>
-            {isEditMode
-              ? "Update your registration preferences for"
-              : isFull
-                ? "Join the waitlist for"
-                : "Register for"}{" "}
-            <strong>{tournamentName}</strong>
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      <DialogHeader>
+        <DialogTitle>
+          {isEditMode
+            ? "Edit Registration"
+            : isFull
+              ? "Join Waitlist"
+              : "Register for Tournament"}
+        </DialogTitle>
+        <DialogDescription>
+          {isEditMode
+            ? "Update your registration preferences for"
+            : isFull
+              ? "Join the waitlist for"
+              : "Register for"}{" "}
+          <strong>{tournamentName}</strong>
+        </DialogDescription>
+      </DialogHeader>
 
-        {/* Tournament Full State (3b) */}
-        {tournamentFullError ? (
-          <div className="space-y-6 py-4">
-            <div
-              className="rounded-lg border border-amber-500/20 bg-amber-500/10 p-5"
-              data-testid="tournament-full-state"
-            >
-              <div className="flex items-start gap-3">
-                <div className="rounded-full bg-amber-500/20 p-2.5 text-amber-600 dark:text-amber-400">
-                  <Users className="size-6" />
-                </div>
-                <div className="flex-1">
-                  <h3 className="text-lg font-semibold">
-                    This tournament is full
-                  </h3>
-                  <p className="text-muted-foreground mt-1 text-sm">
-                    All spots have been filled. You can join the waitlist to be
-                    notified if a spot opens up.
-                  </p>
-                </div>
+      {/* Tournament Full State (3b) */}
+      {tournamentFullError ? (
+        <div className="space-y-6 py-4">
+          <div
+            className="rounded-lg border border-amber-500/20 bg-amber-500/10 p-5"
+            data-testid="tournament-full-state"
+          >
+            <div className="flex items-start gap-3">
+              <div className="rounded-full bg-amber-500/20 p-2.5 text-amber-600 dark:text-amber-400">
+                <Users className="size-6" />
+              </div>
+              <div className="flex-1">
+                <h3 className="text-lg font-semibold">
+                  This tournament is full
+                </h3>
+                <p className="text-muted-foreground mt-1 text-sm">
+                  All spots have been filled. You can join the waitlist to be
+                  notified if a spot opens up.
+                </p>
               </div>
             </div>
+          </div>
 
-            <DialogFooter className="gap-2 sm:gap-0">
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              className="w-full sm:w-auto"
+            >
+              Close
+            </Button>
+          </DialogFooter>
+        </div>
+      ) : /* Success Confirmation State (3a) */
+      registrationSuccess ? (
+        <div className="space-y-6 py-4">
+          {/* Confirmation banner */}
+          <div
+            className={cn(
+              "rounded-lg border p-5",
+              registrationSuccess.status === "waitlist"
+                ? "border-amber-500/20 bg-amber-500/10"
+                : "border-emerald-500/20 bg-emerald-500/10"
+            )}
+            data-testid="registration-success-state"
+          >
+            <div className="flex items-start gap-3">
+              <div
+                className={cn(
+                  "rounded-full p-2.5",
+                  registrationSuccess.status === "waitlist"
+                    ? "bg-amber-500/20 text-amber-600 dark:text-amber-400"
+                    : "bg-emerald-500/20 text-emerald-600 dark:text-emerald-400"
+                )}
+              >
+                <CheckCircle2 className="size-7" />
+              </div>
+              <div className="flex-1">
+                <h3 className="text-lg font-semibold">
+                  {registrationSuccess.status === "waitlist"
+                    ? "Added to Waitlist"
+                    : "You're Registered!"}
+                </h3>
+                <p className="text-muted-foreground mt-1 text-sm">
+                  {registrationSuccess.status === "waitlist" ? (
+                    <>
+                      You&apos;ve been added to the waitlist
+                      {registrationSuccess.waitlistPosition
+                        ? ` at position #${registrationSuccess.waitlistPosition}`
+                        : ""}
+                      . You&apos;ll be notified if a spot opens up.
+                    </>
+                  ) : (
+                    `You're registered for ${tournamentName}`
+                  )}
+                </p>
+                {/* Tournament date/time */}
+                {startDate && (
+                  <p className="text-muted-foreground mt-2 flex items-center gap-1.5 text-xs">
+                    <Calendar className="size-3.5" />
+                    {formatTournamentDate(startDate)}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Next Steps */}
+          <div className="space-y-3">
+            <h4 className="text-sm font-medium">Next Steps</h4>
+            <ul className="text-muted-foreground space-y-2 text-sm">
+              {registrationSuccess.status === "registered" ? (
+                <>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5 text-emerald-500">•</span>
+                    <span>
+                      <strong className="text-foreground">
+                        Submit your team
+                      </strong>{" "}
+                      before the tournament starts
+                    </span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5 text-emerald-500">•</span>
+                    <span>
+                      <strong className="text-foreground">Check in</strong>{" "}
+                      when check-in opens (you&apos;ll be notified)
+                    </span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5 text-emerald-500">•</span>
+                    <span>
+                      Monitor the tournament page for updates and pairings
+                    </span>
+                  </li>
+                </>
+              ) : (
+                <>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5 text-amber-500">•</span>
+                    <span>
+                      You&apos;ll be automatically registered if a spot opens
+                    </span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-0.5 text-amber-500">•</span>
+                    <span>
+                      We&apos;ll notify you immediately if you move off the
+                      waitlist
+                    </span>
+                  </li>
+                </>
+              )}
+            </ul>
+          </div>
+
+          <DialogFooter className="gap-2 sm:gap-0">
+            {registrationSuccess.status === "registered" && (
               <Button
                 variant="outline"
-                onClick={() => onOpenChange(false)}
-                className="w-full sm:w-auto"
-              >
-                Close
-              </Button>
-            </DialogFooter>
-          </div>
-        ) : /* Success Confirmation State (3a) */
-        registrationSuccess ? (
-          <div className="space-y-6 py-4">
-            {/* Confirmation banner */}
-            <div
-              className={cn(
-                "rounded-lg border p-5",
-                registrationSuccess.status === "waitlist"
-                  ? "border-amber-500/20 bg-amber-500/10"
-                  : "border-emerald-500/20 bg-emerald-500/10"
-              )}
-              data-testid="registration-success-state"
-            >
-              <div className="flex items-start gap-3">
-                <div
-                  className={cn(
-                    "rounded-full p-2.5",
-                    registrationSuccess.status === "waitlist"
-                      ? "bg-amber-500/20 text-amber-600 dark:text-amber-400"
-                      : "bg-emerald-500/20 text-emerald-600 dark:text-emerald-400"
-                  )}
-                >
-                  <CheckCircle2 className="size-7" />
-                </div>
-                <div className="flex-1">
-                  <h3 className="text-lg font-semibold">
-                    {registrationSuccess.status === "waitlist"
-                      ? "Added to Waitlist"
-                      : "You're Registered!"}
-                  </h3>
-                  <p className="text-muted-foreground mt-1 text-sm">
-                    {registrationSuccess.status === "waitlist" ? (
-                      <>
-                        You&apos;ve been added to the waitlist
-                        {registrationSuccess.waitlistPosition
-                          ? ` at position #${registrationSuccess.waitlistPosition}`
-                          : ""}
-                        . You&apos;ll be notified if a spot opens up.
-                      </>
-                    ) : (
-                      `You're registered for ${tournamentName}`
-                    )}
-                  </p>
-                  {/* Tournament date/time */}
-                  {startDate && (
-                    <p className="text-muted-foreground mt-2 flex items-center gap-1.5 text-xs">
-                      <Calendar className="size-3.5" />
-                      {formatTournamentDate(startDate)}
-                    </p>
-                  )}
-                </div>
-              </div>
-            </div>
-
-            {/* Next Steps */}
-            <div className="space-y-3">
-              <h4 className="text-sm font-medium">Next Steps</h4>
-              <ul className="text-muted-foreground space-y-2 text-sm">
-                {registrationSuccess.status === "registered" ? (
-                  <>
-                    <li className="flex items-start gap-2">
-                      <span className="mt-0.5 text-emerald-500">•</span>
-                      <span>
-                        <strong className="text-foreground">
-                          Submit your team
-                        </strong>{" "}
-                        before the tournament starts
-                      </span>
-                    </li>
-                    <li className="flex items-start gap-2">
-                      <span className="mt-0.5 text-emerald-500">•</span>
-                      <span>
-                        <strong className="text-foreground">Check in</strong>{" "}
-                        when check-in opens (you&apos;ll be notified)
-                      </span>
-                    </li>
-                    <li className="flex items-start gap-2">
-                      <span className="mt-0.5 text-emerald-500">•</span>
-                      <span>
-                        Monitor the tournament page for updates and pairings
-                      </span>
-                    </li>
-                  </>
-                ) : (
-                  <>
-                    <li className="flex items-start gap-2">
-                      <span className="mt-0.5 text-amber-500">•</span>
-                      <span>
-                        You&apos;ll be automatically registered if a spot opens
-                      </span>
-                    </li>
-                    <li className="flex items-start gap-2">
-                      <span className="mt-0.5 text-amber-500">•</span>
-                      <span>
-                        We&apos;ll notify you immediately if you move off the
-                        waitlist
-                      </span>
-                    </li>
-                  </>
-                )}
-              </ul>
-            </div>
-
-            <DialogFooter className="gap-2 sm:gap-0">
-              {registrationSuccess.status === "registered" && (
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    onOpenChange(false);
-                    router.push(`/tournaments/${tournamentSlug}#team`);
-                  }}
-                  className="w-full sm:w-auto"
-                >
-                  <ClipboardList className="mr-2 size-4" />
-                  Submit Your Team
-                </Button>
-              )}
-              <Button
                 onClick={() => {
                   onOpenChange(false);
-                  if (registrationSuccess.status === "registered") {
-                    router.push(`/tournaments/${tournamentSlug}`);
-                  }
+                  router.push(`/tournaments/${tournamentSlug}#team`);
                 }}
                 className="w-full sm:w-auto"
               >
-                {registrationSuccess.status === "registered"
-                  ? "Go to Tournament"
-                  : "Close"}
+                <ClipboardList className="mr-2 size-4" />
+                Submit Your Team
               </Button>
-            </DialogFooter>
-          </div>
-        ) : isLoadingData ? (
-          <div className="flex items-center justify-center py-8">
-            <Loader2 className="size-6 animate-spin" />
-          </div>
-        ) : alts.length === 0 ? (
-          <div className="text-muted-foreground py-8 text-center text-sm">
-            <p>No player profiles found.</p>
-            <p className="mt-1">
-              Please contact support if you believe this is an error.
-            </p>
-          </div>
-        ) : (
-          <Form {...form}>
-            <form
-              onSubmit={form.handleSubmit(onSubmit)}
-              className="space-y-6 py-4"
+            )}
+            <Button
+              onClick={() => {
+                onOpenChange(false);
+                if (registrationSuccess.status === "registered") {
+                  router.push(`/tournaments/${tournamentSlug}`);
+                }
+              }}
+              className="w-full sm:w-auto"
             >
-              {/* Alt Selection (only show if multiple alts; disabled in edit mode) */}
-              {alts.length > 1 && (
-                <FormField
-                  control={form.control}
-                  name="altId"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Register as</FormLabel>
-                      <Select
-                        onValueChange={field.onChange}
-                        value={field.value}
-                        disabled={isEditMode}
-                      >
-                        <FormControl>
-                          <SelectTrigger className="w-full">
-                            <SelectValue placeholder="Select profile">
-                              {selectedAlt
-                                ? `${selectedAlt.username || selectedAlt.username} (@${selectedAlt.username})`
-                                : "Select profile"}
-                            </SelectValue>
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {alts.map((alt) => (
-                            <SelectItem key={alt.id} value={alt.id.toString()}>
-                              {alt.username || alt.username} (@
-                              {alt.username})
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              )}
-
-              {/* In-Game Name */}
+              {registrationSuccess.status === "registered"
+                ? "Go to Tournament"
+                : "Close"}
+            </Button>
+          </DialogFooter>
+        </div>
+      ) : isLoadingData ? (
+        <div className="flex items-center justify-center py-8">
+          <Loader2 className="size-6 animate-spin" />
+        </div>
+      ) : alts.length === 0 ? (
+        <div className="text-muted-foreground py-8 text-center text-sm">
+          <p>No player profiles found.</p>
+          <p className="mt-1">
+            Please contact support if you believe this is an error.
+          </p>
+        </div>
+      ) : (
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="space-y-6 py-4"
+          >
+            {/* Alt Selection (only show if multiple alts; disabled in edit mode) */}
+            {alts.length > 1 && (
               <FormField
                 control={form.control}
-                name="inGameName"
+                name="altId"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>In-game name</FormLabel>
-                    <FormControl>
-                      <Input placeholder="Switch profile name" {...field} />
-                    </FormControl>
-                    <FormDescription>
-                      Your Nintendo Switch profile name for verification
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              {/* Display Name Options */}
-              <FormField
-                control={form.control}
-                name="displayNameOption"
-                render={({ field }) => (
-                  <FormItem className="space-y-3">
-                    <FormLabel>Display name</FormLabel>
-                    <FormControl>
-                      <RadioGroup
-                        onValueChange={field.onChange}
-                        value={field.value}
-                      >
-                        <div className="flex items-center gap-2">
-                          <RadioGroupItem
-                            value="username"
-                            id="display-username"
-                          />
-                          <FormLabel
-                            htmlFor="display-username"
-                            className="font-normal"
-                          >
-                            Username
-                            {selectedAlt && (
-                              <span className="text-muted-foreground ml-1">
-                                ({selectedAlt.username})
-                              </span>
-                            )}
-                          </FormLabel>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <RadioGroupItem
-                            value="shortened"
-                            id="display-shortened"
-                            disabled={!hasName}
-                          />
-                          <FormLabel
-                            htmlFor="display-shortened"
-                            className={cn(
-                              "font-normal",
-                              !hasName && "text-muted-foreground"
-                            )}
-                          >
-                            Shortened name
-                            {selectedAlt && hasName ? (
-                              <span className="text-muted-foreground ml-1">
-                                ({getShortenedName(selectedAlt)})
-                              </span>
-                            ) : (
-                              <span className="text-muted-foreground ml-1">
-                                (set name in profile)
-                              </span>
-                            )}
-                          </FormLabel>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <RadioGroupItem
-                            value="full"
-                            id="display-full"
-                            disabled={!hasName}
-                          />
-                          <FormLabel
-                            htmlFor="display-full"
-                            className={cn(
-                              "font-normal",
-                              !hasName && "text-muted-foreground"
-                            )}
-                          >
-                            Full name
-                            {selectedAlt && hasName ? (
-                              <span className="text-muted-foreground ml-1">
-                                ({getFullName(selectedAlt)})
-                              </span>
-                            ) : (
-                              <span className="text-muted-foreground ml-1">
-                                (set name in profile)
-                              </span>
-                            )}
-                          </FormLabel>
-                        </div>
-                      </RadioGroup>
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              {/* Country Flag Option */}
-              <FormField
-                control={form.control}
-                name="showCountryFlag"
-                render={({ field }) => (
-                  <FormItem className="flex flex-row items-center gap-2 space-y-0">
-                    <FormControl>
-                      <Checkbox
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                        disabled={!selectedAlt?.country}
-                      />
-                    </FormControl>
-                    <FormLabel
-                      className={cn(
-                        "font-normal",
-                        !selectedAlt?.country && "text-muted-foreground"
-                      )}
+                    <FormLabel>Register as</FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      value={field.value}
+                      disabled={isEditMode}
                     >
-                      Show country flag
-                      {selectedAlt?.country ? (
-                        <span className="ml-1">
-                          {countryCodeToFlag(selectedAlt.country)}
-                        </span>
-                      ) : (
-                        <span className="text-muted-foreground ml-1">
-                          (set country in profile)
-                        </span>
-                      )}
-                    </FormLabel>
+                      <FormControl>
+                        <SelectTrigger className="w-full">
+                          <SelectValue placeholder="Select profile">
+                            {selectedAlt
+                              ? `${selectedAlt.username || selectedAlt.username} (@${selectedAlt.username})`
+                              : "Select profile"}
+                          </SelectValue>
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {alts.map((alt) => (
+                          <SelectItem key={alt.id} value={alt.id.toString()}>
+                            {alt.username || alt.username} (@
+                            {alt.username})
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
                   </FormItem>
                 )}
               />
+            )}
 
-              {/* Bracket Preview */}
-              {selectedAlt && (
-                <div className="bg-muted rounded-lg p-4">
-                  <p className="text-muted-foreground mb-2 text-xs">
-                    Bracket Preview
-                  </p>
-                  <div className="space-y-0.5">
-                    <p className="font-medium">
-                      {getDisplayName(selectedAlt, displayNameOption)}
-                      {showCountryFlag && selectedAlt.country && (
-                        <span className="ml-1.5">
-                          {countryCodeToFlag(selectedAlt.country)}
-                        </span>
-                      )}
-                    </p>
-                    {inGameName && (
-                      <p className="text-muted-foreground text-sm">
-                        {inGameName}
-                      </p>
-                    )}
-                  </div>
-                </div>
+            {/* In-Game Name */}
+            <FormField
+              control={form.control}
+              name="inGameName"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>In-game name</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Switch profile name" {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    Your Nintendo Switch profile name for verification
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
               )}
+            />
 
-              {error && <p className="text-destructive text-sm">{error}</p>}
-
-              <DialogFooter>
-                <DialogClose
-                  render={
-                    <Button
-                      type="button"
-                      variant="outline"
-                      disabled={isSubmitting}
+            {/* Display Name Options */}
+            <FormField
+              control={form.control}
+              name="displayNameOption"
+              render={({ field }) => (
+                <FormItem className="space-y-3">
+                  <FormLabel>Display name</FormLabel>
+                  <FormControl>
+                    <RadioGroup
+                      onValueChange={field.onChange}
+                      value={field.value}
                     >
-                      Cancel
-                    </Button>
-                  }
-                />
-                <Button
-                  type="submit"
-                  disabled={isSubmitting || isLoadingData || !selectedAltId}
-                >
-                  {isSubmitting ? (
-                    <>
-                      <Loader2 className="mr-2 size-4 animate-spin" />
-                      {isEditMode
-                        ? "Saving..."
-                        : isFull
-                          ? "Joining..."
-                          : "Registering..."}
-                    </>
-                  ) : isEditMode ? (
-                    "Save Changes"
-                  ) : isFull ? (
-                    "Join Waitlist"
-                  ) : (
-                    "Confirm Registration"
+                      <div className="flex items-center gap-2">
+                        <RadioGroupItem
+                          value="username"
+                          id="display-username"
+                        />
+                        <FormLabel
+                          htmlFor="display-username"
+                          className="font-normal"
+                        >
+                          Username
+                          {selectedAlt && (
+                            <span className="text-muted-foreground ml-1">
+                              ({selectedAlt.username})
+                            </span>
+                          )}
+                        </FormLabel>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <RadioGroupItem
+                          value="shortened"
+                          id="display-shortened"
+                          disabled={!hasName}
+                        />
+                        <FormLabel
+                          htmlFor="display-shortened"
+                          className={cn(
+                            "font-normal",
+                            !hasName && "text-muted-foreground"
+                          )}
+                        >
+                          Shortened name
+                          {selectedAlt && hasName ? (
+                            <span className="text-muted-foreground ml-1">
+                              ({getShortenedName(selectedAlt)})
+                            </span>
+                          ) : (
+                            <span className="text-muted-foreground ml-1">
+                              (set name in profile)
+                            </span>
+                          )}
+                        </FormLabel>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <RadioGroupItem
+                          value="full"
+                          id="display-full"
+                          disabled={!hasName}
+                        />
+                        <FormLabel
+                          htmlFor="display-full"
+                          className={cn(
+                            "font-normal",
+                            !hasName && "text-muted-foreground"
+                          )}
+                        >
+                          Full name
+                          {selectedAlt && hasName ? (
+                            <span className="text-muted-foreground ml-1">
+                              ({getFullName(selectedAlt)})
+                            </span>
+                          ) : (
+                            <span className="text-muted-foreground ml-1">
+                              (set name in profile)
+                            </span>
+                          )}
+                        </FormLabel>
+                      </div>
+                    </RadioGroup>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Country Flag Option */}
+            <FormField
+              control={form.control}
+              name="showCountryFlag"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-center gap-2 space-y-0">
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                      disabled={!selectedAlt?.country}
+                    />
+                  </FormControl>
+                  <FormLabel
+                    className={cn(
+                      "font-normal",
+                      !selectedAlt?.country && "text-muted-foreground"
+                    )}
+                  >
+                    Show country flag
+                    {selectedAlt?.country ? (
+                      <span className="ml-1">
+                        {countryCodeToFlag(selectedAlt.country)}
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground ml-1">
+                        (set country in profile)
+                      </span>
+                    )}
+                  </FormLabel>
+                </FormItem>
+              )}
+            />
+
+            {/* Bracket Preview */}
+            {selectedAlt && (
+              <div className="bg-muted rounded-lg p-4">
+                <p className="text-muted-foreground mb-2 text-xs">
+                  Bracket Preview
+                </p>
+                <div className="space-y-0.5">
+                  <p className="font-medium">
+                    {getDisplayName(selectedAlt, displayNameOption)}
+                    {showCountryFlag && selectedAlt.country && (
+                      <span className="ml-1.5">
+                        {countryCodeToFlag(selectedAlt.country)}
+                      </span>
+                    )}
+                  </p>
+                  {inGameName && (
+                    <p className="text-muted-foreground text-sm">
+                      {inGameName}
+                    </p>
                   )}
-                </Button>
-              </DialogFooter>
-            </form>
-          </Form>
+                </div>
+              </div>
+            )}
+
+            {error && <p className="text-destructive text-sm">{error}</p>}
+
+            <DialogFooter>
+              <DialogClose
+                render={
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={isSubmitting}
+                  >
+                    Cancel
+                  </Button>
+                }
+              />
+              <Button
+                type="submit"
+                disabled={isSubmitting || isLoadingData || !selectedAltId}
+              >
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className="mr-2 size-4 animate-spin" />
+                    {isEditMode
+                      ? "Saving..."
+                      : isFull
+                        ? "Joining..."
+                        : "Registering..."}
+                  </>
+                ) : isEditMode ? (
+                  "Save Changes"
+                ) : isFull ? (
+                  "Join Waitlist"
+                ) : (
+                  "Confirm Registration"
+                )}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      )}
+    </>
+  );
+}
+
+// --------------------------------------------------------------------------
+// RegisterModal (public wrapper)
+// --------------------------------------------------------------------------
+
+export function RegisterModal({
+  open,
+  onOpenChange,
+  tournamentId,
+  tournamentSlug,
+  tournamentName,
+  startDate,
+  isFull,
+  mode = "register",
+  onSuccess,
+}: RegisterModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        {open && (
+          <RegisterModalBody
+            tournamentId={tournamentId}
+            tournamentSlug={tournamentSlug}
+            tournamentName={tournamentName}
+            startDate={startDate}
+            isFull={isFull}
+            mode={mode}
+            onSuccess={onSuccess}
+            onOpenChange={onOpenChange}
+          />
         )}
       </DialogContent>
     </Dialog>

--- a/apps/web/src/components/tournament/tournament-sidebar-card.tsx
+++ b/apps/web/src/components/tournament/tournament-sidebar-card.tsx
@@ -348,6 +348,7 @@ export function TournamentSidebarCard({
 
   useEffect(() => {
     if (!teamEditMode || !rawText.trim()) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setValidation(null);
       return;
     }

--- a/apps/web/src/components/tournament/tournament-sidebar-card.tsx
+++ b/apps/web/src/components/tournament/tournament-sidebar-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, type ReactNode } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { cn } from "@/lib/utils";
 import {
   useSupabase,
@@ -268,9 +269,6 @@ export function TournamentSidebarCard({
   const [isSubmittingTeam, setIsSubmittingTeam] = useState(false);
 
   // ---- Existing teams for selection ----
-  const [availableTeams, setAvailableTeams] = useState<
-    Array<{ id: number; name: string | null; pokemonCount: number }>
-  >([]);
   const [isSelectingTeam, setIsSelectingTeam] = useState(false);
 
   // ---- Data fetching ----
@@ -369,22 +367,15 @@ export function TournamentSidebarCard({
     registrationStatus?.userStatus?.status === "checked_in" ||
     (checkInStatus?.isCheckedIn ?? false);
 
-  useEffect(() => {
-    if (!showTeamSection) return;
-
-    let cancelled = false;
-
-    getUserTeamsAction().then((result) => {
-      if (cancelled) return;
-      if (result.success) {
-        setAvailableTeams(result.data);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [showTeamSection]);
+  const { data: availableTeams = [] } = useQuery({
+    queryKey: ['user-teams-for-tournament', tournamentId],
+    queryFn: async () => {
+      const result = await getUserTeamsAction();
+      if (result.success) return result.data;
+      return [];
+    },
+    enabled: showTeamSection,
+  });
 
   // ---- Handlers ----
 

--- a/apps/web/src/components/tournament/tournament-sidebar-card.tsx
+++ b/apps/web/src/components/tournament/tournament-sidebar-card.tsx
@@ -65,6 +65,7 @@ import {
 } from "@trainers/validators/team";
 import { RegisterModal } from "./register-modal";
 import { TeamPreview } from "./team-preview";
+import { queryKeys } from "@/lib/query-keys";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -368,7 +369,7 @@ export function TournamentSidebarCard({
     (checkInStatus?.isCheckedIn ?? false);
 
   const { data: availableTeams = [] } = useQuery({
-    queryKey: ['user-teams-for-tournament', tournamentId],
+    queryKey: queryKeys.tournament.userTeams(tournamentId),
     queryFn: async () => {
       const result = await getUserTeamsAction();
       if (result.success) return result.data;

--- a/apps/web/src/components/tournaments/manage/__tests__/tournament-settings.test.tsx
+++ b/apps/web/src/components/tournaments/manage/__tests__/tournament-settings.test.tsx
@@ -862,9 +862,9 @@ describe("TournamentSettings", () => {
       );
 
       await user.click(screen.getByRole("button", { name: /edit settings/i }));
-      // Use getByLabelText since Base UI's Switch derives its accessible name
-      // from htmlFor/id, not aria-label.
-      await user.click(screen.getByLabelText("Late Registration"));
+      // Use getByRole("switch") since Base UI's Switch renders role="switch"
+      // with aria-labelledby pointing to the label.
+      await user.click(screen.getByRole("switch", { name: "Late Registration" }));
       await user.click(screen.getByRole("button", { name: /save changes/i }));
 
       expect(updateTournament).toHaveBeenCalledTimes(1);
@@ -888,7 +888,7 @@ describe("TournamentSettings", () => {
       );
 
       await user.click(screen.getByRole("button", { name: /edit settings/i }));
-      await user.click(screen.getByLabelText("Player Cap"));
+      await user.click(screen.getByRole("switch", { name: "Player Cap" }));
       await user.click(screen.getByRole("button", { name: /save changes/i }));
 
       expect(updateTournament).toHaveBeenCalledTimes(1);

--- a/apps/web/src/components/tournaments/manage/drop-player-dialog.tsx
+++ b/apps/web/src/components/tournaments/manage/drop-player-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import {
   Dialog,
   DialogClose,
@@ -85,13 +85,15 @@ export function DropPlayerDialog({
       : "This will drop the player from the tournament. Choose a reason category and optionally provide notes.";
 
   // Reset form state when dialog closes
-  useEffect(() => {
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (prevOpen !== open) {
+    setPrevOpen(open);
     if (!open) {
       setCategory(null);
       setNotes("");
       setIsSubmitting(false);
     }
-  }, [open]);
+  }
 
   const handleConfirm = async () => {
     if (!isFormValid || category === null) return;

--- a/apps/web/src/components/ui/carousel.tsx
+++ b/apps/web/src/components/ui/carousel.tsx
@@ -95,6 +95,7 @@ function Carousel({
 
   React.useEffect(() => {
     if (!api) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     onSelect(api);
     api.on("reInit", onSelect);
     api.on("select", onSelect);

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -86,6 +86,7 @@ function SidebarProvider({
     if (match) {
       const w = Number(match[1]);
       if (w >= SIDEBAR_MIN_WIDTH && w <= SIDEBAR_MAX_WIDTH) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setSidebarWidth(w);
       }
     }

--- a/apps/web/src/lib/__tests__/query-keys.test.ts
+++ b/apps/web/src/lib/__tests__/query-keys.test.ts
@@ -1,0 +1,78 @@
+import { queryKeys } from "../query-keys";
+
+describe("queryKeys", () => {
+  describe("admin", () => {
+    it("returns broadest admin key", () => {
+      expect(queryKeys.admin.all).toEqual(["admin"]);
+    });
+
+    it("returns user detail key with userId", () => {
+      expect(queryKeys.admin.userDetail("user-123")).toEqual([
+        "admin-user-detail",
+        "user-123",
+      ]);
+    });
+
+    it("returns user detail key with null userId", () => {
+      expect(queryKeys.admin.userDetail(null)).toEqual([
+        "admin-user-detail",
+        null,
+      ]);
+    });
+  });
+
+  describe("sudo", () => {
+    it("returns all key", () => {
+      expect(queryKeys.sudo.all).toEqual(["sudo-status"]);
+    });
+
+    it("returns status key", () => {
+      expect(queryKeys.sudo.status()).toEqual(["sudo-status"]);
+    });
+  });
+
+  describe("tournament", () => {
+    it("returns broadest tournament key", () => {
+      expect(queryKeys.tournament.all).toEqual(["tournament"]);
+    });
+
+    it("returns current match banner key", () => {
+      expect(queryKeys.tournament.currentMatchBanner(42, "user-1")).toEqual([
+        "current-match-banner",
+        42,
+        "user-1",
+      ]);
+    });
+
+    it("returns user teams key", () => {
+      expect(queryKeys.tournament.userTeams(7)).toEqual([
+        "user-teams-for-tournament",
+        7,
+      ]);
+    });
+  });
+
+  describe("match", () => {
+    it("returns broadest match key", () => {
+      expect(queryKeys.match.all).toEqual(["match"]);
+    });
+
+    it("returns post match summary key", () => {
+      expect(queryKeys.match.postMatchSummary(1, 2, 3)).toEqual([
+        "post-match-summary",
+        1,
+        2,
+        3,
+      ]);
+    });
+
+    it("handles undefined/null parameters", () => {
+      expect(queryKeys.match.postMatchSummary(undefined, undefined, null)).toEqual([
+        "post-match-summary",
+        undefined,
+        undefined,
+        null,
+      ]);
+    });
+  });
+});

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -1,0 +1,43 @@
+/**
+ * Query Key Factories
+ *
+ * Centralizes TanStack Query keys so they can be shared across hooks,
+ * prefetching, and invalidation call sites without copy-pasting strings.
+ *
+ * Convention:
+ * - Each domain gets a factory object
+ * - `.all` returns the broadest key (for bulk invalidation)
+ * - Narrower keys extend `.all` with additional discriminators
+ */
+
+export const queryKeys = {
+  admin: {
+    all: ["admin"] as const,
+    userDetail: (userId: string | null | undefined) =>
+      ["admin-user-detail", userId] as const,
+  },
+
+  sudo: {
+    all: ["sudo-status"] as const,
+    status: () => ["sudo-status"] as const,
+  },
+
+  tournament: {
+    all: ["tournament"] as const,
+    currentMatchBanner: (
+      tournamentId: number | undefined,
+      userId: string | undefined
+    ) => ["current-match-banner", tournamentId, userId] as const,
+    userTeams: (tournamentId: number | undefined) =>
+      ["user-teams-for-tournament", tournamentId] as const,
+  },
+
+  match: {
+    all: ["match"] as const,
+    postMatchSummary: (
+      tournamentId: number | undefined,
+      matchId: number | undefined,
+      userAltId: number | null | undefined
+    ) => ["post-match-summary", tournamentId, matchId, userAltId] as const,
+  },
+} as const;

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -186,7 +186,7 @@
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: currentColor;
+  background: currentcolor;
   margin-top: 2px;
   border: none;
   transition:
@@ -196,7 +196,7 @@
 
 .spread-slider[data-at-bump]::-webkit-slider-thumb {
   background: var(--card, #fff);
-  box-shadow: inset 0 0 0 2px currentColor;
+  box-shadow: inset 0 0 0 2px currentcolor;
 }
 
 .spread-slider::-moz-range-track {
@@ -209,7 +209,7 @@
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: currentColor;
+  background: currentcolor;
   border: none;
   transition:
     background 0.15s ease,
@@ -218,7 +218,7 @@
 
 .spread-slider[data-at-bump]::-moz-range-thumb {
   background: var(--card, #fff);
-  box-shadow: inset 0 0 0 2px currentColor;
+  box-shadow: inset 0 0 0 2px currentcolor;
 }
 
 /* -- Active row @container responsive layout ------------------------------ */

--- a/apps/web/src/test-setup.ts
+++ b/apps/web/src/test-setup.ts
@@ -13,6 +13,25 @@ Object.assign(globalThis, {
 
 import "@testing-library/jest-dom";
 
+// Polyfill PointerEvent for JSDOM — required by Base UI components (Switch, etc.)
+// that attach pointer event listeners. Guard on MouseEvent existing (not available
+// in pure Node environments used by API route tests).
+if (
+  typeof globalThis.PointerEvent === "undefined" &&
+  typeof globalThis.MouseEvent !== "undefined"
+) {
+  // @ts-expect-error — minimal polyfill for JSDOM
+  globalThis.PointerEvent = class PointerEvent extends MouseEvent {
+    readonly pointerId: number;
+    readonly pointerType: string;
+    constructor(type: string, params: PointerEventInit = {}) {
+      super(type, params);
+      this.pointerId = params.pointerId ?? 0;
+      this.pointerType = params.pointerType ?? "";
+    }
+  };
+}
+
 // Polyfill window.matchMedia for components using useIsMobile() and other
 // match-media-driven hooks. JSDOM doesn't implement it; the hook subscribes
 // at mount via matchMedia(query).addEventListener.

--- a/packages/supabase/src/mutations/__tests__/users.test.ts
+++ b/packages/supabase/src/mutations/__tests__/users.test.ts
@@ -628,7 +628,6 @@ describe("User Mutations", () => {
       expect(insertMock).toHaveBeenCalledWith({
         user_id: mockUser.id,
         username: "player",
-        display_name: "player",
         avatar_url: "https://example.com/avatar.png",
       });
     });
@@ -661,7 +660,6 @@ describe("User Mutations", () => {
       expect(insertMock).toHaveBeenCalledWith(
         expect.objectContaining({
           username: "MixedCase",
-          display_name: "MixedCase",
         })
       );
     });

--- a/packages/supabase/src/mutations/communities.ts
+++ b/packages/supabase/src/mutations/communities.ts
@@ -550,18 +550,19 @@ export async function addStaffToGroup(
 
   // Remove any existing user_group_roles for this community
   if (existingGroupRoleIds.length > 0) {
-    await supabase
+    const { error: deleteError } = await supabase
       .from("user_group_roles")
       .delete()
       .eq("user_id", userId)
       .in("group_role_id", existingGroupRoleIds);
+
+    if (deleteError) throw deleteError;
   }
 
   // Add user to the new group
-  const { error: roleError } = await supabase.from("user_group_roles").insert({
-    user_id: userId,
-    group_role_id: groupRole.id,
-  });
+  const { error: roleError } = await supabase
+    .from("user_group_roles")
+    .insert({ user_id: userId, group_role_id: groupRole.id });
 
   if (roleError) throw roleError;
 

--- a/packages/supabase/supabase/migrations/20260505194312_fix_user_group_roles_select_rls.sql
+++ b/packages/supabase/supabase/migrations/20260505194312_fix_user_group_roles_select_rls.sql
@@ -1,0 +1,28 @@
+-- Fix user_group_roles SELECT RLS policy
+--
+-- Problem: The existing SELECT policy only allows users to see their OWN
+-- group role assignments (user_id = auth.uid()). This prevents community
+-- owners and staff managers from seeing other users' role assignments,
+-- which breaks the staff management UI (everyone appears "Unassigned")
+-- and causes duplicate-key errors when moving staff (DELETE can't "see"
+-- rows to delete them via PostgREST).
+--
+-- Fix: Add a SELECT policy that allows community owners and admins to
+-- see all user_group_roles for groups in their community.
+
+-- Community owners and admins can view all group role assignments for their community
+CREATE POLICY "Community managers can view group roles"
+  ON public.user_group_roles
+  FOR SELECT
+  TO authenticated
+  USING (
+    is_community_owner(
+      get_community_id_from_group_role(group_role_id),
+      (SELECT auth.uid())
+    )
+    OR user_has_community_role(
+      get_community_id_from_group_role(group_role_id),
+      (SELECT auth.uid()),
+      'org_admin'
+    )
+  );

--- a/packages/validators/src/__tests__/team-builder.test.ts
+++ b/packages/validators/src/__tests__/team-builder.test.ts
@@ -5,6 +5,7 @@ import {
   updateTeamInputSchema,
   deleteTeamInputSchema,
   forkTeamInputSchema,
+  transferTeamInputSchema,
   addPokemonInputSchema,
   updatePokemonInputSchema,
   removePokemonInputSchema,
@@ -652,5 +653,56 @@ describe("teamUpdateDataSchema", () => {
         tags: Array.from({ length: 10 }, (_, i) => `tag${i}`),
       }).success
     ).toBe(true);
+  });
+});
+
+// =============================================================================
+// transferTeamInputSchema
+// =============================================================================
+
+describe("transferTeamInputSchema", () => {
+  it("accepts valid teamId and targetAltId", () => {
+    const result = transferTeamInputSchema.safeParse({
+      teamId: 1,
+      targetAltId: 2,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-positive teamId", () => {
+    expect(
+      transferTeamInputSchema.safeParse({ teamId: 0, targetAltId: 1 }).success
+    ).toBe(false);
+    expect(
+      transferTeamInputSchema.safeParse({ teamId: -1, targetAltId: 1 }).success
+    ).toBe(false);
+  });
+
+  it("rejects non-positive targetAltId", () => {
+    expect(
+      transferTeamInputSchema.safeParse({ teamId: 1, targetAltId: 0 }).success
+    ).toBe(false);
+    expect(
+      transferTeamInputSchema.safeParse({ teamId: 1, targetAltId: -5 }).success
+    ).toBe(false);
+  });
+
+  it("rejects missing fields", () => {
+    expect(transferTeamInputSchema.safeParse({}).success).toBe(false);
+    expect(
+      transferTeamInputSchema.safeParse({ teamId: 1 }).success
+    ).toBe(false);
+    expect(
+      transferTeamInputSchema.safeParse({ targetAltId: 1 }).success
+    ).toBe(false);
+  });
+
+  it("rejects non-integer values", () => {
+    expect(
+      transferTeamInputSchema.safeParse({ teamId: 1.5, targetAltId: 2 }).success
+    ).toBe(false);
+    expect(
+      transferTeamInputSchema.safeParse({ teamId: 1, targetAltId: 2.7 }).success
+    ).toBe(false);
   });
 });

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -190,6 +190,8 @@ export {
   deleteTeamInputSchema,
   forkTeamInputSchema,
   type ForkTeamInput,
+  transferTeamInputSchema,
+  type TransferTeamInput,
   addPokemonInputSchema,
   type AddPokemonInput,
   updatePokemonInputSchema,

--- a/packages/validators/src/team-builder.ts
+++ b/packages/validators/src/team-builder.ts
@@ -50,6 +50,14 @@ export const forkTeamInputSchema = z.object({
 
 export type ForkTeamInput = z.infer<typeof forkTeamInputSchema>;
 
+/** Input for transferring a team to a different alt. */
+export const transferTeamInputSchema = z.object({
+  teamId: positiveIntSchema,
+  targetAltId: positiveIntSchema,
+});
+
+export type TransferTeamInput = z.infer<typeof transferTeamInputSchema>;
+
 // =============================================================================
 // Pokemon CRUD schemas
 // =============================================================================


### PR DESCRIPTION
Replace vertically-stacked SideColumn components with a 3-column grid layout (Ours | Label | Theirs) matching the speed tiers modifiers pattern for visual consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transfer team between alts; inline team renaming and alt picker in workspace.
  * Opponent-side EV override control.

* **Bug Fixes**
  * EV draft totals reset correctly when switching Pokémon.
  * Clipboard copy reports failures to the user.
  * Per-row mega scoping adjusted for more accurate calc results.

* **UI Improvements**
  * Sides redesigned to Ours/Theirs; spacing, padding, and accessibility tweaks; stat labels support nature cycling.

* **Tests**
  * Many tests and fixtures updated to match new rendering and calc behaviors.

* **Chores**
  * Validator exports added for team transfer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->