### PR TITLE
feat: builder UX overhaul — speed tiers redesign, weather sync, subdomain routing, cross-subdomain auth, local persistence

### DIFF
--- a/apps/web/src/__tests__/proxy.test.ts
+++ b/apps/web/src/__tests__/proxy.test.ts
@@ -313,5 +313,21 @@ describe("proxy", () => {
       const cookie = result.cookies.get("sb-access-token");
       expect(cookie?.value).toBe("refreshed-value");
     });
+
+    it("should NOT double-prefix when path already starts with rewrite base", async () => {
+      createMockSupabaseClient({
+        user: { id: "user-1", email: "u@test.com" },
+      });
+
+      const result = await proxy(
+        createRequest("/dashboard/teams", "http://dashboard.trainers.gg", {
+          host: "dashboard.trainers.gg",
+        })
+      );
+
+      const rewriteUrl = result.headers.get("x-middleware-rewrite");
+      expect(rewriteUrl).toContain("/dashboard/teams");
+      expect(rewriteUrl).not.toContain("/dashboard/dashboard");
+    });
   });
 });

--- a/apps/web/src/__tests__/proxy.test.ts
+++ b/apps/web/src/__tests__/proxy.test.ts
@@ -40,9 +40,10 @@ function createMockJWT(payload: object): string {
 // Helper to create a NextRequest
 function createRequest(
   path: string,
-  base = "http://localhost:3000"
+  base = "http://localhost:3000",
+  headers?: Record<string, string>
 ): NextRequest {
-  return new NextRequest(new URL(path, base));
+  return new NextRequest(new URL(path, base), { headers });
 }
 
 // Helper to create a mock Supabase client + response pair
@@ -213,6 +214,103 @@ describe("proxy", () => {
       const result = await proxy(createRequest("/sign-in"));
 
       expect(result.headers.get("location")).toBeNull();
+    });
+  });
+
+  // ── Subdomain rewrites ────────────────────────────────────
+  describe("subdomain rewrites", () => {
+    it("should rewrite dashboard.trainers.gg/ to /dashboard for authenticated users", async () => {
+      createMockSupabaseClient({
+        user: { id: "user-1", email: "u@test.com" },
+      });
+
+      const result = await proxy(
+        createRequest("/", "http://dashboard.trainers.gg", {
+          host: "dashboard.trainers.gg",
+        })
+      );
+
+      const rewriteUrl = result.headers.get("x-middleware-rewrite");
+      expect(rewriteUrl).toContain("/dashboard");
+    });
+
+    it("should rewrite dashboard.trainers.gg/overview to /dashboard/overview", async () => {
+      createMockSupabaseClient({
+        user: { id: "user-1", email: "u@test.com" },
+      });
+
+      const result = await proxy(
+        createRequest("/overview", "http://dashboard.trainers.gg", {
+          host: "dashboard.trainers.gg",
+        })
+      );
+
+      const rewriteUrl = result.headers.get("x-middleware-rewrite");
+      expect(rewriteUrl).toContain("/dashboard/overview");
+    });
+
+    it("should strip port suffix from host header for matching", async () => {
+      createMockSupabaseClient({
+        user: { id: "user-1", email: "u@test.com" },
+      });
+
+      const result = await proxy(
+        createRequest("/", "http://builder.trainers.gg:3000", {
+          host: "builder.trainers.gg:3000",
+        })
+      );
+
+      const rewriteUrl = result.headers.get("x-middleware-rewrite");
+      expect(rewriteUrl).toContain("/builder");
+    });
+
+    it("should NOT rewrite for non-mapped hostnames", async () => {
+      const { mockResponse } = createMockSupabaseClient({
+        user: { id: "user-1", email: "u@test.com" },
+      });
+
+      const result = await proxy(
+        createRequest("/", "http://unknown.trainers.gg", {
+          host: "unknown.trainers.gg",
+        })
+      );
+
+      // No rewrite — returns the standard middleware response
+      expect(result).toBe(mockResponse);
+    });
+
+    it("should enforce auth on subdomain protected routes", async () => {
+      createMockSupabaseClient({ user: null });
+
+      const result = await proxy(
+        createRequest("/", "http://dashboard.trainers.gg", {
+          host: "dashboard.trainers.gg",
+        })
+      );
+
+      // dashboard.trainers.gg/ maps to /dashboard which is protected
+      expect(result.status).toBe(307);
+      const location = new URL(result.headers.get("location")!);
+      expect(location.pathname).toBe("/sign-in");
+      expect(location.searchParams.get("redirect")).toBe("/dashboard");
+    });
+
+    it("should carry session cookies on rewrite response", async () => {
+      const { mockResponse } = createMockSupabaseClient({
+        user: { id: "user-1", email: "u@test.com" },
+      });
+      // Simulate a session-refresh cookie on the middleware response
+      mockResponse.cookies.set("sb-access-token", "refreshed-value");
+
+      const result = await proxy(
+        createRequest("/", "http://dashboard.trainers.gg", {
+          host: "dashboard.trainers.gg",
+        })
+      );
+
+      // The rewrite response should carry the session cookie
+      const cookie = result.cookies.get("sb-access-token");
+      expect(cookie?.value).toBe("refreshed-value");
     });
   });
 });

--- a/apps/web/src/__tests__/proxy.test.ts
+++ b/apps/web/src/__tests__/proxy.test.ts
@@ -289,10 +289,11 @@ describe("proxy", () => {
       );
 
       // dashboard.trainers.gg/ maps to /dashboard which is protected
+      // redirect uses raw pathname ("/") since the user stays on the subdomain
       expect(result.status).toBe(307);
       const location = new URL(result.headers.get("location")!);
       expect(location.pathname).toBe("/sign-in");
-      expect(location.searchParams.get("redirect")).toBe("/dashboard");
+      expect(location.searchParams.get("redirect")).toBe("/");
     });
 
     it("should carry session cookies on rewrite response", async () => {

--- a/apps/web/src/app/(marketing)/layout.tsx
+++ b/apps/web/src/app/(marketing)/layout.tsx
@@ -12,8 +12,8 @@ export default function MarketingLayout({
       <AnnouncementBanner />
       <TopNav />
       <main className="flex w-full flex-1 flex-col">{children}</main>
-      <footer className="text-muted-foreground mx-auto w-full max-w-screen-2xl px-6 py-3 text-[10px] sm:px-10">
-        <div className="flex items-center justify-between">
+      <footer className="text-muted-foreground border-border/40 w-full border-t py-3 text-[10px]">
+        <div className="flex items-center justify-between px-6 sm:px-10">
           <p className="text-[8px] opacity-40">
             trainers.gg is not affiliated with, endorsed by, or connected to
             Nintendo, The Pok&eacute;mon Company, or Game Freak.

--- a/apps/web/src/app/(marketing)/layout.tsx
+++ b/apps/web/src/app/(marketing)/layout.tsx
@@ -1,5 +1,6 @@
 import { TopNav } from "@/components/topnav";
 import { AnnouncementBanner } from "@/components/layout/announcement-banner";
+import Image from "next/image";
 import type { ReactNode } from "react";
 
 export default function MarketingLayout({
@@ -15,10 +16,17 @@ export default function MarketingLayout({
       <footer className="text-muted-foreground border-border/40 w-full border-t py-3 text-[10px]">
         <div className="flex items-center justify-between px-6 sm:px-10">
           <p className="text-[8px] opacity-40">
-            trainers.gg is not affiliated with, endorsed by, or connected to
-            Nintendo, The Pok&eacute;mon Company, or Game Freak.
+            Not affiliated with Nintendo, The Pok&eacute;mon Company, or Game
+            Freak.
           </p>
-          <p className="whitespace-nowrap">
+          <p className="flex items-center gap-1 whitespace-nowrap">
+            <Image
+              src="/icons/beanie_logo.png"
+              alt="Beanie LLC"
+              width={28}
+              height={28}
+              className="inline-block"
+            />
             &copy; {new Date().getFullYear()} Beanie LLC
           </p>
         </div>

--- a/apps/web/src/components/team-builder/__tests__/builder-topbar.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/builder-topbar.test.tsx
@@ -1,0 +1,425 @@
+"use client";
+
+/**
+ * Tests for the BuilderTopbar component.
+ * Verifies: editable name, File dropdown, Validate popover, save button,
+ * load team popover, and export actions.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { type TeamWithPokemon } from "@trainers/supabase";
+
+// =============================================================================
+// Mocks
+// =============================================================================
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+    className,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} className={className} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock("@trainers/pokemon", () => ({
+  exportTeamToShowdown: jest.fn(() => "Pikachu @ Light Ball\nAbility: Static"),
+  getFormatById: jest.fn((id: string) => ({
+    id,
+    label: "VGC 2026 Reg I",
+  })),
+}));
+
+jest.mock("../validation/validation-popover", () => ({
+  ValidationPopover: ({
+    errors,
+    onJumpToPokemon,
+  }: {
+    errors: unknown[];
+    onJumpToPokemon: (id: number) => void;
+  }) => (
+    <div data-testid="validation-popover">
+      <span data-testid="error-count">{errors.length}</span>
+      <button
+        type="button"
+        onClick={() => onJumpToPokemon(99)}
+        data-testid="jump-btn"
+      >
+        Jump
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock("../pokemon-utils", () => ({
+  dbPokemonToFlat: jest.fn((p) => p),
+}));
+
+// Mock dropdown menu (Base UI doesn't render portaled content in jsdom)
+jest.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dropdown-menu">{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dropdown-content">{children}</div>
+  ),
+  DropdownMenuTrigger: ({
+    children,
+    render,
+  }: {
+    children: React.ReactNode;
+    render?: React.ReactElement;
+  }) => (
+    <div data-testid="dropdown-trigger">
+      {render ? React.cloneElement(render, {}, children) : children}
+    </div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" onClick={onClick} data-testid="dropdown-item">
+      {children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuGroup: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dropdown-group">{children}</div>
+  ),
+  DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+
+// Mock Popover (Base UI portals)
+jest.mock("@/components/ui/popover", () => ({
+  Popover: ({
+    children,
+    open,
+    onOpenChange,
+  }: {
+    children: React.ReactNode;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) => (
+    <div
+      data-testid="popover"
+      data-open={open}
+      onClick={() => onOpenChange?.(true)}
+    >
+      {children}
+    </div>
+  ),
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popover-content">{children}</div>
+  ),
+  PopoverTrigger: ({
+    children,
+    render,
+  }: {
+    children?: React.ReactNode;
+    render?: React.ReactElement;
+  }) => (
+    <div data-testid="popover-trigger">
+      {render ?? null}
+      {children}
+    </div>
+  ),
+}));
+
+// =============================================================================
+// Import after mocks
+// =============================================================================
+
+import { BuilderTopbar } from "../builder-topbar";
+import { type ValidationError } from "../validation-hooks";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function makeTeam(overrides: Partial<TeamWithPokemon> = {}): TeamWithPokemon {
+  return {
+    id: -1,
+    name: "Test Team",
+    created_by: -1,
+    format: "gen9vgc2026regi",
+    description: null,
+    format_legal: null,
+    is_public: null,
+    notes: null,
+    parent_team_id: null,
+    tags: null,
+    created_at: "2024-01-01T00:00:00.000Z",
+    updated_at: "2024-01-01T00:00:00.000Z",
+    team_pokemon: [],
+    ...overrides,
+  };
+}
+
+function makeError(overrides: Partial<ValidationError> = {}): ValidationError {
+  return {
+    pokemonId: 1,
+    pokemonName: "Garchomp",
+    field: "ability",
+    message: "Must select an ability",
+    severity: "error",
+    ...overrides,
+  };
+}
+
+function makeWarning(
+  overrides: Partial<ValidationError> = {}
+): ValidationError {
+  return {
+    pokemonId: 2,
+    pokemonName: "Incineroar",
+    field: "item",
+    message: "Duplicate item",
+    severity: "warning",
+    ...overrides,
+  };
+}
+
+interface RenderProps {
+  validationErrors?: ValidationError[];
+  onSaveToAccount?: () => void;
+  isSaving?: boolean;
+  userTeams?: Array<{
+    id: number;
+    name: string;
+    alt_username: string;
+    format: string | null;
+    team_pokemon: Array<{ pokemon: unknown }>;
+  }>;
+  teamsLoading?: boolean;
+  onLoadTeam?: (teamId: number) => void;
+}
+
+function renderTopbar(props: RenderProps = {}) {
+  const onOpenImport = jest.fn();
+  const onJumpToPokemon = jest.fn();
+  const onValidate = jest.fn();
+  const onNameChange = jest.fn().mockResolvedValue(undefined);
+
+  const utils = render(
+    <BuilderTopbar
+      team={makeTeam()}
+      onOpenImport={onOpenImport}
+      validationErrors={props.validationErrors ?? []}
+      onJumpToPokemon={onJumpToPokemon}
+      onValidate={onValidate}
+      onNameChange={onNameChange}
+      onSaveToAccount={props.onSaveToAccount}
+      isSaving={props.isSaving}
+      userTeams={props.userTeams as never}
+      teamsLoading={props.teamsLoading}
+      onLoadTeam={props.onLoadTeam}
+    />
+  );
+
+  return {
+    ...utils,
+    onOpenImport,
+    onJumpToPokemon,
+    onValidate,
+    onNameChange,
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("BuilderTopbar — basic render", () => {
+  it("renders the team name as an editable button", () => {
+    renderTopbar();
+    expect(
+      screen.getByRole("button", { name: "Edit team name" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Test Team")).toBeInTheDocument();
+  });
+
+  it("renders File button", () => {
+    renderTopbar();
+    expect(screen.getByText("File")).toBeInTheDocument();
+  });
+
+  it("renders Validate button text", () => {
+    renderTopbar();
+    expect(screen.getByText("Validate")).toBeInTheDocument();
+  });
+
+  it("renders sign-in link when onSaveToAccount is not provided", () => {
+    renderTopbar();
+    expect(
+      screen.getByRole("link", { name: "Sign in to save" })
+    ).toHaveAttribute("href", expect.stringContaining("/sign-in"));
+  });
+
+  it("renders save button when onSaveToAccount is provided", () => {
+    const onSave = jest.fn();
+    renderTopbar({ onSaveToAccount: onSave });
+    expect(
+      screen.getByRole("button", { name: "Save to account" })
+    ).toBeInTheDocument();
+  });
+
+  it("disables save button when isSaving is true", () => {
+    const onSave = jest.fn();
+    renderTopbar({ onSaveToAccount: onSave, isSaving: true });
+    // The save button has aria-label "Saving…" when isSaving
+    const btn = screen.getByLabelText(/Saving/);
+    expect(btn).toBeDisabled();
+  });
+});
+
+describe("BuilderTopbar — editable name", () => {
+  it("enters edit mode on click", async () => {
+    const user = userEvent.setup();
+    renderTopbar();
+
+    await user.click(screen.getByRole("button", { name: "Edit team name" }));
+    expect(
+      screen.getByRole("textbox", { name: "Team name" })
+    ).toBeInTheDocument();
+  });
+
+  it("calls onNameChange on Enter and exits edit mode", async () => {
+    const user = userEvent.setup();
+    const { onNameChange } = renderTopbar();
+
+    await user.click(screen.getByRole("button", { name: "Edit team name" }));
+    const input = screen.getByRole("textbox", { name: "Team name" });
+
+    await user.clear(input);
+    await user.type(input, "New Name{Enter}");
+
+    await waitFor(() => {
+      expect(onNameChange).toHaveBeenCalledWith("New Name");
+    });
+  });
+
+  it("reverts on Escape without calling onNameChange", async () => {
+    const user = userEvent.setup();
+    const { onNameChange } = renderTopbar();
+
+    await user.click(screen.getByRole("button", { name: "Edit team name" }));
+    const input = screen.getByRole("textbox", { name: "Team name" });
+
+    await user.clear(input);
+    await user.type(input, "Garbage{Escape}");
+
+    expect(onNameChange).not.toHaveBeenCalled();
+    // Should be back to showing the button
+    expect(
+      screen.getByRole("button", { name: "Edit team name" })
+    ).toBeInTheDocument();
+  });
+
+  it("does not call onNameChange if value is unchanged", async () => {
+    const user = userEvent.setup();
+    const { onNameChange } = renderTopbar();
+
+    await user.click(screen.getByRole("button", { name: "Edit team name" }));
+    const input = screen.getByRole("textbox", { name: "Team name" });
+
+    // Just press Enter without changing
+    await user.type(input, "{Enter}");
+
+    expect(onNameChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("BuilderTopbar — validate", () => {
+  it("renders the validate button with correct text", () => {
+    renderTopbar();
+    expect(screen.getByText("Validate")).toBeInTheDocument();
+  });
+
+  it("shows a destructive border when there are errors", () => {
+    renderTopbar({ validationErrors: [makeError()] });
+    const btn = screen.getByText("Validate").closest("button")!;
+    expect(btn.className).toContain("destructive");
+  });
+
+  it("shows an amber border when there are only warnings", () => {
+    renderTopbar({ validationErrors: [makeWarning()] });
+    const btn = screen.getByText("Validate").closest("button")!;
+    expect(btn.className).toContain("amber");
+  });
+
+  it("shows no error/warning styling when there are no issues", () => {
+    renderTopbar({ validationErrors: [] });
+    const btn = screen.getByText("Validate").closest("button")!;
+    expect(btn.className).not.toContain("destructive");
+    expect(btn.className).not.toContain("amber");
+  });
+});
+
+describe("BuilderTopbar — File menu", () => {
+  it("shows Import paste option", () => {
+    renderTopbar();
+    // With mocked dropdown, menu items render immediately
+    expect(screen.getByText("Import paste")).toBeInTheDocument();
+  });
+
+  it("calls onOpenImport when Import paste is clicked", async () => {
+    const user = userEvent.setup();
+    const { onOpenImport } = renderTopbar();
+
+    await user.click(screen.getByText("Import paste"));
+    expect(onOpenImport).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows export options", () => {
+    renderTopbar();
+    expect(screen.getByText("Copy as Showdown text")).toBeInTheDocument();
+    expect(screen.getByText("Open in Pokepaste")).toBeInTheDocument();
+  });
+
+  it("shows Load team option when onLoadTeam is provided", () => {
+    const onLoadTeam = jest.fn();
+    renderTopbar({ onLoadTeam });
+    expect(screen.getByText("Load team...")).toBeInTheDocument();
+  });
+
+  it("does not show Load team option when onLoadTeam is not provided", () => {
+    renderTopbar();
+    expect(screen.queryByText("Load team...")).not.toBeInTheDocument();
+  });
+});
+
+describe("BuilderTopbar — save", () => {
+  it("calls onSaveToAccount when save button is clicked", async () => {
+    const user = userEvent.setup();
+    const onSave = jest.fn();
+    renderTopbar({ onSaveToAccount: onSave });
+
+    await user.click(screen.getByRole("button", { name: "Save to account" }));
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/team-builder/__tests__/calc-reverse-card.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/calc-reverse-card.test.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+/**
+ * Tests for CalcReverseColumn component.
+ * Verifies: renders nothing without defender, renders "Incoming" label,
+ * renders move rows with damage ranges, handles status moves.
+ */
+
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import { type Tables } from "@trainers/supabase";
+
+// =============================================================================
+// Mocks
+// =============================================================================
+
+jest.mock("@trainers/pokemon", () => ({
+  getMoveData: jest.fn((move: string) => {
+    if (move === "Will-O-Wisp") return { type: "Fire", category: "Status" };
+    if (move === "Thunderbolt")
+      return { type: "Electric", category: "Special" };
+    if (move === "Earthquake") return { type: "Ground", category: "Physical" };
+    if (move === "Ice Beam") return { type: "Ice", category: "Special" };
+    return { type: "Normal", category: "Physical" };
+  }),
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+// Mock useTeamLayoutMode
+let mockLayoutMode = "1x6";
+jest.mock("../use-team-layout", () => ({
+  useTeamLayoutMode: () => mockLayoutMode,
+}));
+
+// Mock TypeSymbolIcon
+jest.mock("../type-symbol-icon", () => ({
+  TypeSymbolIcon: ({ type }: { type: string }) => (
+    <span data-testid={`type-icon-${type}`}>{type}</span>
+  ),
+}));
+
+// Mock calc-display-helpers
+jest.mock("../lanes/calc-display-helpers", () => ({
+  getDisplayRangeAndKoTier: jest.fn(({ hasCalc }) => ({
+    spreadApplied: false,
+    displayMin: hasCalc ? 45.2 : 0,
+    displayMax: hasCalc ? 53.8 : 0,
+    koTier: hasCalc ? "2" : null,
+  })),
+}));
+
+// Mock useDefenderMoves
+const mockEffectiveMoves = ["Thunderbolt", "Earthquake", "", ""];
+jest.mock("../calc/use-defender-moves", () => ({
+  useDefenderMoves: () => ({
+    effectiveMoves: mockEffectiveMoves,
+  }),
+}));
+
+// Mock useCalcStateContext
+const mockCalcContext = {
+  defenderSpecies: "Garchomp",
+  defenderMoves: ["Thunderbolt", "Earthquake", "", ""],
+  field: { foesAlive: 2, allyAlive: true },
+  computeReverseOutputsForRow: jest.fn(() => [
+    {
+      minPercent: 45.2,
+      maxPercent: 53.8,
+      koChance: null,
+      desc: "252 SpA Garchomp Thunderbolt vs. 0 HP / 4 SpD Pikachu: 45.2 - 53.8%",
+    },
+    {
+      minPercent: 80.1,
+      maxPercent: 95.0,
+      koChance: 75,
+      desc: "252 Atk Garchomp Earthquake vs. 0 HP / 0 Def Pikachu: 80.1 - 95.0%",
+    },
+    null,
+    null,
+  ]),
+};
+jest.mock("../calc/calc-state-context", () => ({
+  useCalcStateContext: () => mockCalcContext,
+}));
+
+// Mock Tooltip components
+jest.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="tooltip-content">{children}</div>
+  ),
+  TooltipTrigger: ({
+    children,
+    render,
+  }: {
+    children: React.ReactNode;
+    render?: React.ReactElement;
+  }) => (
+    <div data-testid="tooltip-trigger">
+      {render ? React.cloneElement(render, {}, children) : children}
+    </div>
+  ),
+}));
+
+// =============================================================================
+// Import after mocks
+// =============================================================================
+
+import { CalcReverseColumn } from "../lanes/calc-reverse-card";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function makePokemon(
+  overrides?: Partial<Tables<"pokemon">>
+): Tables<"pokemon"> {
+  return {
+    id: -1,
+    species: "Pikachu",
+    ability: "Static",
+    move1: "Thunderbolt",
+    move2: null,
+    move3: null,
+    move4: null,
+    nature: "Timid",
+    nickname: null,
+    notes: null,
+    held_item: null,
+    tera_type: null,
+    gender: null,
+    is_shiny: false,
+    level: 50,
+    format_legal: null,
+    created_at: "2024-01-01T00:00:00.000Z",
+    ev_hp: 0,
+    ev_attack: 0,
+    ev_defense: 0,
+    ev_special_attack: 252,
+    ev_special_defense: 4,
+    ev_speed: 252,
+    iv_hp: 31,
+    iv_attack: 31,
+    iv_defense: 31,
+    iv_special_attack: 31,
+    iv_special_defense: 31,
+    iv_speed: 31,
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("CalcReverseColumn — no defender", () => {
+  beforeEach(() => {
+    mockCalcContext.defenderSpecies = "";
+    mockLayoutMode = "1x6";
+  });
+
+  afterEach(() => {
+    mockCalcContext.defenderSpecies = "Garchomp";
+  });
+
+  it("renders nothing when there is no defender", () => {
+    const { container } = render(
+      <CalcReverseColumn pokemon={makePokemon()} teammates={[]} />
+    );
+    expect(container.innerHTML).toBe("");
+  });
+});
+
+describe("CalcReverseColumn — horizontal (1x6) layout", () => {
+  beforeEach(() => {
+    mockCalcContext.defenderSpecies = "Garchomp";
+    mockLayoutMode = "1x6";
+  });
+
+  it("renders 'Incoming' label", () => {
+    render(<CalcReverseColumn pokemon={makePokemon()} teammates={[]} />);
+    expect(screen.getByText("Incoming")).toBeInTheDocument();
+  });
+
+  it("renders move names for active moves", () => {
+    render(<CalcReverseColumn pokemon={makePokemon()} teammates={[]} />);
+    expect(screen.getByText("Thunderbolt")).toBeInTheDocument();
+    expect(screen.getByText("Earthquake")).toBeInTheDocument();
+  });
+
+  it("renders type icons for moves", () => {
+    render(<CalcReverseColumn pokemon={makePokemon()} teammates={[]} />);
+    expect(screen.getByTestId("type-icon-Electric")).toBeInTheDocument();
+    expect(screen.getByTestId("type-icon-Ground")).toBeInTheDocument();
+  });
+
+  it("does not render when pokemon is null but calc runs", () => {
+    mockCalcContext.computeReverseOutputsForRow.mockReturnValueOnce([
+      null,
+      null,
+      null,
+      null,
+    ]);
+    render(<CalcReverseColumn pokemon={null} teammates={[]} />);
+    // Should still render the "Incoming" label (since defender exists)
+    expect(screen.getByText("Incoming")).toBeInTheDocument();
+  });
+});
+
+describe("CalcReverseColumn — vertical layout", () => {
+  beforeEach(() => {
+    mockCalcContext.defenderSpecies = "Garchomp";
+    mockLayoutMode = "2x3";
+  });
+
+  it("renders 'Incoming' label in vertical mode", () => {
+    render(<CalcReverseColumn pokemon={makePokemon()} teammates={[]} />);
+    expect(screen.getByText("Incoming")).toBeInTheDocument();
+  });
+
+  it("renders move names in vertical layout", () => {
+    render(<CalcReverseColumn pokemon={makePokemon()} teammates={[]} />);
+    expect(screen.getByText("Thunderbolt")).toBeInTheDocument();
+    expect(screen.getByText("Earthquake")).toBeInTheDocument();
+  });
+});
+
+describe("CalcReverseColumn — status moves", () => {
+  beforeEach(() => {
+    mockCalcContext.defenderSpecies = "Garchomp";
+    mockLayoutMode = "1x6";
+    mockEffectiveMoves[0] = "Will-O-Wisp";
+    mockEffectiveMoves[1] = "";
+    mockEffectiveMoves[2] = "";
+    mockEffectiveMoves[3] = "";
+    mockCalcContext.computeReverseOutputsForRow.mockReturnValue([
+      null,
+      null,
+      null,
+      null,
+    ]);
+  });
+
+  afterEach(() => {
+    mockEffectiveMoves[0] = "Thunderbolt";
+    mockEffectiveMoves[1] = "Earthquake";
+  });
+
+  it("renders status moves with a dash for damage", () => {
+    render(<CalcReverseColumn pokemon={makePokemon()} teammates={[]} />);
+    expect(screen.getByText("Will-O-Wisp")).toBeInTheDocument();
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/team-builder/__tests__/heatmap-panel.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/heatmap-panel.test.tsx
@@ -143,16 +143,14 @@ beforeEach(() => {
 });
 
 describe("HeatmapPanel — empty team", () => {
-  it("renders the empty-state message when team is empty", () => {
+  it("renders the grid with placeholder rows when team is empty", () => {
     render(<HeatmapPanel team={[]} format={undefined} />);
-    expect(
-      screen.getByText(/Add Pokémon to your team/i)
-    ).toBeInTheDocument();
+    expect(screen.getByText("Add Pokémon…")).toBeInTheDocument();
   });
 
-  it("does not render the matrix when team is empty", () => {
+  it("renders the TOTAL footer even when team is empty", () => {
     render(<HeatmapPanel team={[]} format={undefined} />);
-    expect(screen.queryByText("TOTAL")).not.toBeInTheDocument();
+    expect(screen.getByText("TOTAL")).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/components/team-builder/__tests__/local-builder-workspace.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/local-builder-workspace.test.tsx
@@ -1,10 +1,10 @@
 /**
  * Tests for LocalBuilderWorkspace.
  * Verifies: hydration loading state, rendering after hydration,
- * saving overlay, and delegating to TeamWorkspaceV2.
+ * saving overlay, delegating to TeamWorkspaceV2, and handleSaveToAccount.
  */
 
-import { render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 
 // =============================================================================
@@ -41,7 +41,11 @@ jest.mock("@trainers/supabase", () => ({
 }));
 
 // Mock auth context
-const mockAuthContext = {
+const mockAuthContext: {
+  isAuthenticated: boolean;
+  loading: boolean;
+  user: { id: string } | null;
+} = {
   isAuthenticated: false,
   loading: false,
   user: null,
@@ -72,9 +76,13 @@ jest.mock("@/components/builder-nav", () => ({
   ),
 }));
 
-// Mock BuilderTopbar
+// Mock BuilderTopbar — capture onSaveToAccount for testing
+let capturedOnSaveToAccount: (() => Promise<void>) | undefined;
 jest.mock("../builder-topbar", () => ({
-  BuilderTopbar: () => <div data-testid="builder-topbar">Builder Topbar</div>,
+  BuilderTopbar: (props: { onSaveToAccount?: () => Promise<void> }) => {
+    capturedOnSaveToAccount = props.onSaveToAccount;
+    return <div data-testid="builder-topbar">Builder Topbar</div>;
+  },
 }));
 
 // Mock PersistenceProvider
@@ -120,7 +128,7 @@ jest.mock("../persistence/use-local-team-storage", () => ({
     setTeam: mockSetTeam,
     hydrated: mockHydrated,
   }),
-  clearLocalTeamStorage: jest.fn(),
+  clearLocalTeamStorage: jest.fn().mockReturnValue(true),
 }));
 
 // Mock TeamWorkspaceV2
@@ -208,5 +216,142 @@ describe("LocalBuilderWorkspace — unauthenticated", () => {
     expect(
       screen.queryByText("Saving your team to your account...")
     ).not.toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// handleSaveToAccount tests
+// =============================================================================
+
+describe("LocalBuilderWorkspace — handleSaveToAccount", () => {
+  const { toast } = jest.requireMock("sonner") as {
+    toast: { success: jest.Mock; error: jest.Mock };
+  };
+  const { teamsApi } = jest.requireMock("@/lib/api/teams-client") as {
+    teamsApi: { saveLocal: jest.Mock };
+  };
+  const { getAltsByUserId, getTeamsForUser } = jest.requireMock(
+    "@trainers/supabase"
+  ) as {
+    getAltsByUserId: jest.Mock;
+    getTeamsForUser: jest.Mock;
+  };
+  const { clearLocalTeamStorage } = jest.requireMock(
+    "../persistence/use-local-team-storage"
+  ) as { clearLocalTeamStorage: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHydrated = true;
+    mockAuthContext.isAuthenticated = true;
+    mockAuthContext.loading = false;
+    mockAuthContext.user = { id: "user-123" };
+    capturedOnSaveToAccount = undefined;
+
+    // Default mocks for the useEffect fetch
+    getAltsByUserId.mockResolvedValue([]);
+    getTeamsForUser.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    mockAuthContext.isAuthenticated = false;
+    mockAuthContext.user = null;
+  });
+
+  it("happy path: saves team, clears storage, shows toast, and redirects", async () => {
+    getAltsByUserId.mockResolvedValue([{ id: 42, name: "TestAlt" }]);
+    teamsApi.saveLocal.mockResolvedValue({
+      success: true,
+      data: { redirectUrl: "/dashboard/teams/99" },
+    });
+
+    render(<LocalBuilderWorkspace />);
+
+    // Wait for the full useEffect to settle (both API calls + re-render)
+    await waitFor(() => {
+      expect(getTeamsForUser).toHaveBeenCalled();
+    });
+
+    // Flush pending state updates so capturedOnSaveToAccount has current closure
+    await act(async () => {});
+
+    expect(capturedOnSaveToAccount).toBeDefined();
+
+    act(() => {
+      capturedOnSaveToAccount!();
+    });
+
+    // Wait for the save to complete and success toast to appear
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Team saved to your account!");
+    });
+
+    expect(teamsApi.saveLocal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        altId: 42,
+        name: "Untitled Team",
+        format: "gen9vgc2026regi",
+      })
+    );
+    expect(clearLocalTeamStorage).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith("/dashboard/teams/99");
+  });
+
+  it("shows error toast on API failure without redirecting", async () => {
+    getAltsByUserId.mockResolvedValue([{ id: 42, name: "TestAlt" }]);
+    teamsApi.saveLocal.mockResolvedValue({
+      success: false,
+      error: "Server error",
+    });
+
+    render(<LocalBuilderWorkspace />);
+
+    // Wait for the full useEffect to settle
+    await waitFor(() => {
+      expect(getTeamsForUser).toHaveBeenCalled();
+    });
+
+    await act(async () => {});
+
+    expect(capturedOnSaveToAccount).toBeDefined();
+
+    act(() => {
+      capturedOnSaveToAccount!();
+    });
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Server error");
+    });
+
+    expect(clearLocalTeamStorage).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("shows error toast when no alts are found", async () => {
+    // getAltsByUserId returns [] (default from beforeEach)
+    render(<LocalBuilderWorkspace />);
+
+    // Wait for the full useEffect to settle
+    await waitFor(() => {
+      expect(getTeamsForUser).toHaveBeenCalled();
+    });
+
+    await act(async () => {});
+
+    expect(capturedOnSaveToAccount).toBeDefined();
+
+    act(() => {
+      capturedOnSaveToAccount!();
+    });
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "No profile found. Please complete your profile setup first."
+      );
+    });
+
+    expect(teamsApi.saveLocal).not.toHaveBeenCalled();
+    expect(clearLocalTeamStorage).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/team-builder/__tests__/local-builder-workspace.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/local-builder-workspace.test.tsx
@@ -37,7 +37,7 @@ jest.mock("@trainers/pokemon", () => ({
 
 // Mock Supabase queries
 jest.mock("@trainers/supabase", () => ({
-  getCurrentUserAlts: jest.fn().mockResolvedValue([]),
+  getAltsByUserId: jest.fn().mockResolvedValue([]),
   getTeamsForUser: jest.fn().mockResolvedValue([]),
   getTeamWithPokemon: jest.fn().mockResolvedValue(null),
 }));

--- a/apps/web/src/components/team-builder/__tests__/local-builder-workspace.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/local-builder-workspace.test.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 /**
  * Tests for LocalBuilderWorkspace.
  * Verifies: hydration loading state, rendering after hydration,

--- a/apps/web/src/components/team-builder/__tests__/local-builder-workspace.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/local-builder-workspace.test.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+/**
+ * Tests for LocalBuilderWorkspace.
+ * Verifies: hydration loading state, rendering after hydration,
+ * saving overlay, and delegating to TeamWorkspaceV2.
+ */
+
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// =============================================================================
+// Mocks
+// =============================================================================
+
+const mockPush = jest.fn();
+const mockRefresh = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+  useSearchParams: () => ({
+    get: jest.fn(() => null),
+  }),
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock("@trainers/pokemon", () => ({
+  getFormatById: jest.fn((id: string) =>
+    id ? { id, label: "VGC 2026 Reg I" } : undefined
+  ),
+}));
+
+// Mock Supabase queries
+jest.mock("@trainers/supabase", () => ({
+  getCurrentUserAlts: jest.fn().mockResolvedValue([]),
+  getTeamsForUser: jest.fn().mockResolvedValue([]),
+  getTeamWithPokemon: jest.fn().mockResolvedValue(null),
+}));
+
+// Mock auth context
+const mockAuthContext = {
+  isAuthenticated: false,
+  loading: false,
+  user: null,
+};
+jest.mock("@/components/auth/auth-provider", () => ({
+  useAuthContext: () => mockAuthContext,
+}));
+
+// Mock Supabase client
+jest.mock("@/lib/supabase", () => ({
+  useSupabase: () => ({}),
+}));
+
+// Mock teams API
+jest.mock("@/lib/api/teams-client", () => ({
+  teamsApi: {
+    saveLocal: jest.fn().mockResolvedValue({
+      success: true,
+      data: { redirectUrl: "/dashboard/teams/1" },
+    }),
+  },
+}));
+
+// Mock BuilderNav
+jest.mock("@/components/builder-nav", () => ({
+  BuilderNav: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="builder-nav">{children}</div>
+  ),
+}));
+
+// Mock BuilderTopbar
+jest.mock("../builder-topbar", () => ({
+  BuilderTopbar: () => <div data-testid="builder-topbar">Builder Topbar</div>,
+}));
+
+// Mock PersistenceProvider
+jest.mock("../persistence/context", () => ({
+  PersistenceProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="persistence-provider">{children}</div>
+  ),
+}));
+
+// Mock createLocalPersistence
+jest.mock("../persistence/local-persistence", () => ({
+  createLocalPersistence: jest.fn(() => ({
+    mode: "local",
+    addPokemon: jest.fn(),
+    updatePokemon: jest.fn(),
+    removePokemon: jest.fn(),
+    reorderPokemon: jest.fn(),
+    updateTeam: jest.fn(),
+    onMutationSuccess: jest.fn(),
+  })),
+}));
+
+// Mock useLocalTeamStorage — default to hydrated
+const mockSetTeam = jest.fn();
+let mockHydrated = true;
+jest.mock("../persistence/use-local-team-storage", () => ({
+  useLocalTeamStorage: () => ({
+    team: {
+      id: -1,
+      name: "Untitled Team",
+      format: "gen9vgc2026regi",
+      format_legal: null,
+      description: null,
+      notes: null,
+      tags: null,
+      is_public: null,
+      parent_team_id: null,
+      created_by: -1,
+      created_at: "2024-01-01T00:00:00.000Z",
+      updated_at: "2024-01-01T00:00:00.000Z",
+      team_pokemon: [],
+    },
+    setTeam: mockSetTeam,
+    hydrated: mockHydrated,
+  }),
+  clearLocalTeamStorage: jest.fn(),
+}));
+
+// Mock TeamWorkspaceV2
+jest.mock("../team-workspace", () => ({
+  TeamWorkspaceV2: ({
+    renderHeader,
+  }: {
+    renderHeader?: (actions: unknown) => React.ReactNode;
+  }) => (
+    <div data-testid="team-workspace">
+      {renderHeader?.({
+        onOpenImport: jest.fn(),
+        validationErrors: [],
+        onJumpToPokemon: jest.fn(),
+        onValidate: jest.fn(),
+        onNameChange: jest.fn(),
+      })}
+      Workspace Content
+    </div>
+  ),
+}));
+
+// =============================================================================
+// Import after mocks
+// =============================================================================
+
+import { LocalBuilderWorkspace } from "../local-builder-workspace";
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("LocalBuilderWorkspace — loading state", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows loading text when not yet hydrated", () => {
+    mockHydrated = false;
+    render(<LocalBuilderWorkspace />);
+    expect(screen.getByText("Loading builder...")).toBeInTheDocument();
+    mockHydrated = true;
+  });
+});
+
+describe("LocalBuilderWorkspace — hydrated render", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHydrated = true;
+  });
+
+  it("renders TeamWorkspaceV2 after hydration", () => {
+    render(<LocalBuilderWorkspace />);
+    expect(screen.getByTestId("team-workspace")).toBeInTheDocument();
+    expect(screen.getByText("Workspace Content")).toBeInTheDocument();
+  });
+
+  it("wraps in PersistenceProvider", () => {
+    render(<LocalBuilderWorkspace />);
+    expect(screen.getByTestId("persistence-provider")).toBeInTheDocument();
+  });
+
+  it("renders BuilderTopbar via renderHeader", () => {
+    render(<LocalBuilderWorkspace />);
+    expect(screen.getByTestId("builder-topbar")).toBeInTheDocument();
+  });
+
+  it("renders BuilderNav in the header", () => {
+    render(<LocalBuilderWorkspace />);
+    expect(screen.getByTestId("builder-nav")).toBeInTheDocument();
+  });
+});
+
+describe("LocalBuilderWorkspace — unauthenticated", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHydrated = true;
+    mockAuthContext.isAuthenticated = false;
+    mockAuthContext.loading = false;
+    mockAuthContext.user = null;
+  });
+
+  it("does not show saving overlay when unauthenticated", () => {
+    render(<LocalBuilderWorkspace />);
+    expect(
+      screen.queryByText("Saving your team to your account...")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/team-builder/__tests__/local-persistence.test.ts
+++ b/apps/web/src/components/team-builder/__tests__/local-persistence.test.ts
@@ -1,0 +1,420 @@
+"use client";
+
+/**
+ * Tests for createLocalPersistence — the local in-memory persistence adapter.
+ */
+
+import type { TeamWithPokemon, TablesInsert } from "@trainers/supabase";
+import { createLocalPersistence } from "../persistence/local-persistence";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function makeTeam(overrides?: Partial<TeamWithPokemon>): TeamWithPokemon {
+  return {
+    id: -1,
+    name: "Test Team",
+    format: "gen9vgc2026regi",
+    format_legal: null,
+    description: null,
+    notes: null,
+    tags: null,
+    is_public: null,
+    parent_team_id: null,
+    created_by: -1,
+    created_at: "2024-01-01T00:00:00.000Z",
+    updated_at: "2024-01-01T00:00:00.000Z",
+    team_pokemon: [],
+    ...overrides,
+  };
+}
+
+function makeTeamPokemon(
+  pokemonId: number,
+  position: number,
+  species = "Pikachu"
+): TeamWithPokemon["team_pokemon"][number] {
+  return {
+    id: pokemonId,
+    pokemon_id: pokemonId,
+    team_position: position,
+    pokemon: {
+      id: pokemonId,
+      species,
+      ability: "Static",
+      move1: "Thunderbolt",
+      move2: null,
+      move3: null,
+      move4: null,
+      nature: "Timid",
+      nickname: null,
+      notes: null,
+      held_item: null,
+      tera_type: null,
+      gender: null,
+      is_shiny: false,
+      level: 50,
+      format_legal: null,
+      created_at: "2024-01-01T00:00:00.000Z",
+      ev_hp: 0,
+      ev_attack: 0,
+      ev_defense: 0,
+      ev_special_attack: 252,
+      ev_special_defense: 4,
+      ev_speed: 252,
+      iv_hp: 31,
+      iv_attack: 31,
+      iv_defense: 31,
+      iv_special_attack: 31,
+      iv_special_defense: 31,
+      iv_speed: 31,
+    },
+  };
+}
+
+function makePokemonInsert(
+  overrides?: Partial<TablesInsert<"pokemon">>
+): TablesInsert<"pokemon"> {
+  return {
+    species: "Charizard",
+    ability: "Blaze",
+    move1: "Flamethrower",
+    move2: "Air Slash",
+    nature: "Modest",
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("createLocalPersistence", () => {
+  it("has mode 'local'", () => {
+    const setTeam = jest.fn();
+    const persistence = createLocalPersistence({ setTeam });
+    expect(persistence.mode).toBe("local");
+  });
+
+  it("onMutationSuccess is a no-op", () => {
+    const setTeam = jest.fn();
+    const persistence = createLocalPersistence({ setTeam });
+    // Should not throw
+    expect(() => persistence.onMutationSuccess()).not.toThrow();
+  });
+});
+
+describe("createLocalPersistence — addPokemon", () => {
+  it("calls setTeam with a new pokemon entry at the given position", async () => {
+    let capturedTeam: TeamWithPokemon | null = null;
+    const initialTeam = makeTeam();
+    const setTeam = jest.fn(
+      (updater: (prev: TeamWithPokemon) => TeamWithPokemon) => {
+        capturedTeam = updater(initialTeam);
+      }
+    );
+
+    const persistence = createLocalPersistence({ setTeam });
+    const result = await persistence.addPokemon(-1, makePokemonInsert(), 0);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // Generated ID should be a negative number
+      expect(result.data.pokemonId).toBeLessThan(0);
+    }
+
+    expect(setTeam).toHaveBeenCalledTimes(1);
+    expect(capturedTeam).not.toBeNull();
+    expect(capturedTeam!.team_pokemon).toHaveLength(1);
+    expect(capturedTeam!.team_pokemon[0]!.team_position).toBe(0);
+    expect(capturedTeam!.team_pokemon[0]!.pokemon!.species).toBe("Charizard");
+    expect(capturedTeam!.team_pokemon[0]!.pokemon!.ability).toBe("Blaze");
+  });
+
+  it("replaces existing pokemon at the same position", async () => {
+    let capturedTeam: TeamWithPokemon | null = null;
+    const initialTeam = makeTeam({
+      team_pokemon: [makeTeamPokemon(-100, 0, "Pikachu")],
+    });
+    const setTeam = jest.fn(
+      (updater: (prev: TeamWithPokemon) => TeamWithPokemon) => {
+        capturedTeam = updater(initialTeam);
+      }
+    );
+
+    const persistence = createLocalPersistence({ setTeam });
+    await persistence.addPokemon(
+      -1,
+      makePokemonInsert({ species: "Garchomp" }),
+      0
+    );
+
+    // Should have only the new pokemon at position 0
+    expect(capturedTeam!.team_pokemon).toHaveLength(1);
+    expect(capturedTeam!.team_pokemon[0]!.pokemon!.species).toBe("Garchomp");
+  });
+
+  it("preserves existing pokemon at other positions", async () => {
+    let capturedTeam: TeamWithPokemon | null = null;
+    const initialTeam = makeTeam({
+      team_pokemon: [
+        makeTeamPokemon(-100, 0, "Pikachu"),
+        makeTeamPokemon(-101, 1, "Eevee"),
+      ],
+    });
+    const setTeam = jest.fn(
+      (updater: (prev: TeamWithPokemon) => TeamWithPokemon) => {
+        capturedTeam = updater(initialTeam);
+      }
+    );
+
+    const persistence = createLocalPersistence({ setTeam });
+    await persistence.addPokemon(
+      -1,
+      makePokemonInsert({ species: "Garchomp" }),
+      2
+    );
+
+    // Should have all 3 pokemon
+    expect(capturedTeam!.team_pokemon).toHaveLength(3);
+  });
+
+  it("fills default values for optional pokemon fields", async () => {
+    let capturedTeam: TeamWithPokemon | null = null;
+    const initialTeam = makeTeam();
+    const setTeam = jest.fn(
+      (updater: (prev: TeamWithPokemon) => TeamWithPokemon) => {
+        capturedTeam = updater(initialTeam);
+      }
+    );
+
+    const persistence = createLocalPersistence({ setTeam });
+    await persistence.addPokemon(
+      -1,
+      { species: "Ditto", ability: "Imposter", move1: "Transform" },
+      0
+    );
+
+    const poke = capturedTeam!.team_pokemon[0]!.pokemon!;
+    expect(poke.nature).toBe("Serious");
+    expect(poke.level).toBe(50);
+    expect(poke.is_shiny).toBe(false);
+    expect(poke.ev_hp).toBe(0);
+    expect(poke.iv_hp).toBe(31);
+    expect(poke.nickname).toBeNull();
+    expect(poke.held_item).toBeNull();
+    expect(poke.tera_type).toBeNull();
+    expect(poke.gender).toBeNull();
+  });
+
+  it("generates unique IDs across multiple calls", async () => {
+    const ids: number[] = [];
+    const setTeam = jest.fn(
+      (updater: (prev: TeamWithPokemon) => TeamWithPokemon) => {
+        const result = updater(makeTeam());
+        ids.push(result.team_pokemon[0]!.pokemon_id);
+      }
+    );
+
+    const persistence = createLocalPersistence({ setTeam });
+    await persistence.addPokemon(-1, makePokemonInsert(), 0);
+    await persistence.addPokemon(-1, makePokemonInsert(), 1);
+    await persistence.addPokemon(-1, makePokemonInsert(), 2);
+
+    // All IDs should be unique
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(3);
+  });
+});
+
+describe("createLocalPersistence — updatePokemon", () => {
+  it("updates fields of the matching pokemon", async () => {
+    let capturedTeam: TeamWithPokemon | null = null;
+    const initialTeam = makeTeam({
+      team_pokemon: [makeTeamPokemon(-100, 0, "Pikachu")],
+    });
+    const setTeam = jest.fn(
+      (updater: (prev: TeamWithPokemon) => TeamWithPokemon) => {
+        capturedTeam = updater(initialTeam);
+      }
+    );
+
+    const persistence = createLocalPersistence({ setTeam });
+    const result = await persistence.updatePokemon(-1, -100, {
+      nature: "Jolly",
+      held_item: "Light Ball",
+    });
+
+    expect(result.success).toBe(true);
+    expect(capturedTeam!.team_pokemon[0]!.pokemon!.nature).toBe("Jolly");
+    expect(capturedTeam!.team_pokemon[0]!.pokemon!.held_item).toBe(
+      "Light Ball"
+    );
+    // Non-updated fields remain unchanged
+    expect(capturedTeam!.team_pokemon[0]!.pokemon!.species).toBe("Pikachu");
+  });
+
+  it("does not modify other pokemon in the team", async () => {
+    let capturedTeam: TeamWithPokemon | null = null;
+    const initialTeam = makeTeam({
+      team_pokemon: [
+        makeTeamPokemon(-100, 0, "Pikachu"),
+        makeTeamPokemon(-101, 1, "Eevee"),
+      ],
+    });
+    const setTeam = jest.fn(
+      (updater: (prev: TeamWithPokemon) => TeamWithPokemon) => {
+        capturedTeam = updater(initialTeam);
+      }
+    );
+
+    const persistence = createLocalPersistence({ setTeam });
+    await persistence.updatePokemon(-1, -100, { nature: "Bold" });
+
+    // Eevee should be untouched
+    expect(capturedTeam!.team_pokemon[1]!.pokemon!.species).toBe("Eevee");
+    expect(capturedTeam!.team_pokemon[1]!.pokemon!.nature).toBe("Timid");
+  });
+
+  it("updates the team updated_at timestamp", async () => {
+    let capturedTeam: TeamWithPokemon | null = null;
+    const initialTeam = makeTeam({
+      team_pokemon: [makeTeamPokemon(-100, 0, "Pikachu")],
+      updated_at: "2020-01-01T00:00:00.000Z",
+    });
+    const setTeam = jest.fn(
+      (updater: (prev: TeamWithPokemon) => TeamWithPokemon) => {
+        capturedTeam = updater(initialTeam);
+      }
+    );
+
+    const persistence = createLocalPersistence({ setTeam });
+    await persistence.updatePokemon(-1, -100, { nature: "Bold" });
+
+    // updated_at should be newer
+    expect(capturedTeam!.updated_at).not.toBe("2020-01-01T00:00:00.000Z");
+  });
+});
+
+describe("createLocalPersistence — removePokemon", () => {
+  it("removes the pokemon with the matching ID", async () => {
+    let capturedTeam: TeamWithPokemon | null = null;
+    const initialTeam = makeTeam({
+      team_pokemon: [
+        makeTeamPokemon(-100, 0, "Pikachu"),
+        makeTeamPokemon(-101, 1, "Eevee"),
+      ],
+    });
+    const setTeam = jest.fn(
+      (updater: (prev: TeamWithPokemon) => TeamWithPokemon) => {
+        capturedTeam = updater(initialTeam);
+      }
+    );
+
+    const persistence = createLocalPersistence({ setTeam });
+    const result = await persistence.removePokemon(-1, -100);
+
+    expect(result.success).toBe(true);
+    expect(capturedTeam!.team_pokemon).toHaveLength(1);
+    expect(capturedTeam!.team_pokemon[0]!.pokemon!.species).toBe("Eevee");
+  });
+
+  it("handles removing from an empty team gracefully", async () => {
+    let capturedTeam: TeamWithPokemon | null = null;
+    const initialTeam = makeTeam();
+    const setTeam = jest.fn(
+      (updater: (prev: TeamWithPokemon) => TeamWithPokemon) => {
+        capturedTeam = updater(initialTeam);
+      }
+    );
+
+    const persistence = createLocalPersistence({ setTeam });
+    const result = await persistence.removePokemon(-1, -999);
+
+    expect(result.success).toBe(true);
+    expect(capturedTeam!.team_pokemon).toHaveLength(0);
+  });
+});
+
+describe("createLocalPersistence — reorderPokemon", () => {
+  it("updates team_position for specified pokemon", async () => {
+    let capturedTeam: TeamWithPokemon | null = null;
+    const initialTeam = makeTeam({
+      team_pokemon: [
+        makeTeamPokemon(-100, 0, "Pikachu"),
+        makeTeamPokemon(-101, 1, "Eevee"),
+        makeTeamPokemon(-102, 2, "Charizard"),
+      ],
+    });
+    const setTeam = jest.fn(
+      (updater: (prev: TeamWithPokemon) => TeamWithPokemon) => {
+        capturedTeam = updater(initialTeam);
+      }
+    );
+
+    const persistence = createLocalPersistence({ setTeam });
+    const result = await persistence.reorderPokemon(-1, [
+      { pokemonId: -100, position: 2 },
+      { pokemonId: -102, position: 0 },
+    ]);
+
+    expect(result.success).toBe(true);
+
+    // Pikachu moved to position 2
+    const pikachu = capturedTeam!.team_pokemon.find(
+      (tp) => tp.pokemon_id === -100
+    );
+    expect(pikachu!.team_position).toBe(2);
+
+    // Charizard moved to position 0
+    const charizard = capturedTeam!.team_pokemon.find(
+      (tp) => tp.pokemon_id === -102
+    );
+    expect(charizard!.team_position).toBe(0);
+
+    // Eevee stays at position 1 (not in the reorder list)
+    const eevee = capturedTeam!.team_pokemon.find(
+      (tp) => tp.pokemon_id === -101
+    );
+    expect(eevee!.team_position).toBe(1);
+  });
+});
+
+describe("createLocalPersistence — updateTeam", () => {
+  it("updates team metadata fields", async () => {
+    let capturedTeam: TeamWithPokemon | null = null;
+    const initialTeam = makeTeam({
+      name: "Old Name",
+      format: "gen9vgc2026regi",
+    });
+    const setTeam = jest.fn(
+      (updater: (prev: TeamWithPokemon) => TeamWithPokemon) => {
+        capturedTeam = updater(initialTeam);
+      }
+    );
+
+    const persistence = createLocalPersistence({ setTeam });
+    const result = await persistence.updateTeam(-1, { name: "New Name" });
+
+    expect(result.success).toBe(true);
+    expect(capturedTeam!.name).toBe("New Name");
+    // Format should remain unchanged
+    expect(capturedTeam!.format).toBe("gen9vgc2026regi");
+  });
+
+  it("sets updated_at to a new value", async () => {
+    let capturedTeam: TeamWithPokemon | null = null;
+    const initialTeam = makeTeam({ updated_at: "2020-01-01T00:00:00.000Z" });
+    const setTeam = jest.fn(
+      (updater: (prev: TeamWithPokemon) => TeamWithPokemon) => {
+        capturedTeam = updater(initialTeam);
+      }
+    );
+
+    const persistence = createLocalPersistence({ setTeam });
+    await persistence.updateTeam(-1, { name: "Updated" });
+
+    expect(capturedTeam!.updated_at).not.toBe("2020-01-01T00:00:00.000Z");
+  });
+});

--- a/apps/web/src/components/team-builder/__tests__/local-persistence.test.ts
+++ b/apps/web/src/components/team-builder/__tests__/local-persistence.test.ts
@@ -1,5 +1,3 @@
-"use client";
-
 /**
  * Tests for createLocalPersistence — the local in-memory persistence adapter.
  */

--- a/apps/web/src/components/team-builder/__tests__/speed-tiers-panel-extra.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/speed-tiers-panel-extra.test.tsx
@@ -180,13 +180,13 @@ describe("SpeedTiersPanel — switch interactions", () => {
     expect(screen.getByText("Theirs")).toBeInTheDocument();
   });
 
-  it("renders Tailwind label with switches for both sides", () => {
+  it("renders Tailwind label with toggle buttons for both sides", () => {
     renderEmpty();
     // In 3-column layout, label appears once in the center
     expect(screen.getByText("Tailwind")).toBeInTheDocument();
-    // Two switch elements for tailwind (ours + theirs)
-    const switches = screen.getAllByRole("switch");
-    expect(switches.length).toBeGreaterThanOrEqual(2);
+    // Two circular toggle buttons for tailwind (ours + theirs)
+    expect(screen.getByRole("button", { name: /our tailwind/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /their tailwind/i })).toBeInTheDocument();
   });
 
   it("renders weather switches", () => {
@@ -197,9 +197,9 @@ describe("SpeedTiersPanel — switch interactions", () => {
     expect(screen.getByText("Snow")).toBeInTheDocument();
   });
 
-  it("renders Trick Room switch", () => {
+  it("renders Trick Room toggle button", () => {
     renderEmpty();
-    expect(screen.getByRole("switch", { name: /trick room/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /trick room/i })).toBeInTheDocument();
   });
 
   it("renders stage steppers for both sides", () => {
@@ -217,24 +217,18 @@ describe("SpeedTiersPanel — switch interactions", () => {
     expect(zeroEls.length).toBeGreaterThanOrEqual(2);
   });
 
-  it("clicking + on yours stage shows +1", async () => {
+  it("clicking stage + on ours side increases stage", async () => {
     renderEmpty();
     const user = userEvent.setup();
-    // The layout is a 3-column grid: [yours stepper] [Stages label] [theirs stepper]
-    // Find the "Stages" label, then grab its previous sibling (yours stepper div).
-    const stagesLabel = screen.getByText("Stages");
-    const yoursStepper = stagesLabel.previousElementSibling as HTMLElement;
-    const plusButton = yoursStepper.querySelector("button:last-child") as HTMLElement;
+    const plusButton = screen.getByRole("button", { name: /our stage increase/i });
     await user.click(plusButton);
     expect(screen.getByText("+1")).toBeInTheDocument();
   });
 
-  it("clicking − on yours stage shows -1", async () => {
+  it("clicking stage − on ours side decreases stage", async () => {
     renderEmpty();
     const user = userEvent.setup();
-    const stagesLabel = screen.getByText("Stages");
-    const yoursStepper = stagesLabel.previousElementSibling as HTMLElement;
-    const minusButton = yoursStepper.querySelector("button:first-child") as HTMLElement;
+    const minusButton = screen.getByRole("button", { name: /our stage decrease/i });
     await user.click(minusButton);
     expect(screen.getByText("-1")).toBeInTheDocument();
   });

--- a/apps/web/src/components/team-builder/__tests__/speed-tiers-panel-extra.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/speed-tiers-panel-extra.test.tsx
@@ -14,10 +14,7 @@ import userEvent from "@testing-library/user-event";
 import React from "react";
 
 import type * as TrainersPokemon from "@trainers/pokemon";
-import {
-  type GameFormat,
-  type MetaSpeedEntry,
-} from "@trainers/pokemon";
+import { type GameFormat, type MetaSpeedEntry } from "@trainers/pokemon";
 
 import { type Tables, type TeamWithPokemon } from "@trainers/supabase";
 
@@ -26,9 +23,8 @@ import { type Tables, type TeamWithPokemon } from "@trainers/supabase";
 // =============================================================================
 
 jest.mock("@trainers/pokemon", () => {
-  const actual = jest.requireActual<typeof TrainersPokemon>(
-    "@trainers/pokemon"
-  );
+  const actual =
+    jest.requireActual<typeof TrainersPokemon>("@trainers/pokemon");
   return {
     ...actual,
     getLegalSpecies: jest.fn().mockReturnValue(null),
@@ -40,9 +36,7 @@ jest.mock("@trainers/pokemon", () => {
     calculateStat: jest.fn().mockReturnValue(150),
     calculateChampionsStat: jest.fn().mockReturnValue(110),
     getNatureMultiplier: jest.fn().mockReturnValue(1.0),
-    applySpeedModifiers: jest
-      .fn()
-      .mockImplementation((base: number) => base),
+    applySpeedModifiers: jest.fn().mockImplementation((base: number) => base),
     groupBySpeed: actual.groupBySpeed,
     isChampionsFormat: actual.isChampionsFormat,
   };
@@ -63,16 +57,17 @@ jest.mock("next/image", () => ({
 // Access mocks
 // =============================================================================
 
-const {
-  getMetaSpeedTiers,
-  applySpeedModifiers,
-} = jest.requireMock<typeof TrainersPokemon>("@trainers/pokemon");
+const { getMetaSpeedTiers, applySpeedModifiers } =
+  jest.requireMock<typeof TrainersPokemon>("@trainers/pokemon");
 
 // =============================================================================
 // Imports AFTER mocks
 // =============================================================================
 
-import { SpeedTiersPanel, getTeamFastestSpeed } from "../dock/speed-tiers-panel";
+import {
+  SpeedTiersPanel,
+  getTeamFastestSpeed,
+} from "../dock/speed-tiers-panel";
 
 // =============================================================================
 // Fixtures
@@ -167,9 +162,7 @@ beforeEach(() => {
 
 describe("SpeedTiersPanel — switch interactions", () => {
   function renderEmpty() {
-    return render(
-      <SpeedTiersPanel team={[]} format={TEST_FORMAT} />
-    );
+    return render(<SpeedTiersPanel team={[]} format={TEST_FORMAT} />);
   }
 
   it("renders section labels and headers", () => {
@@ -180,13 +173,17 @@ describe("SpeedTiersPanel — switch interactions", () => {
     expect(screen.getByText("Theirs")).toBeInTheDocument();
   });
 
-  it("renders Tailwind label with toggle buttons for both sides", () => {
+  it("renders Tailwind label with toggle switches for both sides", () => {
     renderEmpty();
     // In 3-column layout, label appears once in the center
     expect(screen.getByText("Tailwind")).toBeInTheDocument();
-    // Two circular toggle buttons for tailwind (ours + theirs)
-    expect(screen.getByRole("button", { name: /our tailwind/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /their tailwind/i })).toBeInTheDocument();
+    // Two switch toggles for tailwind (ours + theirs)
+    expect(
+      screen.getByRole("switch", { name: /our tailwind/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", { name: /their tailwind/i })
+    ).toBeInTheDocument();
   });
 
   it("renders weather switches", () => {
@@ -199,7 +196,9 @@ describe("SpeedTiersPanel — switch interactions", () => {
 
   it("renders Trick Room toggle button", () => {
     renderEmpty();
-    expect(screen.getByRole("button", { name: /trick room/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /trick room/i })
+    ).toBeInTheDocument();
   });
 
   it("renders stage steppers for both sides", () => {
@@ -220,7 +219,9 @@ describe("SpeedTiersPanel — switch interactions", () => {
   it("clicking stage + on ours side increases stage", async () => {
     renderEmpty();
     const user = userEvent.setup();
-    const plusButton = screen.getByRole("button", { name: /our stage increase/i });
+    const plusButton = screen.getByRole("button", {
+      name: /our stage increase/i,
+    });
     await user.click(plusButton);
     expect(screen.getByText("+1")).toBeInTheDocument();
   });
@@ -228,7 +229,9 @@ describe("SpeedTiersPanel — switch interactions", () => {
   it("clicking stage − on ours side decreases stage", async () => {
     renderEmpty();
     const user = userEvent.setup();
-    const minusButton = screen.getByRole("button", { name: /our stage decrease/i });
+    const minusButton = screen.getByRole("button", {
+      name: /our stage decrease/i,
+    });
     await user.click(minusButton);
     expect(screen.getByText("-1")).toBeInTheDocument();
   });
@@ -264,9 +267,8 @@ describe("getTeamFastestSpeed", () => {
   });
 
   it("skips mons with no base stats (getBaseStats returns null)", () => {
-    const { getBaseStats } = jest.requireMock<typeof TrainersPokemon>(
-      "@trainers/pokemon"
-    );
+    const { getBaseStats } =
+      jest.requireMock<typeof TrainersPokemon>("@trainers/pokemon");
     (getBaseStats as jest.Mock).mockReturnValueOnce(null);
 
     const pikachu = makePokemon(1, "Pikachu");
@@ -281,9 +283,8 @@ describe("getTeamFastestSpeed", () => {
   });
 
   it("returns 0 for a single-mon team when getBaseStats returns null", () => {
-    const { getBaseStats } = jest.requireMock<typeof TrainersPokemon>(
-      "@trainers/pokemon"
-    );
+    const { getBaseStats } =
+      jest.requireMock<typeof TrainersPokemon>("@trainers/pokemon");
     (getBaseStats as jest.Mock).mockReturnValueOnce(null);
 
     const pikachu = makePokemon(1, "Pikachu");

--- a/apps/web/src/components/team-builder/__tests__/speed-tiers-panel.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/speed-tiers-panel.test.tsx
@@ -27,9 +27,8 @@ if (typeof globalThis.PointerEvent === "undefined") {
 // =============================================================================
 
 jest.mock("@trainers/pokemon", () => {
-  const actual = jest.requireActual<typeof TrainersPokemon>(
-    "@trainers/pokemon"
-  );
+  const actual =
+    jest.requireActual<typeof TrainersPokemon>("@trainers/pokemon");
   return {
     ...actual,
     // Return null so the panel falls through to getMetaSpeedTiers
@@ -45,12 +44,12 @@ jest.mock("@trainers/pokemon", () => {
       .fn()
       .mockImplementation((_species: string) => ({ speed: 0 })),
     calculateStat: jest.fn().mockImplementation((base: number) => base),
-    calculateChampionsStat: jest.fn().mockImplementation((base: number) => base),
-    getNatureMultiplier: jest.fn().mockReturnValue(1.0),
-    // Speed modifiers passthrough — return the base unchanged
-    applySpeedModifiers: jest
+    calculateChampionsStat: jest
       .fn()
       .mockImplementation((base: number) => base),
+    getNatureMultiplier: jest.fn().mockReturnValue(1.0),
+    // Speed modifiers passthrough — return the base unchanged
+    applySpeedModifiers: jest.fn().mockImplementation((base: number) => base),
     // groupBySpeed: use the real implementation — it's pure and tiny
     groupBySpeed: actual.groupBySpeed,
   };
@@ -72,13 +71,11 @@ jest.mock("next/image", () => ({
 // Helpers
 // =============================================================================
 
-const { getMetaSpeedTiers } = jest.requireMock<typeof TrainersPokemon>(
-  "@trainers/pokemon"
-);
+const { getMetaSpeedTiers } =
+  jest.requireMock<typeof TrainersPokemon>("@trainers/pokemon");
 
-const { applySpeedModifiers } = jest.requireMock<typeof TrainersPokemon>(
-  "@trainers/pokemon"
-);
+const { applySpeedModifiers } =
+  jest.requireMock<typeof TrainersPokemon>("@trainers/pokemon");
 
 /** Minimal gen 9 format for the panel */
 const TEST_FORMAT: GameFormat = {
@@ -116,9 +113,7 @@ function renderPanel(
   (getMetaSpeedTiers as jest.Mock).mockReturnValue(entries);
 
   // applySpeedModifiers returns the entry's fastSpread unchanged
-  (applySpeedModifiers as jest.Mock).mockImplementation(
-    (base: number) => base
-  );
+  (applySpeedModifiers as jest.Mock).mockImplementation((base: number) => base);
 
   return render(<SpeedTiersPanel team={[]} format={format} />);
 }
@@ -151,9 +146,9 @@ describe("SpeedTiersPanel — Trick Room sort order", () => {
     renderPanel(ENTRIES);
 
     // groupBySpeed returns descending by default; sortedGroups keeps that order
-    const names = screen.getAllByText(/flutter mane|rillaboom|amoonguss/i).map(
-      (el) => el.textContent?.trim()
-    );
+    const names = screen
+      .getAllByText(/flutter mane|rillaboom|amoonguss/i)
+      .map((el) => el.textContent?.trim());
 
     const flutterIdx = names.findIndex((n) => n === "Flutter Mane");
     const rillaboomIdx = names.findIndex((n) => n === "Rillaboom");
@@ -169,9 +164,9 @@ describe("SpeedTiersPanel — Trick Room sort order", () => {
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: /trick room/i }));
 
-    const names = screen.getAllByText(/flutter mane|rillaboom|amoonguss/i).map(
-      (el) => el.textContent?.trim()
-    );
+    const names = screen
+      .getAllByText(/flutter mane|rillaboom|amoonguss/i)
+      .map((el) => el.textContent?.trim());
 
     const flutterIdx = names.findIndex((n) => n === "Flutter Mane");
     const rillaboomIdx = names.findIndex((n) => n === "Rillaboom");
@@ -191,9 +186,9 @@ describe("SpeedTiersPanel — Trick Room sort order", () => {
     await user.click(trButton); // TR on
     await user.click(trButton); // TR off
 
-    const names = screen.getAllByText(/flutter mane|rillaboom|amoonguss/i).map(
-      (el) => el.textContent?.trim()
-    );
+    const names = screen
+      .getAllByText(/flutter mane|rillaboom|amoonguss/i)
+      .map((el) => el.textContent?.trim());
 
     const flutterIdx = names.findIndex((n) => n === "Flutter Mane");
     const amoongussIdx = names.findIndex((n) => n === "Amoonguss");
@@ -233,5 +228,72 @@ describe("SpeedTiersPanel — TR switch state", () => {
 
     const trButton = screen.getByRole("button", { name: /trick room/i });
     expect(trButton.className).toMatch(/bg-primary/);
+  });
+});
+
+// =============================================================================
+// External weather prop (synced from calc)
+// =============================================================================
+
+describe("SpeedTiersPanel — external weather prop", () => {
+  const ENTRIES = [makeEntry("Pikachu", 110)];
+
+  function renderWithWeather(
+    weather?: string,
+    setWeather?: (v: string) => void
+  ) {
+    (getMetaSpeedTiers as jest.Mock).mockReturnValue(ENTRIES);
+    (applySpeedModifiers as jest.Mock).mockImplementation(
+      (base: number) => base
+    );
+
+    return render(
+      <SpeedTiersPanel
+        team={[]}
+        format={TEST_FORMAT}
+        weather={weather}
+        setWeather={setWeather}
+      />
+    );
+  }
+
+  it("highlights the Sun button when weather='Sun' is passed", () => {
+    renderWithWeather("Sun");
+
+    const sunButton = screen.getByRole("button", { name: /sun/i });
+    expect(sunButton.className).toMatch(/bg-primary|ring/);
+  });
+
+  it("treats unknown weather values as 'none' (no button highlighted)", () => {
+    renderWithWeather("Hail");
+
+    // No weather button should be active — all should lack the active class
+    const weatherButtons = ["Sun", "Rain", "Sand", "Snow"].map((w) =>
+      screen.getByRole("button", { name: new RegExp(`^${w}$`, "i") })
+    );
+    for (const btn of weatherButtons) {
+      expect(btn.className).not.toMatch(/bg-primary/);
+    }
+  });
+
+  it("calls setWeather with capitalized value when a weather button is clicked", async () => {
+    const mockSetWeather = jest.fn();
+    renderWithWeather("", mockSetWeather);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /rain/i }));
+
+    expect(mockSetWeather).toHaveBeenCalledWith("Rain");
+  });
+
+  it("calls setWeather with empty string to toggle off active weather", async () => {
+    const mockSetWeather = jest.fn();
+    renderWithWeather("Rain", mockSetWeather);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /rain/i }));
+
+    // Clicking the already-active weather should toggle it off
+    expect(mockSetWeather).toHaveBeenCalledWith("");
   });
 });

--- a/apps/web/src/components/team-builder/__tests__/speed-tiers-panel.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/speed-tiers-panel.test.tsx
@@ -167,7 +167,7 @@ describe("SpeedTiersPanel — Trick Room sort order", () => {
     renderPanel(ENTRIES);
 
     const user = userEvent.setup();
-    await user.click(screen.getByRole("switch", { name: /trick room/i }));
+    await user.click(screen.getByRole("button", { name: /trick room/i }));
 
     const names = screen.getAllByText(/flutter mane|rillaboom|amoonguss/i).map(
       (el) => el.textContent?.trim()
@@ -186,10 +186,10 @@ describe("SpeedTiersPanel — Trick Room sort order", () => {
     renderPanel(ENTRIES);
 
     const user = userEvent.setup();
-    const trSwitch = screen.getByRole("switch", { name: /trick room/i });
+    const trButton = screen.getByRole("button", { name: /trick room/i });
 
-    await user.click(trSwitch); // TR on
-    await user.click(trSwitch); // TR off
+    await user.click(trButton); // TR on
+    await user.click(trButton); // TR off
 
     const names = screen.getAllByText(/flutter mane|rillaboom|amoonguss/i).map(
       (el) => el.textContent?.trim()
@@ -219,19 +219,19 @@ describe("SpeedTiersPanel — summary removed", () => {
 // =============================================================================
 
 describe("SpeedTiersPanel — TR switch state", () => {
-  it("TR switch is not checked by default", () => {
+  it("TR button is not active by default", () => {
     renderPanel([makeEntry("Pikachu", 110)]);
-    const trSwitch = screen.getByRole("switch", { name: /trick room/i });
-    expect(trSwitch).toHaveAttribute("aria-checked", "false");
+    const trButton = screen.getByRole("button", { name: /trick room/i });
+    expect(trButton.className).not.toMatch(/bg-primary/);
   });
 
-  it("TR switch is checked when Trick Room is active", async () => {
+  it("TR button is active when Trick Room is toggled", async () => {
     renderPanel([makeEntry("Pikachu", 110)]);
 
     const user = userEvent.setup();
-    await user.click(screen.getByRole("switch", { name: /trick room/i }));
+    await user.click(screen.getByRole("button", { name: /trick room/i }));
 
-    const trSwitch = screen.getByRole("switch", { name: /trick room/i });
-    expect(trSwitch).toHaveAttribute("aria-checked", "true");
+    const trButton = screen.getByRole("button", { name: /trick room/i });
+    expect(trButton.className).toMatch(/bg-primary/);
   });
 });

--- a/apps/web/src/components/team-builder/__tests__/use-local-team-storage.test.ts
+++ b/apps/web/src/components/team-builder/__tests__/use-local-team-storage.test.ts
@@ -288,13 +288,15 @@ describe("clearLocalTeamStorage", () => {
     localStorage.clear();
   });
 
-  it("removes the storage key from localStorage", () => {
+  it("removes the storage key from localStorage and returns true", () => {
     localStorage.setItem(STORAGE_KEY, "something");
-    clearLocalTeamStorage();
+    const result = clearLocalTeamStorage();
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(result).toBe(true);
   });
 
-  it("does nothing if storage key does not exist", () => {
-    expect(() => clearLocalTeamStorage()).not.toThrow();
+  it("returns true if storage key does not exist", () => {
+    const result = clearLocalTeamStorage();
+    expect(result).toBe(true);
   });
 });

--- a/apps/web/src/components/team-builder/__tests__/use-local-team-storage.test.ts
+++ b/apps/web/src/components/team-builder/__tests__/use-local-team-storage.test.ts
@@ -1,0 +1,300 @@
+"use client";
+
+/**
+ * Tests for useLocalTeamStorage hook.
+ * Covers: hydration from localStorage, debounced writes, deduplication,
+ * clearLocalTeamStorage, and version checking.
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+import type { TeamWithPokemon } from "@trainers/supabase";
+
+import {
+  useLocalTeamStorage,
+  clearLocalTeamStorage,
+} from "../persistence/use-local-team-storage";
+
+// =============================================================================
+// Constants (mirrored from source)
+// =============================================================================
+
+const STORAGE_KEY = "trainersgg.builder.localTeam.v1";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function makeTeam(overrides?: Partial<TeamWithPokemon>): TeamWithPokemon {
+  return {
+    id: -1,
+    name: "Untitled Team",
+    format: "gen9vgc2026regi",
+    format_legal: null,
+    description: null,
+    notes: null,
+    tags: null,
+    is_public: null,
+    parent_team_id: null,
+    created_by: -1,
+    created_at: "2024-01-01T00:00:00.000Z",
+    updated_at: "2024-01-01T00:00:00.000Z",
+    team_pokemon: [],
+    ...overrides,
+  };
+}
+
+function storeTeam(team: TeamWithPokemon) {
+  const data = {
+    team,
+    updatedAt: new Date().toISOString(),
+    version: 1,
+  };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("useLocalTeamStorage — initialization", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns an empty team when localStorage is empty", () => {
+    const { result } = renderHook(() => useLocalTeamStorage());
+    expect(result.current.team.name).toBe("Untitled Team");
+    expect(result.current.team.team_pokemon).toHaveLength(0);
+    expect(result.current.team.format).toBe("gen9vgc2026regi");
+  });
+
+  it("sets hydrated to true after mount", () => {
+    const { result } = renderHook(() => useLocalTeamStorage());
+    expect(result.current.hydrated).toBe(true);
+  });
+
+  it("hydrates from localStorage if data exists", () => {
+    const team = makeTeam({ name: "Saved Team" });
+    storeTeam(team);
+
+    const { result } = renderHook(() => useLocalTeamStorage());
+    expect(result.current.team.name).toBe("Saved Team");
+  });
+
+  it("returns empty team if localStorage has invalid JSON", () => {
+    localStorage.setItem(STORAGE_KEY, "not-json{{{");
+
+    const { result } = renderHook(() => useLocalTeamStorage());
+    expect(result.current.team.name).toBe("Untitled Team");
+    expect(result.current.hydrated).toBe(true);
+  });
+
+  it("returns empty team if localStorage has wrong version", () => {
+    const data = {
+      team: makeTeam({ name: "V2 Team" }),
+      updatedAt: new Date().toISOString(),
+      version: 2,
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+
+    const { result } = renderHook(() => useLocalTeamStorage());
+    expect(result.current.team.name).toBe("Untitled Team");
+  });
+});
+
+describe("useLocalTeamStorage — setTeam", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("updates team state immediately with an updater function", () => {
+    const { result } = renderHook(() => useLocalTeamStorage());
+
+    act(() => {
+      result.current.setTeam((prev) => ({ ...prev, name: "Updated" }));
+    });
+
+    expect(result.current.team.name).toBe("Updated");
+  });
+
+  it("updates team state immediately with a direct value", () => {
+    const { result } = renderHook(() => useLocalTeamStorage());
+
+    act(() => {
+      result.current.setTeam(makeTeam({ name: "Direct Value" }));
+    });
+
+    expect(result.current.team.name).toBe("Direct Value");
+  });
+
+  it("debounces writes to localStorage", () => {
+    const { result } = renderHook(() => useLocalTeamStorage());
+
+    act(() => {
+      result.current.setTeam((prev) => ({ ...prev, name: "First" }));
+    });
+
+    // Should not have written yet
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    // Advance timers past the debounce
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+
+    // Now it should be written
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored.team.name).toBe("First");
+  });
+
+  it("only writes once if setTeam is called multiple times within debounce window", () => {
+    const { result } = renderHook(() => useLocalTeamStorage());
+    const spy = jest.spyOn(Storage.prototype, "setItem");
+
+    act(() => {
+      result.current.setTeam((prev) => ({ ...prev, name: "A" }));
+    });
+    act(() => {
+      result.current.setTeam((prev) => ({ ...prev, name: "B" }));
+    });
+    act(() => {
+      result.current.setTeam((prev) => ({ ...prev, name: "C" }));
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+
+    // Only the last value should be stored (one write after debounce)
+    const storedCalls = spy.mock.calls.filter(([key]) => key === STORAGE_KEY);
+    expect(storedCalls).toHaveLength(1);
+    const stored = JSON.parse(storedCalls[0]![1] as string);
+    expect(stored.team.name).toBe("C");
+
+    spy.mockRestore();
+  });
+});
+
+describe("useLocalTeamStorage — deduplication", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // Ensure real timers — other tests may have set fake timers
+    jest.useRealTimers();
+  });
+
+  it("deduplicates team_pokemon by pokemon_id on hydration", async () => {
+    const team = makeTeam({
+      team_pokemon: [
+        {
+          id: -1,
+          pokemon_id: -1,
+          team_position: 0,
+          pokemon: {
+            id: -1,
+            species: "Pikachu",
+            ability: "Static",
+            move1: "Thunderbolt",
+            move2: null,
+            move3: null,
+            move4: null,
+            nature: "Timid",
+            nickname: null,
+            notes: null,
+            held_item: null,
+            tera_type: null,
+            gender: null,
+            is_shiny: false,
+            level: 50,
+            format_legal: null,
+            created_at: "2024-01-01T00:00:00.000Z",
+            ev_hp: 0,
+            ev_attack: 0,
+            ev_defense: 0,
+            ev_special_attack: 252,
+            ev_special_defense: 4,
+            ev_speed: 252,
+            iv_hp: 31,
+            iv_attack: 31,
+            iv_defense: 31,
+            iv_special_attack: 31,
+            iv_special_defense: 31,
+            iv_speed: 31,
+          },
+        },
+        // Duplicate entry with same pokemon_id at different position
+        {
+          id: -1,
+          pokemon_id: -1,
+          team_position: 3,
+          pokemon: {
+            id: -1,
+            species: "Pikachu",
+            ability: "Static",
+            move1: "Thunderbolt",
+            move2: null,
+            move3: null,
+            move4: null,
+            nature: "Timid",
+            nickname: null,
+            notes: null,
+            held_item: null,
+            tera_type: null,
+            gender: null,
+            is_shiny: false,
+            level: 50,
+            format_legal: null,
+            created_at: "2024-01-01T00:00:00.000Z",
+            ev_hp: 0,
+            ev_attack: 0,
+            ev_defense: 0,
+            ev_special_attack: 252,
+            ev_special_defense: 4,
+            ev_speed: 252,
+            iv_hp: 31,
+            iv_attack: 31,
+            iv_defense: 31,
+            iv_special_attack: 31,
+            iv_special_defense: 31,
+            iv_speed: 31,
+          },
+        },
+      ],
+    });
+    storeTeam(team);
+
+    const { result } = renderHook(() => useLocalTeamStorage());
+
+    // The useEffect hydration runs asynchronously — wait for it
+    await waitFor(() => {
+      expect(result.current.team.team_pokemon).toHaveLength(1);
+    });
+    expect(result.current.team.team_pokemon[0]!.team_position).toBe(3);
+  });
+});
+
+describe("clearLocalTeamStorage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("removes the storage key from localStorage", () => {
+    localStorage.setItem(STORAGE_KEY, "something");
+    clearLocalTeamStorage();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("does nothing if storage key does not exist", () => {
+    expect(() => clearLocalTeamStorage()).not.toThrow();
+  });
+});

--- a/apps/web/src/components/team-builder/builder-topbar.tsx
+++ b/apps/web/src/components/team-builder/builder-topbar.tsx
@@ -47,6 +47,28 @@ import { dbPokemonToFlat } from "./pokemon-utils";
 import { ValidationPopover } from "./validation/validation-popover";
 
 // =============================================================================
+// Shared Icons
+// =============================================================================
+
+const SaveIcon = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="size-4"
+    aria-hidden="true"
+  >
+    <path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" />
+    <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" />
+    <path d="M7 3v4a1 1 0 0 0 1 1h7" />
+  </svg>
+);
+
+// =============================================================================
 // Props
 // =============================================================================
 
@@ -243,21 +265,7 @@ export function BuilderTopbar({
               aria-label={isSaving ? "Saving…" : "Save to account"}
               className="text-muted-foreground hover:text-primary disabled:text-muted-foreground/40 flex size-7 items-center justify-center rounded-md transition-colors"
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth={2}
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="size-4"
-                aria-hidden="true"
-              >
-                <path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" />
-                <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" />
-                <path d="M7 3v4a1 1 0 0 0 1 1h7" />
-              </svg>
+              {SaveIcon}
             </button>
           ) : (
             <Link
@@ -265,21 +273,7 @@ export function BuilderTopbar({
               aria-label="Sign in to save"
               className="text-muted-foreground hover:text-primary flex size-7 items-center justify-center rounded-md transition-colors"
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth={2}
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="size-4"
-                aria-hidden="true"
-              >
-                <path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" />
-                <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" />
-                <path d="M7 3v4a1 1 0 0 0 1 1h7" />
-              </svg>
+              {SaveIcon}
             </Link>
           )}
         </div>

--- a/apps/web/src/components/team-builder/builder-topbar.tsx
+++ b/apps/web/src/components/team-builder/builder-topbar.tsx
@@ -29,6 +29,7 @@ import {
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuLabel,
@@ -299,7 +300,7 @@ export function BuilderTopbar({
             File
             <ChevronDown className="text-muted-foreground size-3" />
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" sideOffset={6} className="min-w-44">
+          <DropdownMenuContent align="end" sideOffset={6} className="min-w-52">
             {onLoadTeam && (
               <>
                 <DropdownMenuItem onClick={() => setLoadOpen(true)}>
@@ -314,15 +315,17 @@ export function BuilderTopbar({
               Import paste
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuLabel>Export</DropdownMenuLabel>
-            <DropdownMenuItem onClick={handleCopyShowdown}>
-              <Copy className="size-4" />
-              Copy as Showdown text
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={handleOpenPokepaste}>
-              <ExternalLink className="size-4" />
-              Open in Pokepaste
-            </DropdownMenuItem>
+            <DropdownMenuGroup>
+              <DropdownMenuLabel>Export</DropdownMenuLabel>
+              <DropdownMenuItem onClick={handleCopyShowdown}>
+                <Copy className="size-4" />
+                Copy as Showdown text
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={handleOpenPokepaste}>
+                <ExternalLink className="size-4" />
+                Open in Pokepaste
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
           </DropdownMenuContent>
         </DropdownMenu>
 
@@ -400,7 +403,9 @@ export function BuilderTopbar({
                         <p className="truncate font-medium">{t.name}</p>
                         <p className="text-muted-foreground text-xs">
                           {t.alt_username}
-                          {t.format ? ` · ${getFormatById(t.format)?.label ?? t.format}` : ""}
+                          {t.format
+                            ? ` · ${getFormatById(t.format)?.label ?? t.format}`
+                            : ""}
                           {" · "}
                           {t.team_pokemon.filter((tp) => tp.pokemon).length}/6
                         </p>

--- a/apps/web/src/components/team-builder/builder-topbar.tsx
+++ b/apps/web/src/components/team-builder/builder-topbar.tsx
@@ -26,7 +26,6 @@ import {
   type CrossAltTeamListItem,
 } from "@trainers/supabase";
 
-import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -233,8 +232,55 @@ export function BuilderTopbar({
     <>
       {/* Center: Team name — absolutely centered in the nav bar */}
       <div className="pointer-events-none absolute inset-x-0 flex items-center justify-center">
-        <div className="pointer-events-auto">
+        <div className="pointer-events-auto flex items-center gap-1.5">
           <EditableName defaultValue={team.name} onSave={onNameChange} />
+          {onSaveToAccount ? (
+            <button
+              type="button"
+              onClick={onSaveToAccount}
+              disabled={isSaving}
+              aria-label={isSaving ? "Saving…" : "Save to account"}
+              className="text-muted-foreground hover:text-primary disabled:text-muted-foreground/40 flex size-7 items-center justify-center rounded-md transition-colors"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="size-4"
+                aria-hidden="true"
+              >
+                <path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" />
+                <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" />
+                <path d="M7 3v4a1 1 0 0 0 1 1h7" />
+              </svg>
+            </button>
+          ) : (
+            <Link
+              href={`/sign-in?redirect=${encodeURIComponent("/builder?action=save")}`}
+              aria-label="Sign in to save"
+              className="text-muted-foreground hover:text-primary flex size-7 items-center justify-center rounded-md transition-colors"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="size-4"
+                aria-hidden="true"
+              >
+                <path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" />
+                <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" />
+                <path d="M7 3v4a1 1 0 0 0 1 1h7" />
+              </svg>
+            </Link>
+          )}
         </div>
       </div>
 
@@ -319,25 +365,6 @@ export function BuilderTopbar({
             />
           </PopoverContent>
         </Popover>
-
-        {/* Save / Sign in */}
-        {onSaveToAccount ? (
-          <Button
-            size="sm"
-            onClick={onSaveToAccount}
-            disabled={isSaving}
-            className="h-7 px-3 text-xs"
-          >
-            {isSaving ? "Saving..." : "Save to account"}
-          </Button>
-        ) : (
-          <Link
-            href={`/sign-in?redirect=${encodeURIComponent("/builder?action=save")}`}
-            className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-7 items-center rounded-md px-3 text-xs font-medium shadow-xs transition-colors"
-          >
-            Sign in to save
-          </Link>
-        )}
       </div>
 
       {/* Load team popover (opened from File menu) */}

--- a/apps/web/src/components/team-builder/builder-topbar.tsx
+++ b/apps/web/src/components/team-builder/builder-topbar.tsx
@@ -398,7 +398,7 @@ export function BuilderTopbar({
                         <p className="text-muted-foreground text-xs">
                           {t.alt_username}
                           {t.format
-                            ? ` · ${getFormatById(t.format)?.label ?? t.format}`
+                            ? ` · ${getFormatById(t.format)?.label ?? "Unknown format"}`
                             : ""}
                           {" · "}
                           {t.team_pokemon.filter((tp) => tp.pokemon).length}/6

--- a/apps/web/src/components/team-builder/calc/calc-bottom-panel.tsx
+++ b/apps/web/src/components/team-builder/calc/calc-bottom-panel.tsx
@@ -85,15 +85,15 @@ export function CalcBottomPanel({
   return (
     <section className="flex min-h-0 flex-1 flex-col" aria-label="Damage Calc">
       {/* Panel header */}
-      <header className="flex items-center gap-2 border-b border-border px-3 py-2">
-        <span className="font-mono text-[10px] font-bold uppercase tracking-wider text-primary">
+      <header className="border-border flex items-center gap-2 border-b px-3 py-2">
+        <span className="text-primary flex-1 text-center font-mono text-[10px] font-bold tracking-wider uppercase">
           Damage Calc
         </span>
         <button
           type="button"
           onClick={onClose}
           aria-label="Close damage calc"
-          className="ml-auto text-muted-foreground hover:text-foreground flex size-5 items-center justify-center rounded transition-colors"
+          className="text-muted-foreground hover:text-foreground flex size-5 items-center justify-center rounded transition-colors"
         >
           ×
         </button>
@@ -119,7 +119,7 @@ export function CalcBottomPanel({
         />
 
         {/* Defender stats */}
-        <div className="border-b border-dashed border-border px-3 py-1.5">
+        <div className="border-border border-b border-dashed px-3 py-1.5">
           <CalcDefenderStats
             defenderSpecies={effectiveDefenderSpecies}
             defenderNature={calc.defenderNature}
@@ -136,7 +136,7 @@ export function CalcBottomPanel({
         </div>
 
         {/* Defender moves */}
-        <div className="border-b border-dashed border-border px-3 py-2">
+        <div className="border-border border-b border-dashed px-3 py-2">
           <CalcDefenderMoves
             effectiveMoves={effectiveMoves}
             defenderSpecies={calc.defenderSpecies}
@@ -177,7 +177,10 @@ export function CalcBottomPanel({
               setAllyAlive: (v) => calc.setField({ allyAlive: v }),
             }}
             fainted={{ yours: faintedYours, theirs: faintedTheirs }}
-            setFainted={{ setYours: setFaintedYours, setTheirs: setFaintedTheirs }}
+            setFainted={{
+              setYours: setFaintedYours,
+              setTheirs: setFaintedTheirs,
+            }}
             inferred={{
               weather: calc.inferredWeather,
               terrain: calc.inferredTerrain,

--- a/apps/web/src/components/team-builder/calc/calc-field-block.tsx
+++ b/apps/web/src/components/team-builder/calc/calc-field-block.tsx
@@ -278,7 +278,7 @@ export function CalcFieldBlock({
 
       {/* Conditions: weather, terrain, gravity, fairy aura */}
       <fieldset className="rounded-lg border border-border/60 px-3 py-2">
-        <legend className="px-1 font-mono text-[9px] font-bold uppercase tracking-[0.12em] text-muted-foreground">
+        <legend className="px-1 font-mono text-[9px] font-bold uppercase tracking-[0.12em] text-primary">
           Conditions
         </legend>
         <div className="flex flex-col gap-2">
@@ -364,7 +364,7 @@ export function CalcFieldBlock({
 
       {/* Sides — mirrored Ours | Label | Theirs grid */}
       <fieldset className="rounded-lg border border-border/60 px-3 py-2">
-        <legend className="px-1 font-mono text-[9px] font-bold uppercase tracking-[0.12em] text-muted-foreground">
+        <legend className="px-1 font-mono text-[9px] font-bold uppercase tracking-[0.12em] text-primary">
           Sides
         </legend>
         <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-x-1 gap-y-0.5">

--- a/apps/web/src/components/team-builder/dock/dockbar.tsx
+++ b/apps/web/src/components/team-builder/dock/dockbar.tsx
@@ -107,11 +107,16 @@ export function Dockbar({
   const calcSubLabel = defenderSpecies ? `vs ${defenderSpecies}` : "no target";
 
   return (
-    <div className="bg-background @container/dock w-full rounded-b-lg border-t">
+    <div className="bg-background @container/dock relative w-full rounded-b-lg border-t">
+      {/* Footer disclaimer — left side, absolutely positioned */}
+      <p className="text-muted-foreground absolute top-1/2 left-3 hidden -translate-y-1/2 text-[8px] opacity-40 @[900px]/dock:block">
+        Not affiliated with Nintendo, The Pok&eacute;mon Company, or Game Freak.
+      </p>
+
       <div
         role="toolbar"
         aria-label="Builder tools"
-        className="flex min-w-0 flex-nowrap items-center gap-2 overflow-x-auto px-3 py-2 @[700px]/dock:flex-wrap @[700px]/dock:justify-center @[700px]/dock:overflow-visible"
+        className="flex min-w-0 items-center justify-center gap-2 overflow-x-auto px-3 py-2"
       >
         {/* Type matchups pill */}
         <DockPill
@@ -179,23 +184,17 @@ export function Dockbar({
         </DockPill>
       </div>
 
-      {/* Footer content */}
-      <div className="text-muted-foreground border-border/40 flex items-center justify-between border-t px-3 py-1.5 text-[8px]">
-        <p className="opacity-40">
-          trainers.gg is not affiliated with, endorsed by, or connected to
-          Nintendo, The Pok&eacute;mon Company, or Game Freak.
-        </p>
-        <p className="flex items-center gap-1 whitespace-nowrap">
-          <Image
-            src="/icons/beanie_logo.png"
-            alt="Beanie LLC"
-            width={12}
-            height={12}
-            className="inline-block"
-          />
-          &copy; {new Date().getFullYear()} Beanie LLC
-        </p>
-      </div>
+      {/* Footer copyright — right side, absolutely positioned */}
+      <p className="text-muted-foreground absolute top-1/2 right-3 hidden -translate-y-1/2 items-center gap-1 text-[10px] whitespace-nowrap @[900px]/dock:flex">
+        <Image
+          src="/icons/beanie_logo.png"
+          alt="Beanie LLC"
+          width={28}
+          height={28}
+          className="inline-block"
+        />
+        &copy; {new Date().getFullYear()} Beanie LLC
+      </p>
     </div>
   );
 }

--- a/apps/web/src/components/team-builder/dock/dockbar.tsx
+++ b/apps/web/src/components/team-builder/dock/dockbar.tsx
@@ -109,7 +109,7 @@ export function Dockbar({
   return (
     <div className="bg-background @container/dock relative w-full rounded-b-lg border-t">
       {/* Footer disclaimer — left side, absolutely positioned */}
-      <p className="text-muted-foreground absolute top-1/2 left-3 hidden -translate-y-1/2 text-[8px] opacity-40 @[900px]/dock:block">
+      <p className="text-muted-foreground absolute top-1/2 left-3 hidden -translate-y-1/2 text-[8px] @[900px]/dock:block">
         Not affiliated with Nintendo, The Pok&eacute;mon Company, or Game Freak.
       </p>
 

--- a/apps/web/src/components/team-builder/dock/dockbar.tsx
+++ b/apps/web/src/components/team-builder/dock/dockbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { type ReactNode } from "react";
+import Image from "next/image";
 
 import { cn } from "@/lib/utils";
 
@@ -176,6 +177,24 @@ export function Dockbar({
             {isCalcActive ? "▾" : "▴"}
           </span>
         </DockPill>
+      </div>
+
+      {/* Footer content */}
+      <div className="text-muted-foreground border-border/40 flex items-center justify-between border-t px-3 py-1.5 text-[8px]">
+        <p className="opacity-40">
+          trainers.gg is not affiliated with, endorsed by, or connected to
+          Nintendo, The Pok&eacute;mon Company, or Game Freak.
+        </p>
+        <p className="flex items-center gap-1 whitespace-nowrap">
+          <Image
+            src="/icons/beanie_logo.png"
+            alt="Beanie LLC"
+            width={12}
+            height={12}
+            className="inline-block"
+          />
+          &copy; {new Date().getFullYear()} Beanie LLC
+        </p>
       </div>
     </div>
   );

--- a/apps/web/src/components/team-builder/dock/heatmap-panel.tsx
+++ b/apps/web/src/components/team-builder/dock/heatmap-panel.tsx
@@ -223,11 +223,10 @@ function MonRowLabel({ pokemon }: { pokemon: Tables<"pokemon"> }) {
   } catch {
     spriteUrl = undefined;
   }
-  const name =
-    pokemon.nickname || pokemon.species?.split("-")[0] || "Unknown";
+  const name = pokemon.nickname || pokemon.species?.split("-")[0] || "Unknown";
 
   return (
-    <div className="flex items-center gap-1.5 min-w-0">
+    <div className="flex min-w-0 items-center gap-1.5">
       <span className="bg-muted/40 inline-flex size-8 shrink-0 items-center justify-center rounded-full">
         {spriteUrl ? (
           <img
@@ -243,7 +242,7 @@ function MonRowLabel({ pokemon }: { pokemon: Tables<"pokemon"> }) {
           </span>
         )}
       </span>
-      <span className="text-[11px] font-medium text-foreground whitespace-nowrap">
+      <span className="text-foreground text-[11px] font-medium whitespace-nowrap">
         {name}
       </span>
     </div>
@@ -372,7 +371,7 @@ export function HeatmapPanel({ team, format, onClose }: HeatmapPanelProps) {
             <span
               key={label}
               className={cn(
-                "inline-flex items-center justify-center rounded px-1.5 py-0.5 font-mono text-[10px] leading-tight min-w-[26px]",
+                "inline-flex min-w-[26px] items-center justify-center rounded px-1.5 py-0.5 font-mono text-[10px] leading-tight",
                 cls
               )}
             >
@@ -397,7 +396,7 @@ export function HeatmapPanel({ team, format, onClose }: HeatmapPanelProps) {
       <div className="min-h-0 flex-1 overflow-auto">
         {/* Column headers: type abbreviations */}
         <div
-          className="bg-muted/50 grid items-end gap-px px-2 py-1.5 sticky top-0 z-10"
+          className="bg-muted/50 sticky top-0 z-10 grid items-end gap-px px-2 py-1.5"
           style={gridStyle}
         >
           {/* Row label spacer */}
@@ -405,206 +404,199 @@ export function HeatmapPanel({ team, format, onClose }: HeatmapPanelProps) {
           {ALL_TYPES.map((t, idx) => (
             <Tooltip key={t}>
               <TooltipTrigger
-                  render={
-                    <span
-                      tabIndex={0}
-                      className={cn(
-                        "flex items-center justify-center cursor-default transition-opacity duration-100",
-                        hoverCell !== null &&
-                          hoverCell.col !== idx &&
-                          "opacity-40"
-                      )}
-                    >
-                      <Image
-                        src={`/types/${t}.png`}
-                        alt={t}
-                        width={24}
-                        height={24}
-                        className="size-6"
-                        unoptimized
-                      />
-                    </span>
-                  }
-                />
-                <TooltipContent>{t}</TooltipContent>
-              </Tooltip>
-            ))}
-            {/* Summary header */}
-            <span className="text-muted-foreground text-center text-[8px] font-semibold uppercase tracking-wide">
-              Net
-            </span>
-          </div>
+                render={
+                  <span
+                    tabIndex={0}
+                    className={cn(
+                      "flex cursor-default items-center justify-center transition-opacity duration-100",
+                      hoverCell !== null &&
+                        hoverCell.col !== idx &&
+                        "opacity-40"
+                    )}
+                  >
+                    <Image
+                      src={`/types/${t}.png`}
+                      alt={t}
+                      width={24}
+                      height={24}
+                      className="size-6"
+                      unoptimized
+                    />
+                  </span>
+                }
+              />
+              <TooltipContent>{t}</TooltipContent>
+            </Tooltip>
+          ))}
+          {/* Summary header */}
+          <span className="text-muted-foreground text-center text-[8px] font-semibold tracking-wide uppercase">
+            Net
+          </span>
+        </div>
 
-          {/* Pokemon rows */}
-          <div className="divide-muted/40 divide-y">
-            {rows.map((row, rowIdx) => (
-              <div
-                key={row.pokemon.id}
-                className={cn(
-                  "grid items-center gap-px px-2 py-1 transition-colors duration-100",
-                  hoverCell !== null &&
-                    hoverCell.row === rowIdx &&
-                    "bg-muted/30"
-                )}
-                style={gridStyle}
-              >
-                {/* Pokemon label */}
-                <MonRowLabel pokemon={row.pokemon} />
+        {/* Pokemon rows */}
+        <div className="divide-muted/40 divide-y">
+          {rows.map((row, rowIdx) => (
+            <div
+              key={row.pokemon.id}
+              className={cn(
+                "grid items-center gap-px px-2 py-1 transition-colors duration-100",
+                hoverCell !== null && hoverCell.row === rowIdx && "bg-muted/30"
+              )}
+              style={gridStyle}
+            >
+              {/* Pokemon label */}
+              <MonRowLabel pokemon={row.pokemon} />
 
-                {/* Type cells */}
-                {ALL_TYPES.map((t, colIdx) => {
-                  const mult = row.multipliers[colIdx] ?? null;
-                  const isHighlightedCol =
-                    hoverCell !== null && hoverCell.col === colIdx;
-                  const isHighlightedRow =
-                    hoverCell !== null && hoverCell.row === rowIdx;
-                  const isCrosshair = isHighlightedCol || isHighlightedRow;
+              {/* Type cells */}
+              {ALL_TYPES.map((t, colIdx) => {
+                const mult = row.multipliers[colIdx] ?? null;
+                const isHighlightedCol =
+                  hoverCell !== null && hoverCell.col === colIdx;
+                const isHighlightedRow =
+                  hoverCell !== null && hoverCell.row === rowIdx;
+                const isCrosshair = isHighlightedCol || isHighlightedRow;
 
-                  if (mult === null) {
-                    return (
-                      <span
-                        key={`${row.pokemon.id}-${t}`}
-                        className="text-muted-foreground/40 inline-flex items-center justify-center font-mono text-[10px] leading-none"
-                        onMouseEnter={() =>
-                          setHoverCell({ row: rowIdx, col: colIdx })
-                        }
-                        onMouseLeave={() => setHoverCell(null)}
-                      >
-                        —
-                      </span>
-                    );
-                  }
-
+                if (mult === null) {
                   return (
                     <span
                       key={`${row.pokemon.id}-${t}`}
-                      className={cn(
-                        "inline-flex items-center justify-center rounded px-0.5 py-0.5 font-mono text-[10px] leading-tight transition-all duration-100",
-                        cellClass(mult, mode),
-                        isCrosshair && "ring-1 ring-primary/30"
-                      )}
+                      className="text-muted-foreground/40 inline-flex items-center justify-center font-mono text-[10px] leading-none"
                       onMouseEnter={() =>
                         setHoverCell({ row: rowIdx, col: colIdx })
                       }
                       onMouseLeave={() => setHoverCell(null)}
                     >
-                      {formatMultiplier(mult)}
+                      —
                     </span>
                   );
-                })}
+                }
 
-                {/* Row summary — net score */}
-                {(() => {
-                  // Defensive: (resists + immunities) - weaknesses (positive = well-defended)
-                  // Offensive: super-effective - (resisted + immune) (positive = good coverage)
-                  const net =
-                    mode === "defensive"
-                      ? row.resistCount + row.immuneCount - row.weakCount
-                      : row.weakCount - row.resistCount - row.immuneCount;
-                  return (
-                    <span
-                      className={cn(
-                        "flex justify-center font-mono text-[10px] font-semibold",
-                        net > 0
-                          ? "text-emerald-600 dark:text-emerald-400"
-                          : net < 0
-                            ? "text-destructive"
-                            : "text-muted-foreground/60"
-                      )}
-                    >
-                      {net > 0 ? `+${net}` : net}
-                    </span>
-                  );
-                })()}
-              </div>
-            ))}
-
-            {/* Empty placeholder rows for remaining team slots */}
-            {Array.from({ length: Math.max(0, 6 - rows.length) }).map(
-              (_, idx) => (
-                <div
-                  key={`empty-${idx}`}
-                  className="grid items-center gap-px px-2 py-1"
-                  style={gridStyle}
-                >
-                  <span className="text-muted-foreground/30 text-[10px] italic">
-                    {rows.length === 0 && idx === 2
-                      ? "Add Pokémon…"
-                      : "\u00A0"}
+                return (
+                  <span
+                    key={`${row.pokemon.id}-${t}`}
+                    className={cn(
+                      "inline-flex items-center justify-center rounded px-0.5 py-0.5 font-mono text-[10px] leading-tight transition-all duration-100",
+                      cellClass(mult, mode),
+                      isCrosshair && "ring-primary/30 ring-1"
+                    )}
+                    onMouseEnter={() =>
+                      setHoverCell({ row: rowIdx, col: colIdx })
+                    }
+                    onMouseLeave={() => setHoverCell(null)}
+                  >
+                    {formatMultiplier(mult)}
                   </span>
-                  {ALL_TYPES.map((t) => (
-                    <span
-                      key={`empty-${idx}-${t}`}
-                      className="inline-flex items-center justify-center font-mono text-[10px] leading-none text-muted-foreground/15"
-                    >
-                      ·
-                    </span>
-                  ))}
-                  <span />
-                </div>
-              )
-            )}
-          </div>
+                );
+              })}
 
-          {/* Column totals footer */}
-          <div
-            className="bg-muted/50 grid items-center gap-px border-t px-2 py-1.5 sticky bottom-0"
-            style={gridStyle}
-          >
-            <span className="text-muted-foreground text-[9px] font-semibold uppercase tracking-wide">
-              TOTAL
-            </span>
-            {colTotals.map((col, idx) => {
-              const net =
+              {/* Row summary — net score */}
+              {(() => {
+                // Defensive: (resists + immunities) - weaknesses (positive = well-defended)
+                // Offensive: super-effective - (resisted + immune) (positive = good coverage)
+                const net =
+                  mode === "defensive"
+                    ? row.resistCount + row.immuneCount - row.weakCount
+                    : row.weakCount - row.resistCount - row.immuneCount;
+                return (
+                  <span
+                    className={cn(
+                      "flex justify-center font-mono text-[10px] font-semibold",
+                      net > 0
+                        ? "text-emerald-600 dark:text-emerald-400"
+                        : net < 0
+                          ? "text-destructive"
+                          : "text-muted-foreground/60"
+                    )}
+                  >
+                    {net > 0 ? `+${net}` : net}
+                  </span>
+                );
+              })()}
+            </div>
+          ))}
+
+          {/* Empty placeholder rows for remaining team slots */}
+          {Array.from({ length: Math.max(0, 6 - rows.length) }).map(
+            (_, idx) => (
+              <div
+                key={`empty-slot-${rows.length + idx}`}
+                className="grid items-center gap-px px-2 py-1"
+                style={gridStyle}
+              >
+                <span className="text-muted-foreground/30 text-[10px] italic">
+                  {rows.length === 0 && idx === 2 ? "Add Pokémon…" : "\u00A0"}
+                </span>
+                {ALL_TYPES.map((t) => (
+                  <span
+                    key={`empty-${rows.length + idx}-${t}`}
+                    className="text-muted-foreground/15 inline-flex items-center justify-center font-mono text-[10px] leading-none"
+                  >
+                    ·
+                  </span>
+                ))}
+                <span />
+              </div>
+            )
+          )}
+        </div>
+
+        {/* Column totals footer */}
+        <div
+          className="bg-muted/50 sticky bottom-0 grid items-center gap-px border-t px-2 py-1.5"
+          style={gridStyle}
+        >
+          <span className="text-muted-foreground text-[9px] font-semibold tracking-wide uppercase">
+            TOTAL
+          </span>
+          {colTotals.map((col, idx) => {
+            const net =
+              mode === "defensive"
+                ? col.rs + col.im - col.wk
+                : col.wk - col.rs - col.im;
+            return (
+              <span
+                key={ALL_TYPES[idx]}
+                className={cn(
+                  "flex justify-center font-mono text-[9px] font-semibold transition-opacity duration-100",
+                  hoverCell !== null && hoverCell.col !== idx && "opacity-40",
+                  net > 0
+                    ? "text-emerald-600 dark:text-emerald-400"
+                    : net < 0
+                      ? "text-destructive"
+                      : "text-muted-foreground/60"
+                )}
+              >
+                {net > 0 ? `+${net}` : net}
+              </span>
+            );
+          })}
+          {/* Grand total */}
+          {(() => {
+            const grandNet = colTotals.reduce((s, col) => {
+              const n =
                 mode === "defensive"
                   ? col.rs + col.im - col.wk
                   : col.wk - col.rs - col.im;
-              return (
-                <span
-                  key={ALL_TYPES[idx]}
-                  className={cn(
-                    "flex justify-center font-mono text-[9px] font-semibold transition-opacity duration-100",
-                    hoverCell !== null &&
-                      hoverCell.col !== idx &&
-                      "opacity-40",
-                    net > 0
-                      ? "text-emerald-600 dark:text-emerald-400"
-                      : net < 0
-                        ? "text-destructive"
-                        : "text-muted-foreground/60"
-                  )}
-                >
-                  {net > 0 ? `+${net}` : net}
-                </span>
-              );
-            })}
-            {/* Grand total */}
-            {(() => {
-              const grandNet = colTotals.reduce((s, col) => {
-                const n =
-                  mode === "defensive"
-                    ? col.rs + col.im - col.wk
-                    : col.wk - col.rs - col.im;
-                return s + n;
-              }, 0);
-              return (
-                <span
-                  className={cn(
-                    "flex justify-center font-mono text-[9px] font-semibold",
-                    grandNet > 0
-                      ? "text-emerald-600 dark:text-emerald-400"
-                      : grandNet < 0
-                        ? "text-destructive"
-                        : "text-muted-foreground/60"
-                  )}
-                >
-                  {grandNet > 0 ? `+${grandNet}` : grandNet}
-                </span>
-              );
-            })()}
-          </div>
-
+              return s + n;
+            }, 0);
+            return (
+              <span
+                className={cn(
+                  "flex justify-center font-mono text-[9px] font-semibold",
+                  grandNet > 0
+                    ? "text-emerald-600 dark:text-emerald-400"
+                    : grandNet < 0
+                      ? "text-destructive"
+                      : "text-muted-foreground/60"
+                )}
+              >
+                {grandNet > 0 ? `+${grandNet}` : grandNet}
+              </span>
+            );
+          })()}
         </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/team-builder/dock/heatmap-panel.tsx
+++ b/apps/web/src/components/team-builder/dock/heatmap-panel.tsx
@@ -523,6 +523,7 @@ export function HeatmapPanel({ team, format, onClose }: HeatmapPanelProps) {
                 key={`empty-slot-${rows.length + idx}`}
                 className="grid items-center gap-px px-2 py-1"
                 style={gridStyle}
+                aria-hidden="true"
               >
                 <span className="text-muted-foreground/30 text-[10px] italic">
                   {rows.length === 0 && idx === 2 ? "Add Pokémon…" : "\u00A0"}

--- a/apps/web/src/components/team-builder/dock/heatmap-panel.tsx
+++ b/apps/web/src/components/team-builder/dock/heatmap-panel.tsx
@@ -394,24 +394,17 @@ export function HeatmapPanel({ team, format, onClose }: HeatmapPanelProps) {
         )}
       </div>
 
-      {rows.length === 0 && (
-        <div className="text-muted-foreground px-3 py-6 text-center text-xs">
-          Add Pokémon to your team to see the type chart.
-        </div>
-      )}
-
-      {rows.length > 0 && (
-        <div className="min-h-0 flex-1 overflow-auto">
-          {/* Column headers: type abbreviations */}
-          <div
-            className="bg-muted/50 grid items-end gap-px px-2 py-1.5 sticky top-0 z-10"
-            style={gridStyle}
-          >
-            {/* Row label spacer */}
-            <span aria-hidden />
-            {ALL_TYPES.map((t, idx) => (
-              <Tooltip key={t}>
-                <TooltipTrigger
+      <div className="min-h-0 flex-1 overflow-auto">
+        {/* Column headers: type abbreviations */}
+        <div
+          className="bg-muted/50 grid items-end gap-px px-2 py-1.5 sticky top-0 z-10"
+          style={gridStyle}
+        >
+          {/* Row label spacer */}
+          <span aria-hidden />
+          {ALL_TYPES.map((t, idx) => (
+            <Tooltip key={t}>
+              <TooltipTrigger
                   render={
                     <span
                       tabIndex={0}
@@ -525,6 +518,32 @@ export function HeatmapPanel({ team, format, onClose }: HeatmapPanelProps) {
                 })()}
               </div>
             ))}
+
+            {/* Empty placeholder rows for remaining team slots */}
+            {Array.from({ length: Math.max(0, 6 - rows.length) }).map(
+              (_, idx) => (
+                <div
+                  key={`empty-${idx}`}
+                  className="grid items-center gap-px px-2 py-1"
+                  style={gridStyle}
+                >
+                  <span className="text-muted-foreground/30 text-[10px] italic">
+                    {rows.length === 0 && idx === 2
+                      ? "Add Pokémon…"
+                      : "\u00A0"}
+                  </span>
+                  {ALL_TYPES.map((t) => (
+                    <span
+                      key={`empty-${idx}-${t}`}
+                      className="inline-flex items-center justify-center font-mono text-[10px] leading-none text-muted-foreground/15"
+                    >
+                      ·
+                    </span>
+                  ))}
+                  <span />
+                </div>
+              )
+            )}
           </div>
 
           {/* Column totals footer */}
@@ -586,7 +605,6 @@ export function HeatmapPanel({ team, format, onClose }: HeatmapPanelProps) {
           </div>
 
         </div>
-      )}
     </div>
   );
 }

--- a/apps/web/src/components/team-builder/dock/heatmap-panel.tsx
+++ b/apps/web/src/components/team-builder/dock/heatmap-panel.tsx
@@ -50,6 +50,20 @@ interface PokemonRow {
 // Helpers
 // =============================================================================
 
+/**
+ * Compute the net coverage score for a row or column.
+ * Defensive: (resists + immunities) - weaknesses (positive = well-defended)
+ * Offensive: super-effective - (resisted + immune) (positive = good coverage)
+ */
+function netScore(
+  counts: { wk: number; rs: number; im: number },
+  mode: CoverageMode
+): number {
+  return mode === "defensive"
+    ? counts.rs + counts.im - counts.wk
+    : counts.wk - counts.rs - counts.im;
+}
+
 function getDefenderTypes(
   pokemon: Tables<"pokemon">,
   showTera: boolean
@@ -492,12 +506,10 @@ export function HeatmapPanel({ team, format, onClose }: HeatmapPanelProps) {
 
               {/* Row summary — net score */}
               {(() => {
-                // Defensive: (resists + immunities) - weaknesses (positive = well-defended)
-                // Offensive: super-effective - (resisted + immune) (positive = good coverage)
-                const net =
-                  mode === "defensive"
-                    ? row.resistCount + row.immuneCount - row.weakCount
-                    : row.weakCount - row.resistCount - row.immuneCount;
+                const net = netScore(
+                  { wk: row.weakCount, rs: row.resistCount, im: row.immuneCount },
+                  mode
+                );
                 return (
                   <span
                     className={cn(
@@ -517,6 +529,11 @@ export function HeatmapPanel({ team, format, onClose }: HeatmapPanelProps) {
           ))}
 
           {/* Empty placeholder rows for remaining team slots */}
+          {rows.length === 0 && (
+            <span className="sr-only" role="status">
+              Add Pokémon to your team to populate the heatmap.
+            </span>
+          )}
           {Array.from({ length: Math.max(0, 6 - rows.length) }).map(
             (_, idx) => (
               <div
@@ -551,10 +568,7 @@ export function HeatmapPanel({ team, format, onClose }: HeatmapPanelProps) {
             TOTAL
           </span>
           {colTotals.map((col, idx) => {
-            const net =
-              mode === "defensive"
-                ? col.rs + col.im - col.wk
-                : col.wk - col.rs - col.im;
+            const net = netScore(col, mode);
             return (
               <span
                 key={ALL_TYPES[idx]}
@@ -574,13 +588,10 @@ export function HeatmapPanel({ team, format, onClose }: HeatmapPanelProps) {
           })}
           {/* Grand total */}
           {(() => {
-            const grandNet = colTotals.reduce((s, col) => {
-              const n =
-                mode === "defensive"
-                  ? col.rs + col.im - col.wk
-                  : col.wk - col.rs - col.im;
-              return s + n;
-            }, 0);
+            const grandNet = colTotals.reduce(
+              (s, col) => s + netScore(col, mode),
+              0
+            );
             return (
               <span
                 className={cn(

--- a/apps/web/src/components/team-builder/dock/speed-tiers-panel.tsx
+++ b/apps/web/src/components/team-builder/dock/speed-tiers-panel.tsx
@@ -581,7 +581,8 @@ export function SpeedTiersPanel({
   }
 
   // Weather: derive from external (calc) state if provided, else use local toggle
-  const effectiveWeather: Weather = externalWeather
+  const isExternallyControlled = externalWeather !== undefined;
+  const effectiveWeather: Weather = isExternallyControlled
     ? parseExternalWeather(externalWeather)
     : toggle.weather;
 
@@ -638,7 +639,8 @@ export function SpeedTiersPanel({
   // ---- helpers ----------------------------------------------------------------
 
   function setWeather(w: Weather) {
-    if (externalSetWeather) {
+    if (isExternallyControlled) {
+      if (!externalSetWeather) return;
       // Toggle off if already active, otherwise sync to calc state
       const current = parseExternalWeather(externalWeather);
       externalSetWeather(current === w ? "" : panelWeatherToEngine(w));

--- a/apps/web/src/components/team-builder/dock/speed-tiers-panel.tsx
+++ b/apps/web/src/components/team-builder/dock/speed-tiers-panel.tsx
@@ -23,6 +23,7 @@ import { getPokemonSprite } from "@trainers/pokemon/sprites";
 import { type Tables, type TeamWithPokemon } from "@trainers/supabase";
 
 import { cn } from "@/lib/utils";
+import { Switch } from "@/components/ui/switch";
 import { ItemSprite } from "@/components/tournament/item-sprite";
 import {
   TableBody,
@@ -39,6 +40,10 @@ import {
 export interface SpeedTiersPanelProps {
   team: TeamWithPokemon["team_pokemon"];
   format: GameFormat | undefined;
+  /** Capitalized weather from calc state (e.g. "Sun", "Rain", "" for none). */
+  weather?: string;
+  /** Setter for the shared calc weather state. */
+  setWeather?: (v: string) => void;
 }
 
 type Weather = "none" | "sun" | "rain" | "sand" | "snow";
@@ -508,7 +513,12 @@ function TierMonRow({
  * YOURS/THEIRS switches let you simulate real game scenarios.
  * Trick Room toggle inverts the sort order.
  */
-export function SpeedTiersPanel({ team, format }: SpeedTiersPanelProps) {
+export function SpeedTiersPanel({
+  team,
+  format,
+  weather: externalWeather,
+  setWeather: externalSetWeather,
+}: SpeedTiersPanelProps) {
   const [toggle, setToggle] = useState<ToggleState>(DEFAULT_TOGGLE);
   const [prevFormatId, setPrevFormatId] = useState<
     string | undefined | typeof UNINITIALIZED_FORMAT_ID
@@ -549,13 +559,21 @@ export function SpeedTiersPanel({ team, format }: SpeedTiersPanelProps) {
     );
   }
 
+  // Weather: derive from external (calc) state if provided, else use local toggle
+  const effectiveWeather: Weather = externalWeather
+    ? (externalWeather.toLowerCase() as Weather) || "none"
+    : toggle.weather;
+
   // Filter to non-null pokemon on the team.
   const pokemons = team
     .filter((tp) => tp.pokemon != null)
     .map((tp) => tp.pokemon as Tables<"pokemon">);
 
+  // Use effectiveWeather (synced from calc) in the toggle for scoring
+  const effectiveToggle: ToggleState = { ...toggle, weather: effectiveWeather };
+
   const teamScored: ScoredMon[] = pokemons.map((p) =>
-    teamMonToScored(p, format, toggle, false)
+    teamMonToScored(p, format, effectiveToggle, false)
   );
 
   const legalSpecies = legalSetOrPermissive(getLegalSpecies(format.id));
@@ -564,7 +582,7 @@ export function SpeedTiersPanel({ team, format }: SpeedTiersPanelProps) {
     : getMetaSpeedTiers(format.id);
 
   const metaScored: ScoredMon[] = metaTiers.map((e) =>
-    metaToScored(e, toggle, format)
+    metaToScored(e, effectiveToggle, format)
   );
 
   const allScored = [...teamScored, ...metaScored];
@@ -589,10 +607,21 @@ export function SpeedTiersPanel({ team, format }: SpeedTiersPanelProps) {
   // ---- helpers ----------------------------------------------------------------
 
   function setWeather(w: Weather) {
-    setToggle((prev) => ({
-      ...prev,
-      weather: prev.weather === w ? "none" : w,
-    }));
+    if (externalSetWeather) {
+      // Sync to calc state: capitalize for @smogon/calc, "" for none
+      const capitalized =
+        w === "none" ? "" : w.charAt(0).toUpperCase() + w.slice(1);
+      // Toggle off if already active
+      const current = externalWeather
+        ? (externalWeather.toLowerCase() as Weather) || "none"
+        : "none";
+      externalSetWeather(current === w ? "" : capitalized);
+    } else {
+      setToggle((prev) => ({
+        ...prev,
+        weather: prev.weather === w ? "none" : w,
+      }));
+    }
   }
   function setTrickRoom(v: boolean) {
     setToggle((prev) => ({
@@ -629,40 +658,50 @@ export function SpeedTiersPanel({ team, format }: SpeedTiersPanelProps) {
           <legend className="text-primary px-1 font-mono text-[9px] font-bold tracking-[0.12em] uppercase">
             Field
           </legend>
-          <div className="flex flex-col items-center gap-1.5">
+          <div className="flex flex-col gap-2">
             <div className="flex items-center gap-2">
-              <span className="text-muted-foreground text-[11px]">
-                Trick Room
+              <span className="text-muted-foreground/70 shrink-0 font-mono text-[8.5px] tracking-wide uppercase">
+                Weather
               </span>
-              <button
-                type="button"
-                aria-label="Trick Room"
-                onClick={() => setTrickRoom(!toggle.trickRoom)}
-                className={cn(
-                  "size-4 rounded-full border-2 transition-colors",
-                  toggle.trickRoom
-                    ? "border-primary bg-primary"
-                    : "border-muted-foreground/40 hover:border-muted-foreground"
-                )}
-              />
+              <div className="flex flex-1 flex-wrap justify-end gap-1">
+                {(["sun", "rain", "sand", "snow"] as const).map((w) => (
+                  <button
+                    key={w}
+                    type="button"
+                    aria-label={WEATHER_LABELS[w]}
+                    onClick={() => setWeather(w)}
+                    className={cn(
+                      "rounded-full border px-2 py-0.5 font-mono text-[10px] leading-tight transition-all",
+                      effectiveWeather === w
+                        ? "border-primary/50 bg-primary/10 text-primary font-semibold shadow-[0_0_0_1px_hsl(var(--primary)/0.15)]"
+                        : "border-border bg-card text-muted-foreground hover:border-primary/30 hover:text-foreground"
+                    )}
+                  >
+                    {WEATHER_LABELS[w]}
+                  </button>
+                ))}
+              </div>
             </div>
-            <div className="flex items-center gap-1">
-              {(["sun", "rain", "sand", "snow"] as const).map((w) => (
+            <div className="border-border/40 flex items-center gap-2 border-t border-dashed pt-1.5">
+              <span className="text-muted-foreground/70 shrink-0 font-mono text-[8.5px] tracking-wide uppercase">
+                Other
+              </span>
+              <div className="flex flex-1 flex-wrap justify-end gap-1">
                 <button
-                  key={w}
                   type="button"
-                  aria-label={WEATHER_LABELS[w]}
-                  onClick={() => setWeather(w)}
+                  aria-label="Trick Room"
+                  aria-pressed={toggle.trickRoom}
+                  onClick={() => setTrickRoom(!toggle.trickRoom)}
                   className={cn(
-                    "rounded-md px-2 py-0.5 text-[10px] font-medium capitalize transition-colors",
-                    toggle.weather === w
-                      ? "bg-primary/15 text-primary"
-                      : "text-muted-foreground hover:text-foreground"
+                    "rounded-full border px-2 py-0.5 font-mono text-[10px] leading-tight transition-all",
+                    toggle.trickRoom
+                      ? "border-primary/50 bg-primary/10 text-primary font-semibold shadow-[0_0_0_1px_hsl(var(--primary)/0.15)]"
+                      : "border-border bg-card text-muted-foreground hover:border-primary/30 hover:text-foreground"
                   )}
                 >
-                  {WEATHER_LABELS[w]}
+                  Trick Room
                 </button>
-              ))}
+              </div>
             </div>
           </div>
         </fieldset>
@@ -730,7 +769,7 @@ export function SpeedTiersPanel({ team, format }: SpeedTiersPanelProps) {
                   trickRoom={toggle.trickRoom}
                   abilityActive={isSpeedAbilityActive(
                     scored.mon.speedAbility,
-                    toggle.weather,
+                    effectiveWeather,
                     scored.mon.isYours
                       ? toggle.yours.unburden
                       : toggle.theirs.unburden
@@ -750,145 +789,109 @@ export function SpeedTiersPanel({ team, format }: SpeedTiersPanelProps) {
           <legend className="text-primary px-1 font-mono text-[9px] font-bold tracking-[0.12em] uppercase">
             Modifiers
           </legend>
-          <div className="grid grid-cols-[auto_auto_auto] items-center gap-x-3 gap-y-1.5">
+          <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-x-1 gap-y-0.5">
             {/* Header */}
-            <span className="text-muted-foreground text-right text-[10px] font-semibold uppercase">
+            <span className="text-muted-foreground text-right text-[10px] font-semibold tracking-wider uppercase">
               Ours
             </span>
             <span />
-            <span className="text-muted-foreground text-[10px] font-semibold uppercase">
+            <span className="text-muted-foreground text-[10px] font-semibold tracking-wider uppercase">
               Theirs
             </span>
 
             {/* Tailwind */}
             <div className="flex justify-end">
-              <button
-                type="button"
-                aria-label="Our Tailwind"
-                onClick={() =>
+              <Switch
+                size="sm"
+                checked={toggle.yours.tailwind}
+                onCheckedChange={() =>
                   setToggle((prev) => ({
                     ...prev,
                     yours: { ...prev.yours, tailwind: !prev.yours.tailwind },
                   }))
                 }
-                className={cn(
-                  "size-4 rounded-full border-2 transition-colors",
-                  toggle.yours.tailwind
-                    ? "border-primary bg-primary"
-                    : "border-muted-foreground/40 hover:border-muted-foreground"
-                )}
+                aria-label="Our Tailwind"
               />
             </div>
-            <span className="text-foreground text-center text-[11px]">
-              Tailwind
-            </span>
+            <span className="text-center text-[11px]">Tailwind</span>
             <div className="flex justify-start">
-              <button
-                type="button"
-                aria-label="Their Tailwind"
-                onClick={() =>
+              <Switch
+                size="sm"
+                checked={toggle.theirs.tailwind}
+                onCheckedChange={() =>
                   setToggle((prev) => ({
                     ...prev,
                     theirs: { ...prev.theirs, tailwind: !prev.theirs.tailwind },
                   }))
                 }
-                className={cn(
-                  "size-4 rounded-full border-2 transition-colors",
-                  toggle.theirs.tailwind
-                    ? "border-primary bg-primary"
-                    : "border-muted-foreground/40 hover:border-muted-foreground"
-                )}
+                aria-label="Their Tailwind"
               />
             </div>
 
             {/* Scarf */}
             <div className="flex justify-end">
-              <button
-                type="button"
-                aria-label="Our Scarf"
-                onClick={() =>
+              <Switch
+                size="sm"
+                checked={toggle.yours.scarf}
+                onCheckedChange={() =>
                   setToggle((prev) => ({
                     ...prev,
                     yours: { ...prev.yours, scarf: !prev.yours.scarf },
                   }))
                 }
-                className={cn(
-                  "size-4 rounded-full border-2 transition-colors",
-                  toggle.yours.scarf
-                    ? "border-primary bg-primary"
-                    : "border-muted-foreground/40 hover:border-muted-foreground"
-                )}
+                aria-label="Our Scarf"
               />
             </div>
-            <span className="text-foreground text-center text-[11px]">
-              Scarf
-            </span>
+            <span className="text-center text-[11px]">Scarf</span>
             <div className="flex justify-start">
-              <button
-                type="button"
-                aria-label="Their Scarf"
-                onClick={() =>
+              <Switch
+                size="sm"
+                checked={toggle.theirs.scarf}
+                onCheckedChange={() =>
                   setToggle((prev) => ({
                     ...prev,
                     theirs: { ...prev.theirs, scarf: !prev.theirs.scarf },
                   }))
                 }
-                className={cn(
-                  "size-4 rounded-full border-2 transition-colors",
-                  toggle.theirs.scarf
-                    ? "border-primary bg-primary"
-                    : "border-muted-foreground/40 hover:border-muted-foreground"
-                )}
+                aria-label="Their Scarf"
               />
             </div>
 
             {/* Unburden */}
             <div className="flex justify-end">
-              <button
-                type="button"
-                aria-label="Our Unburden"
-                onClick={() =>
+              <Switch
+                size="sm"
+                checked={toggle.yours.unburden}
+                onCheckedChange={() =>
                   setToggle((prev) => ({
                     ...prev,
                     yours: { ...prev.yours, unburden: !prev.yours.unburden },
                   }))
                 }
-                className={cn(
-                  "size-4 rounded-full border-2 transition-colors",
-                  toggle.yours.unburden
-                    ? "border-primary bg-primary"
-                    : "border-muted-foreground/40 hover:border-muted-foreground"
-                )}
+                aria-label="Our Unburden"
               />
             </div>
-            <span className="text-foreground text-center text-[11px]">
-              Unburden
-            </span>
+            <span className="text-center text-[11px]">Unburden</span>
             <div className="flex justify-start">
-              <button
-                type="button"
-                aria-label="Their Unburden"
-                onClick={() =>
+              <Switch
+                size="sm"
+                checked={toggle.theirs.unburden}
+                onCheckedChange={() =>
                   setToggle((prev) => ({
                     ...prev,
                     theirs: { ...prev.theirs, unburden: !prev.theirs.unburden },
                   }))
                 }
-                className={cn(
-                  "size-4 rounded-full border-2 transition-colors",
-                  toggle.theirs.unburden
-                    ? "border-primary bg-primary"
-                    : "border-muted-foreground/40 hover:border-muted-foreground"
-                )}
+                aria-label="Their Unburden"
               />
             </div>
 
             {/* Paralyzed */}
             <div className="flex justify-end">
-              <button
-                type="button"
-                aria-label="Our Paralyzed"
-                onClick={() =>
+              <Switch
+                size="sm"
+                checked={toggle.yours.status === "paralyzed"}
+                onCheckedChange={() =>
                   setToggle((prev) => ({
                     ...prev,
                     yours: {
@@ -900,22 +903,15 @@ export function SpeedTiersPanel({ team, format }: SpeedTiersPanelProps) {
                     },
                   }))
                 }
-                className={cn(
-                  "size-4 rounded-full border-2 transition-colors",
-                  toggle.yours.status === "paralyzed"
-                    ? "border-primary bg-primary"
-                    : "border-muted-foreground/40 hover:border-muted-foreground"
-                )}
+                aria-label="Our Paralyzed"
               />
             </div>
-            <span className="text-foreground text-center text-[11px]">
-              Paralyzed
-            </span>
+            <span className="text-center text-[11px]">Paralyzed</span>
             <div className="flex justify-start">
-              <button
-                type="button"
-                aria-label="Their Paralyzed"
-                onClick={() =>
+              <Switch
+                size="sm"
+                checked={toggle.theirs.status === "paralyzed"}
+                onCheckedChange={() =>
                   setToggle((prev) => ({
                     ...prev,
                     theirs: {
@@ -927,20 +923,13 @@ export function SpeedTiersPanel({ team, format }: SpeedTiersPanelProps) {
                     },
                   }))
                 }
-                className={cn(
-                  "size-4 rounded-full border-2 transition-colors",
-                  toggle.theirs.status === "paralyzed"
-                    ? "border-primary bg-primary"
-                    : "border-muted-foreground/40 hover:border-muted-foreground"
-                )}
+                aria-label="Their Paralyzed"
               />
             </div>
 
             {/* Nature — theirs only */}
             <div />
-            <span className="text-foreground text-center text-[11px]">
-              Nature
-            </span>
+            <span className="text-center text-[11px]">Nature</span>
             <div className="flex justify-start gap-0.5">
               {(["negative", "neutral", "positive"] as const).map((n) => (
                 <button
@@ -967,9 +956,7 @@ export function SpeedTiersPanel({ team, format }: SpeedTiersPanelProps) {
 
             {/* EVs — theirs only */}
             <div />
-            <span className="text-foreground text-center text-[11px]">
-              {evLabel}
-            </span>
+            <span className="text-center text-[11px]">{evLabel}</span>
             <div className="flex items-center justify-start gap-0.5">
               <button
                 type="button"
@@ -1077,9 +1064,7 @@ export function SpeedTiersPanel({ team, format }: SpeedTiersPanelProps) {
                 +
               </button>
             </div>
-            <span className="text-foreground text-center text-[11px]">
-              Stages
-            </span>
+            <span className="text-center text-[11px]">Stages</span>
             <div className="flex items-center justify-start gap-0.5">
               <button
                 type="button"

--- a/apps/web/src/components/team-builder/dock/speed-tiers-panel.tsx
+++ b/apps/web/src/components/team-builder/dock/speed-tiers-panel.tsx
@@ -31,8 +31,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Switch } from "@/components/ui/switch";
-import { Toggle } from "@/components/ui/toggle";
 
 // =============================================================================
 // Types
@@ -350,7 +348,7 @@ function metaToScored(
 // =============================================================================
 
 const STAT_CELL =
-  "text-right font-mono text-xs tabular-nums px-2 py-1.5 w-[3.5rem]";
+  "text-right font-mono text-xs tabular-nums px-2 py-1.5 whitespace-nowrap";
 
 /** Determine if a speed ability is currently active based on field/toggle state */
 function isSpeedAbilityActive(
@@ -385,6 +383,7 @@ interface TierMonRowProps {
   trickRoom: boolean;
   abilityActive: boolean;
   showGroupSeparator?: boolean;
+  groupBaseSpeed?: number;
 }
 
 function TierMonRow({
@@ -393,6 +392,7 @@ function TierMonRow({
   trickRoom,
   abilityActive,
   showGroupSeparator,
+  groupBaseSpeed,
 }: TierMonRowProps) {
   const { mon, speed } = scored;
   const isTie = !mon.isSelected && speed === heroSpeed && heroSpeed > 0;
@@ -402,74 +402,98 @@ function TierMonRow({
     (trickRoom ? speed > heroSpeed : speed < heroSpeed);
 
   return (
-    <TableRow
-      className={cn(
-        "border-border/30 border-b",
-        showGroupSeparator && "border-t-primary/40 border-t-2",
-        mon.isSelected && "bg-primary/10",
-        mon.isYours && !mon.isSelected && "bg-primary/5",
-        isFaster && "opacity-40"
-      )}
-    >
-      {/* Pokemon name + sprite */}
-      <TableCell className="px-1.5 py-1">
-        <div className="flex min-w-0 items-center gap-1.5">
-          {mon.spriteUrl ? (
-            <Image
-              src={mon.spriteUrl}
-              alt=""
-              width={44}
-              height={44}
-              unoptimized
-              className="size-11 shrink-0 object-contain"
-            />
-          ) : (
-            <span className="bg-muted inline-block size-11 shrink-0 rounded-full" />
-          )}
-          <span
-            className={cn(
-              "truncate text-xs leading-tight",
-              mon.isYours ? "text-primary font-semibold" : "text-foreground"
-            )}
+    <>
+      {showGroupSeparator && (
+        <TableRow className="border-0">
+          <TableCell
+            colSpan={2}
+            className="text-muted-foreground h-auto px-2 py-0.5 text-[10px] font-medium tabular-nums"
           >
-            {mon.name}
-          </span>
-          {mon.speedAbility && (
-            <span
-              className={cn(
-                "shrink-0 rounded-full px-1.5 py-0.5 text-[8px] leading-none font-medium capitalize",
-                abilityActive
-                  ? "bg-violet-500/15 text-violet-600 dark:text-violet-400"
-                  : "bg-muted text-muted-foreground/50"
-              )}
-            >
-              {mon.speedAbility.replace(/-/g, " ")}
-            </span>
-          )}
-          {mon.isYours && mon.heldItem && (
-            <ItemSprite item={mon.heldItem} size={14} className="shrink-0" />
-          )}
-          {isTie && (
-            <span className="shrink-0 rounded-full bg-amber-500/10 px-1.5 py-0.5 text-[8px] leading-none font-medium text-amber-600 dark:text-amber-400">
-              Tie
-            </span>
-          )}
-        </div>
-      </TableCell>
-      {/* Base speed */}
-      <TableCell className="text-muted-foreground px-2 py-1.5 text-right font-mono text-xs tabular-nums">
-        {mon.baseSpeed}
-      </TableCell>
-      {/* SPE column */}
-      <TableCell
+            <div className="border-primary/40 flex items-center justify-center gap-1.5 border-t-2 pt-0.5">
+              <span className="text-primary/70 font-mono text-[10px]">
+                {groupBaseSpeed}
+              </span>
+              <span className="text-muted-foreground/70 text-[9px] tracking-wider uppercase">
+                Base Speed
+              </span>
+            </div>
+          </TableCell>
+        </TableRow>
+      )}
+      <TableRow
         className={cn(
-          STAT_CELL,
-          mon.isYours ? "text-primary font-bold" : "text-foreground font-bold"
+          "border-border/30 [&:hover>td]:bg-muted/50 border-b hover:bg-transparent [&:hover>td:first-child]:rounded-l-lg [&:hover>td:last-child]:rounded-r-lg",
+          mon.isSelected && "bg-primary/10",
+          mon.isYours && !mon.isSelected && "bg-primary/5",
+          isFaster && "opacity-40"
         )}
       >
-        {speed}
-      </TableCell>
-    </TableRow>
+        {/* Pokemon name + sprite */}
+        <TableCell className="px-1.5 py-1">
+          <div className="flex min-w-0 items-center gap-2.5">
+            {mon.spriteUrl ? (
+              <Image
+                src={mon.spriteUrl}
+                alt=""
+                width={36}
+                height={36}
+                unoptimized
+                className="size-9 shrink-0 object-contain"
+              />
+            ) : (
+              <span className="bg-muted inline-block size-9 shrink-0 rounded-full" />
+            )}
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <div className="flex items-center gap-1">
+                <span
+                  className={cn(
+                    "truncate text-xs leading-tight",
+                    mon.isYours
+                      ? "text-primary font-semibold"
+                      : "text-foreground"
+                  )}
+                >
+                  {mon.name}
+                </span>
+                {mon.isYours && mon.heldItem && (
+                  <ItemSprite
+                    item={mon.heldItem}
+                    size={14}
+                    className="shrink-0"
+                  />
+                )}
+                {isTie && (
+                  <span className="shrink-0 rounded-full bg-amber-500/10 px-1.5 py-0.5 text-[8px] leading-none font-medium text-amber-600 dark:text-amber-400">
+                    Tie
+                  </span>
+                )}
+              </div>
+              {mon.speedAbility && (
+                <span
+                  className={cn(
+                    "w-fit truncate rounded-full px-1.5 py-0.5 text-[8px] leading-none font-medium capitalize",
+                    abilityActive
+                      ? "bg-violet-500/15 text-violet-600 dark:text-violet-400"
+                      : "bg-muted text-muted-foreground/50"
+                  )}
+                >
+                  {mon.speedAbility.replace(/-/g, " ")}
+                </span>
+              )}
+            </div>
+          </div>
+        </TableCell>
+        {/* SPE column */}
+        <TableCell
+          className={cn(
+            STAT_CELL,
+            mon.isYours ? "text-primary font-bold" : "text-foreground font-bold"
+          )}
+        >
+          {speed}
+        </TableCell>
+      </TableRow>
+    </>
   );
 }
 
@@ -599,422 +623,62 @@ export function SpeedTiersPanel({ team, format }: SpeedTiersPanelProps) {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      {/* Toolbar — two sections side by side: Field (left) | Modifiers (right) */}
-      <div className="bg-muted/30 flex gap-3 border-b px-3 py-2">
-        {/* Left column: Trick Room + Weather */}
-        <div className="flex w-36 flex-col gap-1.5">
-          <span className="text-primary font-mono text-[10px] font-bold tracking-[0.12em] uppercase">
+      {/* FIELD section — above table */}
+      <div className="border-b px-3 py-3">
+        <fieldset className="border-border/60 rounded-lg border px-3 py-2">
+          <legend className="text-primary px-1 font-mono text-[9px] font-bold tracking-[0.12em] uppercase">
             Field
-          </span>
-          <div className="flex items-center gap-1.5">
-            <span className="text-muted-foreground/70 text-[11px]">
-              Trick Room
-            </span>
-            <Switch
-              size="sm"
-              checked={toggle.trickRoom}
-              onCheckedChange={setTrickRoom}
-              aria-label="Trick Room"
-            />
-          </div>
-          <span className="text-muted-foreground/70 text-[11px]">Weather</span>
-          <div className="flex flex-col gap-1">
-            {(["sun", "rain", "sand", "snow"] as const).map((w) => (
-              <Toggle
-                key={w}
-                variant="outline"
-                pressed={toggle.weather === w}
-                onPressedChange={() => setWeather(w)}
-                aria-label={WEATHER_LABELS[w]}
+          </legend>
+          <div className="flex flex-col items-center gap-1.5">
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground text-[11px]">
+                Trick Room
+              </span>
+              <button
+                type="button"
+                aria-label="Trick Room"
+                onClick={() => setTrickRoom(!toggle.trickRoom)}
                 className={cn(
-                  "w-full",
-                  toggle.weather === w &&
-                    "bg-primary/15 text-primary border-primary/40"
+                  "size-4 rounded-full border-2 transition-colors",
+                  toggle.trickRoom
+                    ? "border-primary bg-primary"
+                    : "border-muted-foreground/40 hover:border-muted-foreground"
                 )}
-              >
-                {WEATHER_LABELS[w]}
-              </Toggle>
-            ))}
-          </div>
-        </div>
-
-        {/* Divider */}
-        <div className="bg-border w-px self-stretch" />
-
-        {/* Right section: Ours | Label | Theirs mirrored grid */}
-        <div className="flex flex-1 flex-col items-center gap-1.5">
-          <span className="text-primary font-mono text-[10px] font-bold tracking-[0.12em] uppercase">
-            Modifiers
-          </span>
-          <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-x-1 gap-y-0.5">
-            {/* Header */}
-            <span className="text-muted-foreground text-right text-[10px] font-semibold tracking-wider uppercase">
-              Ours
-            </span>
-            <span />
-            <span className="text-muted-foreground text-[10px] font-semibold tracking-wider uppercase">
-              Theirs
-            </span>
-
-            {/* Tailwind */}
-            <div className="flex justify-end">
-              <Switch
-                size="sm"
-                checked={toggle.yours.tailwind}
-                onCheckedChange={(v) =>
-                  setToggle((prev) => ({
-                    ...prev,
-                    yours: { ...prev.yours, tailwind: v },
-                  }))
-                }
               />
             </div>
-            <span className="text-center text-[11px]">Tailwind</span>
-            <div className="flex justify-start">
-              <Switch
-                size="sm"
-                checked={toggle.theirs.tailwind}
-                onCheckedChange={(v) =>
-                  setToggle((prev) => ({
-                    ...prev,
-                    theirs: { ...prev.theirs, tailwind: v },
-                  }))
-                }
-              />
-            </div>
-
-            {/* Scarf */}
-            <div className="flex justify-end">
-              <Switch
-                size="sm"
-                checked={toggle.yours.scarf}
-                onCheckedChange={(v) =>
-                  setToggle((prev) => ({
-                    ...prev,
-                    yours: { ...prev.yours, scarf: v },
-                  }))
-                }
-              />
-            </div>
-            <span className="text-center text-[11px]">Scarf</span>
-            <div className="flex justify-start">
-              <Switch
-                size="sm"
-                checked={toggle.theirs.scarf}
-                onCheckedChange={(v) =>
-                  setToggle((prev) => ({
-                    ...prev,
-                    theirs: { ...prev.theirs, scarf: v },
-                  }))
-                }
-              />
-            </div>
-
-            {/* Unburden */}
-            <div className="flex justify-end">
-              <Switch
-                size="sm"
-                checked={toggle.yours.unburden}
-                onCheckedChange={(v) =>
-                  setToggle((prev) => ({
-                    ...prev,
-                    yours: { ...prev.yours, unburden: v },
-                  }))
-                }
-              />
-            </div>
-            <span className="text-center text-[11px]">Unburden</span>
-            <div className="flex justify-start">
-              <Switch
-                size="sm"
-                checked={toggle.theirs.unburden}
-                onCheckedChange={(v) =>
-                  setToggle((prev) => ({
-                    ...prev,
-                    theirs: { ...prev.theirs, unburden: v },
-                  }))
-                }
-                aria-label="Unburden"
-              />
-            </div>
-
-            {/* Paralyzed */}
-            <div className="flex justify-end">
-              <Switch
-                size="sm"
-                checked={toggle.yours.status === "paralyzed"}
-                onCheckedChange={(v) =>
-                  setToggle((prev) => ({
-                    ...prev,
-                    yours: {
-                      ...prev.yours,
-                      status: v ? "paralyzed" : "healthy",
-                    },
-                  }))
-                }
-              />
-            </div>
-            <span className="text-center text-[11px]">Paralyzed</span>
-            <div className="flex justify-start">
-              <Switch
-                size="sm"
-                checked={toggle.theirs.status === "paralyzed"}
-                onCheckedChange={(v) =>
-                  setToggle((prev) => ({
-                    ...prev,
-                    theirs: {
-                      ...prev.theirs,
-                      status: v ? "paralyzed" : "healthy",
-                    },
-                  }))
-                }
-              />
-            </div>
-
-            {/* Nature toggle — only theirs side */}
-            <div />
-            <span className="text-center text-[11px]">Nature</span>
-            <div className="flex justify-start">
-              <div className="bg-card grid grid-cols-3 overflow-hidden rounded-md border">
+            <div className="flex items-center gap-1">
+              {(["sun", "rain", "sand", "snow"] as const).map((w) => (
                 <button
+                  key={w}
                   type="button"
-                  aria-label="Negative speed nature"
-                  onClick={() =>
-                    setToggle((prev) => ({
-                      ...prev,
-                      theirs: { ...prev.theirs, nature: "negative" },
-                    }))
-                  }
+                  aria-label={WEATHER_LABELS[w]}
+                  onClick={() => setWeather(w)}
                   className={cn(
-                    "flex items-center justify-center px-1.5 py-0.5 text-[10px] font-semibold",
-                    toggle.theirs.nature === "negative"
-                      ? "bg-blue-500/15 text-blue-600 dark:text-blue-400"
-                      : "hover:bg-muted text-muted-foreground"
+                    "rounded-md px-2 py-0.5 text-[10px] font-medium capitalize transition-colors",
+                    toggle.weather === w
+                      ? "bg-primary/15 text-primary"
+                      : "text-muted-foreground hover:text-foreground"
                   )}
                 >
-                  −
+                  {WEATHER_LABELS[w]}
                 </button>
-                <button
-                  type="button"
-                  aria-label="Neutral speed nature"
-                  onClick={() =>
-                    setToggle((prev) => ({
-                      ...prev,
-                      theirs: { ...prev.theirs, nature: "neutral" },
-                    }))
-                  }
-                  className={cn(
-                    "flex items-center justify-center border-x px-2 py-0.5 text-[10px] font-semibold",
-                    toggle.theirs.nature === "neutral"
-                      ? "bg-amber-500/15 text-amber-600 dark:text-amber-400"
-                      : "hover:bg-muted text-muted-foreground"
-                  )}
-                >
-                  ●
-                </button>
-                <button
-                  type="button"
-                  aria-label="Positive speed nature"
-                  onClick={() =>
-                    setToggle((prev) => ({
-                      ...prev,
-                      theirs: { ...prev.theirs, nature: "positive" },
-                    }))
-                  }
-                  className={cn(
-                    "flex items-center justify-center px-1.5 py-0.5 text-[10px] font-semibold",
-                    toggle.theirs.nature === "positive"
-                      ? "bg-red-500/15 text-red-600 dark:text-red-400"
-                      : "hover:bg-muted text-muted-foreground"
-                  )}
-                >
-                  +
-                </button>
-              </div>
-            </div>
-
-            {/* EVs — only theirs side has input, ours is empty */}
-            <div />
-            <span className="text-center text-[11px]">{evLabel}</span>
-            <div className="flex justify-start">
-              <div className="bg-card grid grid-cols-[20px_40px_20px] overflow-hidden rounded-md border">
-                <button
-                  type="button"
-                  aria-label={`Decrease speed ${evLabel}`}
-                  disabled={
-                    toggle.theirs.evs === null || toggle.theirs.evs <= 0
-                  }
-                  onClick={() =>
-                    setToggle((prev) => ({
-                      ...prev,
-                      theirs: {
-                        ...prev.theirs,
-                        evs: Math.max(0, (prev.theirs.evs ?? maxEv) - evStep),
-                      },
-                    }))
-                  }
-                  className="hover:bg-muted text-foreground flex items-center justify-center text-xs disabled:cursor-not-allowed disabled:opacity-40"
-                >
-                  −
-                </button>
-                <input
-                  type="text"
-                  inputMode="numeric"
-                  aria-label={`Speed ${evLabel} override`}
-                  value={toggle.theirs.evs ?? ""}
-                  placeholder={String(maxEv)}
-                  onChange={(e) => {
-                    const raw = e.target.value.replace(/[^0-9]/g, "");
-                    if (raw === "") {
-                      setToggle((prev) => ({
-                        ...prev,
-                        theirs: { ...prev.theirs, evs: null },
-                      }));
-                      return;
-                    }
-                    const val = Math.min(maxEv, Math.max(0, Number(raw)));
-                    setToggle((prev) => ({
-                      ...prev,
-                      theirs: { ...prev.theirs, evs: val },
-                    }));
-                  }}
-                  className="text-foreground w-full [appearance:textfield] bg-transparent text-center font-mono text-[10px] font-semibold outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                />
-                <button
-                  type="button"
-                  aria-label={`Increase speed ${evLabel}`}
-                  disabled={
-                    toggle.theirs.evs !== null && toggle.theirs.evs >= maxEv
-                  }
-                  onClick={() =>
-                    setToggle((prev) => ({
-                      ...prev,
-                      theirs: {
-                        ...prev.theirs,
-                        evs: Math.min(
-                          maxEv,
-                          (prev.theirs.evs ?? maxEv) + evStep
-                        ),
-                      },
-                    }))
-                  }
-                  className="hover:bg-muted text-foreground flex items-center justify-center text-xs disabled:cursor-not-allowed disabled:opacity-40"
-                >
-                  +
-                </button>
-              </div>
-            </div>
-
-            {/* Stages */}
-            <div className="flex justify-end">
-              <div className="bg-card grid grid-cols-[20px_28px_20px] overflow-hidden rounded-md border">
-                <button
-                  type="button"
-                  disabled={toggle.yours.stage <= STAGE_MIN}
-                  onClick={() =>
-                    setToggle((prev) => ({
-                      ...prev,
-                      yours: { ...prev.yours, stage: prev.yours.stage - 1 },
-                    }))
-                  }
-                  className="hover:bg-muted text-foreground flex items-center justify-center text-xs disabled:cursor-not-allowed disabled:opacity-40"
-                >
-                  −
-                </button>
-                <div className="text-foreground flex items-center justify-center font-mono text-[10px] font-semibold">
-                  {toggle.yours.stage === 0
-                    ? "0"
-                    : toggle.yours.stage > 0
-                      ? `+${toggle.yours.stage}`
-                      : toggle.yours.stage}
-                </div>
-                <button
-                  type="button"
-                  disabled={toggle.yours.stage >= STAGE_MAX}
-                  onClick={() =>
-                    setToggle((prev) => ({
-                      ...prev,
-                      yours: { ...prev.yours, stage: prev.yours.stage + 1 },
-                    }))
-                  }
-                  className="hover:bg-muted text-foreground flex items-center justify-center text-xs disabled:cursor-not-allowed disabled:opacity-40"
-                >
-                  +
-                </button>
-              </div>
-            </div>
-            <span className="text-center text-[11px]">Stages</span>
-            <div className="flex justify-start">
-              <div className="bg-card grid grid-cols-[20px_28px_20px] overflow-hidden rounded-md border">
-                <button
-                  type="button"
-                  disabled={toggle.theirs.stage <= STAGE_MIN}
-                  onClick={() =>
-                    setToggle((prev) => ({
-                      ...prev,
-                      theirs: { ...prev.theirs, stage: prev.theirs.stage - 1 },
-                    }))
-                  }
-                  className="hover:bg-muted text-foreground flex items-center justify-center text-xs disabled:cursor-not-allowed disabled:opacity-40"
-                >
-                  −
-                </button>
-                <div className="text-foreground flex items-center justify-center font-mono text-[10px] font-semibold">
-                  {toggle.theirs.stage === 0
-                    ? "0"
-                    : toggle.theirs.stage > 0
-                      ? `+${toggle.theirs.stage}`
-                      : toggle.theirs.stage}
-                </div>
-                <button
-                  type="button"
-                  disabled={toggle.theirs.stage >= STAGE_MAX}
-                  onClick={() =>
-                    setToggle((prev) => ({
-                      ...prev,
-                      theirs: { ...prev.theirs, stage: prev.theirs.stage + 1 },
-                    }))
-                  }
-                  className="hover:bg-muted text-foreground flex items-center justify-center text-xs disabled:cursor-not-allowed disabled:opacity-40"
-                >
-                  +
-                </button>
-              </div>
+              ))}
             </div>
           </div>
-        </div>
+        </fieldset>
       </div>
 
       {/* Tier table */}
-      <div className="min-h-0 flex-1 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-        <table className="w-full caption-bottom text-sm">
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <table className="w-full table-fixed caption-bottom text-sm">
+          <colgroup>
+            <col className="w-full" />
+            <col className="w-14" />
+          </colgroup>
           <TableHeader className="bg-card/95 sticky top-0 z-10 backdrop-blur-sm">
             <TableRow className="border-b">
-              <TableHead className="text-muted-foreground h-auto px-1.5 py-1.5 text-[10px] leading-tight font-medium tracking-wide">
+              <TableHead className="text-muted-foreground h-auto px-3 py-1.5 text-[10px] leading-tight font-medium tracking-wide">
                 Pokémon
-              </TableHead>
-              <TableHead
-                aria-sort={
-                  toggle.sortBy === "base"
-                    ? toggle.sortDir === "desc"
-                      ? "descending"
-                      : "ascending"
-                    : "none"
-                }
-                className="h-auto px-0 py-0"
-              >
-                <button
-                  type="button"
-                  onClick={() => setSortBy("base")}
-                  className={cn(
-                    "text-muted-foreground h-auto w-full px-2 py-1.5 text-right text-[10px] leading-tight font-medium tracking-wide",
-                    toggle.sortBy === "base" && "text-primary"
-                  )}
-                >
-                  Base{" "}
-                  {toggle.sortBy === "base" &&
-                    (toggle.sortDir === "desc" ? "↓" : "↑")}
-                </button>
               </TableHead>
               <TableHead
                 aria-sort={
@@ -1030,8 +694,10 @@ export function SpeedTiersPanel({ team, format }: SpeedTiersPanelProps) {
                   type="button"
                   onClick={() => setSortBy("speed")}
                   className={cn(
-                    "h-auto w-full px-2 py-1.5 text-right text-[10px] leading-tight font-semibold tracking-wide",
-                    toggle.sortBy === "speed" ? "text-primary" : "text-foreground"
+                    "h-auto w-full px-3 py-1.5 text-right text-[10px] leading-tight font-semibold tracking-wide",
+                    toggle.sortBy === "speed"
+                      ? "text-primary"
+                      : "text-foreground"
                   )}
                 >
                   SPE{" "}
@@ -1055,7 +721,7 @@ export function SpeedTiersPanel({ team, format }: SpeedTiersPanelProps) {
               };
               const prev = i > 0 ? getGroupValue(sorted[i - 1]!) : null;
               const curr = getGroupValue(scored);
-              const showSeparator = prev !== null && prev !== curr;
+              const showSeparator = i === 0 || (prev !== null && prev !== curr);
               return (
                 <TierMonRow
                   key={scored.mon.id}
@@ -1070,11 +736,396 @@ export function SpeedTiersPanel({ team, format }: SpeedTiersPanelProps) {
                       : toggle.theirs.unburden
                   )}
                   showGroupSeparator={showSeparator}
+                  groupBaseSpeed={scored.mon.baseSpeed}
                 />
               );
             })}
           </TableBody>
         </table>
+      </div>
+
+      {/* MODIFIERS section — below table */}
+      <div className="border-t px-3 py-3">
+        <fieldset className="border-border/60 rounded-lg border px-3 py-2">
+          <legend className="text-primary px-1 font-mono text-[9px] font-bold tracking-[0.12em] uppercase">
+            Modifiers
+          </legend>
+          <div className="grid grid-cols-[auto_auto_auto] items-center gap-x-3 gap-y-1.5">
+            {/* Header */}
+            <span className="text-muted-foreground text-right text-[10px] font-semibold uppercase">
+              Ours
+            </span>
+            <span />
+            <span className="text-muted-foreground text-[10px] font-semibold uppercase">
+              Theirs
+            </span>
+
+            {/* Tailwind */}
+            <div className="flex justify-end">
+              <button
+                type="button"
+                aria-label="Our Tailwind"
+                onClick={() =>
+                  setToggle((prev) => ({
+                    ...prev,
+                    yours: { ...prev.yours, tailwind: !prev.yours.tailwind },
+                  }))
+                }
+                className={cn(
+                  "size-4 rounded-full border-2 transition-colors",
+                  toggle.yours.tailwind
+                    ? "border-primary bg-primary"
+                    : "border-muted-foreground/40 hover:border-muted-foreground"
+                )}
+              />
+            </div>
+            <span className="text-foreground text-center text-[11px]">
+              Tailwind
+            </span>
+            <div className="flex justify-start">
+              <button
+                type="button"
+                aria-label="Their Tailwind"
+                onClick={() =>
+                  setToggle((prev) => ({
+                    ...prev,
+                    theirs: { ...prev.theirs, tailwind: !prev.theirs.tailwind },
+                  }))
+                }
+                className={cn(
+                  "size-4 rounded-full border-2 transition-colors",
+                  toggle.theirs.tailwind
+                    ? "border-primary bg-primary"
+                    : "border-muted-foreground/40 hover:border-muted-foreground"
+                )}
+              />
+            </div>
+
+            {/* Scarf */}
+            <div className="flex justify-end">
+              <button
+                type="button"
+                aria-label="Our Scarf"
+                onClick={() =>
+                  setToggle((prev) => ({
+                    ...prev,
+                    yours: { ...prev.yours, scarf: !prev.yours.scarf },
+                  }))
+                }
+                className={cn(
+                  "size-4 rounded-full border-2 transition-colors",
+                  toggle.yours.scarf
+                    ? "border-primary bg-primary"
+                    : "border-muted-foreground/40 hover:border-muted-foreground"
+                )}
+              />
+            </div>
+            <span className="text-foreground text-center text-[11px]">
+              Scarf
+            </span>
+            <div className="flex justify-start">
+              <button
+                type="button"
+                aria-label="Their Scarf"
+                onClick={() =>
+                  setToggle((prev) => ({
+                    ...prev,
+                    theirs: { ...prev.theirs, scarf: !prev.theirs.scarf },
+                  }))
+                }
+                className={cn(
+                  "size-4 rounded-full border-2 transition-colors",
+                  toggle.theirs.scarf
+                    ? "border-primary bg-primary"
+                    : "border-muted-foreground/40 hover:border-muted-foreground"
+                )}
+              />
+            </div>
+
+            {/* Unburden */}
+            <div className="flex justify-end">
+              <button
+                type="button"
+                aria-label="Our Unburden"
+                onClick={() =>
+                  setToggle((prev) => ({
+                    ...prev,
+                    yours: { ...prev.yours, unburden: !prev.yours.unburden },
+                  }))
+                }
+                className={cn(
+                  "size-4 rounded-full border-2 transition-colors",
+                  toggle.yours.unburden
+                    ? "border-primary bg-primary"
+                    : "border-muted-foreground/40 hover:border-muted-foreground"
+                )}
+              />
+            </div>
+            <span className="text-foreground text-center text-[11px]">
+              Unburden
+            </span>
+            <div className="flex justify-start">
+              <button
+                type="button"
+                aria-label="Their Unburden"
+                onClick={() =>
+                  setToggle((prev) => ({
+                    ...prev,
+                    theirs: { ...prev.theirs, unburden: !prev.theirs.unburden },
+                  }))
+                }
+                className={cn(
+                  "size-4 rounded-full border-2 transition-colors",
+                  toggle.theirs.unburden
+                    ? "border-primary bg-primary"
+                    : "border-muted-foreground/40 hover:border-muted-foreground"
+                )}
+              />
+            </div>
+
+            {/* Paralyzed */}
+            <div className="flex justify-end">
+              <button
+                type="button"
+                aria-label="Our Paralyzed"
+                onClick={() =>
+                  setToggle((prev) => ({
+                    ...prev,
+                    yours: {
+                      ...prev.yours,
+                      status:
+                        prev.yours.status === "paralyzed"
+                          ? "healthy"
+                          : "paralyzed",
+                    },
+                  }))
+                }
+                className={cn(
+                  "size-4 rounded-full border-2 transition-colors",
+                  toggle.yours.status === "paralyzed"
+                    ? "border-primary bg-primary"
+                    : "border-muted-foreground/40 hover:border-muted-foreground"
+                )}
+              />
+            </div>
+            <span className="text-foreground text-center text-[11px]">
+              Paralyzed
+            </span>
+            <div className="flex justify-start">
+              <button
+                type="button"
+                aria-label="Their Paralyzed"
+                onClick={() =>
+                  setToggle((prev) => ({
+                    ...prev,
+                    theirs: {
+                      ...prev.theirs,
+                      status:
+                        prev.theirs.status === "paralyzed"
+                          ? "healthy"
+                          : "paralyzed",
+                    },
+                  }))
+                }
+                className={cn(
+                  "size-4 rounded-full border-2 transition-colors",
+                  toggle.theirs.status === "paralyzed"
+                    ? "border-primary bg-primary"
+                    : "border-muted-foreground/40 hover:border-muted-foreground"
+                )}
+              />
+            </div>
+
+            {/* Nature — theirs only */}
+            <div />
+            <span className="text-foreground text-center text-[11px]">
+              Nature
+            </span>
+            <div className="flex justify-start gap-0.5">
+              {(["negative", "neutral", "positive"] as const).map((n) => (
+                <button
+                  key={n}
+                  type="button"
+                  aria-label={`${n} speed nature`}
+                  onClick={() =>
+                    setToggle((prev) => ({
+                      ...prev,
+                      theirs: { ...prev.theirs, nature: n },
+                    }))
+                  }
+                  className={cn(
+                    "rounded px-1.5 py-0.5 font-mono text-[10px] font-bold transition-colors",
+                    toggle.theirs.nature === n
+                      ? "bg-primary/20 text-primary"
+                      : "text-muted-foreground/60 hover:text-muted-foreground"
+                  )}
+                >
+                  {n === "negative" ? "−" : n === "neutral" ? "●" : "+"}
+                </button>
+              ))}
+            </div>
+
+            {/* EVs — theirs only */}
+            <div />
+            <span className="text-foreground text-center text-[11px]">
+              {evLabel}
+            </span>
+            <div className="flex items-center justify-start gap-0.5">
+              <button
+                type="button"
+                aria-label={`Decrease speed ${evLabel}`}
+                disabled={toggle.theirs.evs === null || toggle.theirs.evs <= 0}
+                onClick={() =>
+                  setToggle((prev) => ({
+                    ...prev,
+                    theirs: {
+                      ...prev.theirs,
+                      evs: Math.max(0, (prev.theirs.evs ?? maxEv) - evStep),
+                    },
+                  }))
+                }
+                className="text-muted-foreground hover:text-foreground text-xs font-bold disabled:opacity-30"
+              >
+                −
+              </button>
+              <input
+                type="text"
+                inputMode="numeric"
+                aria-label={`Speed ${evLabel} override`}
+                value={toggle.theirs.evs ?? ""}
+                placeholder={String(maxEv)}
+                onChange={(e) => {
+                  const raw = e.target.value.replace(/[^0-9]/g, "");
+                  if (raw === "") {
+                    setToggle((prev) => ({
+                      ...prev,
+                      theirs: { ...prev.theirs, evs: null },
+                    }));
+                    return;
+                  }
+                  const val = Math.min(maxEv, Math.max(0, Number(raw)));
+                  setToggle((prev) => ({
+                    ...prev,
+                    theirs: { ...prev.theirs, evs: val },
+                  }));
+                }}
+                className="text-foreground w-8 [appearance:textfield] bg-transparent text-center font-mono text-[10px] font-semibold outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+              />
+              <button
+                type="button"
+                aria-label={`Increase speed ${evLabel}`}
+                disabled={
+                  toggle.theirs.evs !== null && toggle.theirs.evs >= maxEv
+                }
+                onClick={() =>
+                  setToggle((prev) => ({
+                    ...prev,
+                    theirs: {
+                      ...prev.theirs,
+                      evs: Math.min(maxEv, (prev.theirs.evs ?? maxEv) + evStep),
+                    },
+                  }))
+                }
+                className="text-muted-foreground hover:text-foreground text-xs font-bold disabled:opacity-30"
+              >
+                +
+              </button>
+            </div>
+
+            {/* Stages — compact ±stepper */}
+            <div className="flex items-center justify-end gap-0.5">
+              <button
+                type="button"
+                aria-label="Our stage decrease"
+                disabled={toggle.yours.stage <= STAGE_MIN}
+                onClick={() =>
+                  setToggle((prev) => ({
+                    ...prev,
+                    yours: { ...prev.yours, stage: prev.yours.stage - 1 },
+                  }))
+                }
+                className="text-muted-foreground hover:text-foreground text-xs font-bold disabled:opacity-30"
+              >
+                −
+              </button>
+              <span
+                className={cn(
+                  "min-w-5 rounded px-1 text-center font-mono text-[10px] font-bold",
+                  toggle.yours.stage !== 0
+                    ? "bg-primary/20 text-primary"
+                    : "text-muted-foreground"
+                )}
+              >
+                {toggle.yours.stage === 0
+                  ? "0"
+                  : toggle.yours.stage > 0
+                    ? `+${toggle.yours.stage}`
+                    : toggle.yours.stage}
+              </span>
+              <button
+                type="button"
+                aria-label="Our stage increase"
+                disabled={toggle.yours.stage >= STAGE_MAX}
+                onClick={() =>
+                  setToggle((prev) => ({
+                    ...prev,
+                    yours: { ...prev.yours, stage: prev.yours.stage + 1 },
+                  }))
+                }
+                className="text-muted-foreground hover:text-foreground text-xs font-bold disabled:opacity-30"
+              >
+                +
+              </button>
+            </div>
+            <span className="text-foreground text-center text-[11px]">
+              Stages
+            </span>
+            <div className="flex items-center justify-start gap-0.5">
+              <button
+                type="button"
+                aria-label="Their stage decrease"
+                disabled={toggle.theirs.stage <= STAGE_MIN}
+                onClick={() =>
+                  setToggle((prev) => ({
+                    ...prev,
+                    theirs: { ...prev.theirs, stage: prev.theirs.stage - 1 },
+                  }))
+                }
+                className="text-muted-foreground hover:text-foreground text-xs font-bold disabled:opacity-30"
+              >
+                −
+              </button>
+              <span
+                className={cn(
+                  "min-w-5 rounded px-1 text-center font-mono text-[10px] font-bold",
+                  toggle.theirs.stage !== 0
+                    ? "bg-primary/20 text-primary"
+                    : "text-muted-foreground"
+                )}
+              >
+                {toggle.theirs.stage === 0
+                  ? "0"
+                  : toggle.theirs.stage > 0
+                    ? `+${toggle.theirs.stage}`
+                    : toggle.theirs.stage}
+              </span>
+              <button
+                type="button"
+                aria-label="Their stage increase"
+                disabled={toggle.theirs.stage >= STAGE_MAX}
+                onClick={() =>
+                  setToggle((prev) => ({
+                    ...prev,
+                    theirs: { ...prev.theirs, stage: prev.theirs.stage + 1 },
+                  }))
+                }
+                className="text-muted-foreground hover:text-foreground text-xs font-bold disabled:opacity-30"
+              >
+                +
+              </button>
+            </div>
+          </div>
+        </fieldset>
       </div>
     </div>
   );

--- a/apps/web/src/components/team-builder/dock/speed-tiers-panel.tsx
+++ b/apps/web/src/components/team-builder/dock/speed-tiers-panel.tsx
@@ -409,7 +409,8 @@ interface TierMonRowProps {
   trickRoom: boolean;
   abilityActive: boolean;
   showGroupSeparator?: boolean;
-  groupBaseSpeed?: number;
+  groupValue?: number;
+  groupLabel?: string;
 }
 
 function TierMonRow({
@@ -418,7 +419,8 @@ function TierMonRow({
   trickRoom,
   abilityActive,
   showGroupSeparator,
-  groupBaseSpeed,
+  groupValue,
+  groupLabel,
 }: TierMonRowProps) {
   const { mon, speed } = scored;
   const isTie = !mon.isSelected && speed === heroSpeed && heroSpeed > 0;
@@ -437,10 +439,10 @@ function TierMonRow({
           >
             <div className="border-primary/40 flex items-center justify-center gap-1.5 border-t-2 pt-0.5">
               <span className="text-primary/70 font-mono text-[10px]">
-                {groupBaseSpeed}
+                {groupValue}
               </span>
               <span className="text-muted-foreground/70 text-[9px] tracking-wider uppercase">
-                Base Speed
+                {groupLabel ?? "Base Speed"}
               </span>
             </div>
           </TableCell>
@@ -793,7 +795,8 @@ export function SpeedTiersPanel({
                       : toggle.theirs.unburden
                   )}
                   showGroupSeparator={showSeparator}
-                  groupBaseSpeed={scored.mon.baseSpeed}
+                  groupValue={curr}
+                  groupLabel={toggle.sortBy === "base" ? "Base Speed" : "Speed"}
                 />
               );
             })}

--- a/apps/web/src/components/team-builder/dock/speed-tiers-panel.tsx
+++ b/apps/web/src/components/team-builder/dock/speed-tiers-panel.tsx
@@ -795,8 +795,8 @@ export function SpeedTiersPanel({
                       : toggle.theirs.unburden
                   )}
                   showGroupSeparator={showSeparator}
-                  groupValue={curr}
-                  groupLabel={toggle.sortBy === "base" ? "Base Speed" : "Speed"}
+                  groupValue={scored.mon.baseSpeed}
+                  groupLabel="Base Speed"
                 />
               );
             })}

--- a/apps/web/src/components/team-builder/dock/speed-tiers-panel.tsx
+++ b/apps/web/src/components/team-builder/dock/speed-tiers-panel.tsx
@@ -624,6 +624,17 @@ export function SpeedTiersPanel({
     return isAsc ? aVal - bVal : bVal - aVal;
   });
 
+  const getGroupValue = (s: ScoredMon) => {
+    switch (toggle.sortBy) {
+      case "base":
+        return s.mon.baseSpeed;
+      case "speed":
+        return s.speed;
+      default:
+        return s.speed;
+    }
+  };
+
   // ---- helpers ----------------------------------------------------------------
 
   function setWeather(w: Weather) {
@@ -763,16 +774,6 @@ export function SpeedTiersPanel({
           </TableHeader>
           <TableBody>
             {sorted.map((scored, i) => {
-              const getGroupValue = (s: ScoredMon) => {
-                switch (toggle.sortBy) {
-                  case "base":
-                    return s.mon.baseSpeed;
-                  case "speed":
-                    return s.speed;
-                  default:
-                    return s.speed;
-                }
-              };
               const prev = i > 0 ? getGroupValue(sorted[i - 1]!) : null;
               const curr = getGroupValue(scored);
               const showSeparator = i === 0 || (prev !== null && prev !== curr);

--- a/apps/web/src/components/team-builder/dock/speed-tiers-panel.tsx
+++ b/apps/web/src/components/team-builder/dock/speed-tiers-panel.tsx
@@ -134,6 +134,25 @@ const WEATHER_LABELS: Record<Weather, string> = {
   snow: "Snow",
 };
 
+/** Map engine-level weather strings (from @smogon/calc) to panel Weather type. */
+const ENGINE_TO_PANEL_WEATHER: Record<string, Weather> = {
+  Sun: "sun",
+  Rain: "rain",
+  Sand: "sand",
+  Snow: "snow",
+};
+
+/** Safely convert an external engine weather string to a validated Weather value. */
+function parseExternalWeather(engineWeather: string | undefined): Weather {
+  if (!engineWeather) return "none";
+  return ENGINE_TO_PANEL_WEATHER[engineWeather] ?? "none";
+}
+
+/** Convert panel Weather back to engine format for the calc state setter. */
+function panelWeatherToEngine(w: Weather): string {
+  return w === "none" ? "" : w.charAt(0).toUpperCase() + w.slice(1);
+}
+
 const STAGE_MIN = -6;
 const STAGE_MAX = 6;
 
@@ -165,6 +184,8 @@ function safeSprite(species: string): string | undefined {
   try {
     return getPokemonSprite(species).url;
   } catch {
+    // getPokemonSprite throws for unknown/mismatched species names — graceful
+    // degradation to no sprite is preferred over crashing the entire panel.
     return undefined;
   }
 }
@@ -561,7 +582,7 @@ export function SpeedTiersPanel({
 
   // Weather: derive from external (calc) state if provided, else use local toggle
   const effectiveWeather: Weather = externalWeather
-    ? (externalWeather.toLowerCase() as Weather) || "none"
+    ? parseExternalWeather(externalWeather)
     : toggle.weather;
 
   // Filter to non-null pokemon on the team.
@@ -569,7 +590,6 @@ export function SpeedTiersPanel({
     .filter((tp) => tp.pokemon != null)
     .map((tp) => tp.pokemon as Tables<"pokemon">);
 
-  // Use effectiveWeather (synced from calc) in the toggle for scoring
   const effectiveToggle: ToggleState = { ...toggle, weather: effectiveWeather };
 
   const teamScored: ScoredMon[] = pokemons.map((p) =>
@@ -608,14 +628,9 @@ export function SpeedTiersPanel({
 
   function setWeather(w: Weather) {
     if (externalSetWeather) {
-      // Sync to calc state: capitalize for @smogon/calc, "" for none
-      const capitalized =
-        w === "none" ? "" : w.charAt(0).toUpperCase() + w.slice(1);
-      // Toggle off if already active
-      const current = externalWeather
-        ? (externalWeather.toLowerCase() as Weather) || "none"
-        : "none";
-      externalSetWeather(current === w ? "" : capitalized);
+      // Toggle off if already active, otherwise sync to calc state
+      const current = parseExternalWeather(externalWeather);
+      externalSetWeather(current === w ? "" : panelWeatherToEngine(w));
     } else {
       setToggle((prev) => ({
         ...prev,

--- a/apps/web/src/components/team-builder/lanes/calc-reverse-card.tsx
+++ b/apps/web/src/components/team-builder/lanes/calc-reverse-card.tsx
@@ -181,7 +181,7 @@ export function CalcReverseColumn({ pokemon, teammates }: CalcReverseColumnProps
       </span>
 
       {/* Moves — left-aligned, wrap when narrow */}
-      <div className="flex-1 flex items-center flex-wrap gap-y-0.5 ml-2">
+      <div className="flex-1 flex items-center justify-center flex-wrap gap-x-6 gap-y-0.5 ml-2">
       {activeMoves.map((m, i) => {
         const moveType = m.moveData?.type ?? null;
 

--- a/apps/web/src/components/team-builder/lanes/calc-reverse-card.tsx
+++ b/apps/web/src/components/team-builder/lanes/calc-reverse-card.tsx
@@ -180,7 +180,7 @@ export function CalcReverseColumn({ pokemon, teammates }: CalcReverseColumnProps
         Incoming
       </span>
 
-      {/* Moves — left-aligned, wrap when narrow */}
+      {/* Moves — centered, wrap when narrow */}
       <div className="flex-1 flex items-center justify-center flex-wrap gap-x-6 gap-y-0.5 ml-2">
       {activeMoves.map((m, i) => {
         const moveType = m.moveData?.type ?? null;

--- a/apps/web/src/components/team-builder/local-builder-workspace.tsx
+++ b/apps/web/src/components/team-builder/local-builder-workspace.tsx
@@ -113,7 +113,7 @@ export function LocalBuilderWorkspace() {
       // Reset the fetch guard on unmount so StrictMode re-mounts can re-fetch
       fetchingRef.current = false;
     };
-  }, [isAuthenticated, authLoading, user]);
+  }, [isAuthenticated, authLoading, user, supabase]);
 
   // Auto-trigger save when returning from auth with ?action=save
   const actionParam = searchParams.get("action");

--- a/apps/web/src/components/team-builder/local-builder-workspace.tsx
+++ b/apps/web/src/components/team-builder/local-builder-workspace.tsx
@@ -16,7 +16,7 @@
  * - Load existing teams from any alt
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 
@@ -72,8 +72,11 @@ export function LocalBuilderWorkspace() {
 
   // Fetch alts and teams when authenticated (serialized to avoid
   // concurrent Supabase auth lock contention).
+  const fetchingRef = useRef(false);
   useEffect(() => {
     if (!isAuthenticated || authLoading || !user) return;
+    if (fetchingRef.current) return;
+    fetchingRef.current = true;
     let cancelled = false;
 
     async function fetchData() {
@@ -92,12 +95,15 @@ export function LocalBuilderWorkspace() {
       } catch (err) {
         if (!cancelled) console.error("Failed to fetch user data:", err);
       } finally {
+        fetchingRef.current = false;
         if (!cancelled) setTeamsLoading(false);
       }
     }
 
     fetchData();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [isAuthenticated, authLoading, user]);
 
   // Auto-trigger save when returning from auth with ?action=save

--- a/apps/web/src/components/team-builder/local-builder-workspace.tsx
+++ b/apps/web/src/components/team-builder/local-builder-workspace.tsx
@@ -22,7 +22,7 @@ import { toast } from "sonner";
 
 import { getFormatById } from "@trainers/pokemon";
 import {
-  getCurrentUserAlts,
+  getAltsByUserId,
   getTeamsForUser,
   getTeamWithPokemon,
   type Tables,
@@ -70,8 +70,9 @@ export function LocalBuilderWorkspace() {
 
   const format = team.format ? getFormatById(team.format) : undefined;
 
-  // Fetch alts and teams when authenticated (serialized to avoid
-  // concurrent Supabase auth lock contention).
+  // Fetch alts and teams when authenticated. Uses user.id from context
+  // directly to avoid a redundant supabase.auth.getUser() call that races
+  // with other auth requests and triggers lock contention.
   const fetchingRef = useRef(false);
   useEffect(() => {
     if (!isAuthenticated || authLoading || !user) return;
@@ -82,7 +83,7 @@ export function LocalBuilderWorkspace() {
     async function fetchData() {
       setTeamsLoading(true);
       try {
-        const fetchedAlts = await getCurrentUserAlts(supabase);
+        const fetchedAlts = await getAltsByUserId(supabase, user!.id);
         if (cancelled) return;
         setAlts(fetchedAlts);
         if (fetchedAlts.length > 0 && !selectedAltId) {
@@ -131,7 +132,7 @@ export function LocalBuilderWorkspace() {
         targetAlt = alts.find((a) => a.id === selectedAltId);
       }
       if (!targetAlt) {
-        const fetchedAlts = await getCurrentUserAlts(supabase);
+        const fetchedAlts = await getAltsByUserId(supabase, user!.id);
         if (!fetchedAlts || fetchedAlts.length === 0) {
           toast.error(
             "No profile found. Please complete your profile setup first."

--- a/apps/web/src/components/team-builder/local-builder-workspace.tsx
+++ b/apps/web/src/components/team-builder/local-builder-workspace.tsx
@@ -29,6 +29,7 @@ import {
   type TeamWithPokemon,
   type CrossAltTeamListItem,
 } from "@trainers/supabase";
+import { getErrorMessage, logError } from "@trainers/utils";
 
 import { useAuthContext } from "@/components/auth/auth-provider";
 import { useSupabase } from "@/lib/supabase";
@@ -94,7 +95,12 @@ export function LocalBuilderWorkspace() {
         if (cancelled) return;
         setUserTeams(teams);
       } catch (err) {
-        if (!cancelled) console.error("Failed to fetch user data:", err);
+        if (!cancelled) {
+          logError("localBuilder.fetchData", err);
+          toast.error(
+            "Failed to load your account data. You can still build locally."
+          );
+        }
       } finally {
         fetchingRef.current = false;
         if (!cancelled) setTeamsLoading(false);
@@ -104,6 +110,8 @@ export function LocalBuilderWorkspace() {
     fetchData();
     return () => {
       cancelled = true;
+      // Reset the fetch guard on unmount so StrictMode re-mounts can re-fetch
+      fetchingRef.current = false;
     };
   }, [isAuthenticated, authLoading, user]);
 
@@ -119,7 +127,14 @@ export function LocalBuilderWorkspace() {
     ) {
       handleSaveToAccount();
     }
-  }, [actionParam, isAuthenticated, authLoading, hydrated]);
+  }, [
+    actionParam,
+    isAuthenticated,
+    authLoading,
+    hydrated,
+    isSaving,
+    handleSaveToAccount,
+  ]);
 
   async function handleSaveToAccount() {
     if (isSaving) return;
@@ -171,8 +186,10 @@ export function LocalBuilderWorkspace() {
       toast.success("Team saved to your account!");
       router.push(result.data.redirectUrl);
     } catch (error) {
-      console.error("Save to account failed:", error);
-      toast.error("Something went wrong. Please try again.");
+      logError("localBuilder.saveToAccount", error);
+      toast.error(
+        getErrorMessage(error, "Something went wrong. Please try again.")
+      );
       setIsSaving(false);
     }
   }
@@ -197,8 +214,10 @@ export function LocalBuilderWorkspace() {
 
       toast.success(`Loaded "${fullTeam.name}" into the builder.`);
     } catch (err) {
-      console.error("Failed to load team:", err);
-      toast.error("Failed to load team. Please try again.");
+      logError("localBuilder.loadTeam", err);
+      toast.error(
+        getErrorMessage(err, "Failed to load team. Please try again.")
+      );
     }
   }
 

--- a/apps/web/src/components/team-builder/local-builder-workspace.tsx
+++ b/apps/web/src/components/team-builder/local-builder-workspace.tsx
@@ -80,18 +80,19 @@ export function LocalBuilderWorkspace() {
     if (fetchingRef.current) return;
     fetchingRef.current = true;
     let cancelled = false;
+    const userId = user.id;
 
     async function fetchData() {
       setTeamsLoading(true);
       try {
-        const fetchedAlts = await getAltsByUserId(supabase, user!.id);
+        const fetchedAlts = await getAltsByUserId(supabase, userId);
         if (cancelled) return;
         setAlts(fetchedAlts);
         if (fetchedAlts.length > 0 && !selectedAltId) {
           setSelectedAltId(fetchedAlts[0]!.id);
         }
 
-        const teams = await getTeamsForUser(supabase, user!.id);
+        const teams = await getTeamsForUser(supabase, userId);
         if (cancelled) return;
         setUserTeams(teams);
       } catch (err) {
@@ -138,6 +139,10 @@ export function LocalBuilderWorkspace() {
 
   async function handleSaveToAccount() {
     if (isSaving) return;
+    if (!user) {
+      toast.error("You must be signed in to save a team.");
+      return;
+    }
     setIsSaving(true);
 
     try {
@@ -147,7 +152,7 @@ export function LocalBuilderWorkspace() {
         targetAlt = alts.find((a) => a.id === selectedAltId);
       }
       if (!targetAlt) {
-        const fetchedAlts = await getAltsByUserId(supabase, user!.id);
+        const fetchedAlts = await getAltsByUserId(supabase, user.id);
         if (!fetchedAlts || fetchedAlts.length === 0) {
           toast.error(
             "No profile found. Please complete your profile setup first."

--- a/apps/web/src/components/team-builder/local-builder-workspace.tsx
+++ b/apps/web/src/components/team-builder/local-builder-workspace.tsx
@@ -70,42 +70,34 @@ export function LocalBuilderWorkspace() {
 
   const format = team.format ? getFormatById(team.format) : undefined;
 
-  // Fetch alts when authenticated
+  // Fetch alts and teams when authenticated (serialized to avoid
+  // concurrent Supabase auth lock contention).
   useEffect(() => {
     if (!isAuthenticated || authLoading || !user) return;
+    let cancelled = false;
 
-    async function fetchAlts() {
+    async function fetchData() {
+      setTeamsLoading(true);
       try {
         const fetchedAlts = await getCurrentUserAlts(supabase);
+        if (cancelled) return;
         setAlts(fetchedAlts);
         if (fetchedAlts.length > 0 && !selectedAltId) {
           setSelectedAltId(fetchedAlts[0]!.id);
         }
-      } catch (err) {
-        console.error("Failed to fetch alts:", err);
-      }
-    }
 
-    fetchAlts();
-  }, [isAuthenticated, authLoading, user]);
-
-  // Fetch teams when authenticated
-  useEffect(() => {
-    if (!isAuthenticated || authLoading || !user) return;
-
-    async function fetchTeams() {
-      setTeamsLoading(true);
-      try {
         const teams = await getTeamsForUser(supabase, user!.id);
+        if (cancelled) return;
         setUserTeams(teams);
       } catch (err) {
-        console.error("Failed to fetch teams:", err);
+        if (!cancelled) console.error("Failed to fetch user data:", err);
       } finally {
-        setTeamsLoading(false);
+        if (!cancelled) setTeamsLoading(false);
       }
     }
 
-    fetchTeams();
+    fetchData();
+    return () => { cancelled = true; };
   }, [isAuthenticated, authLoading, user]);
 
   // Auto-trigger save when returning from auth with ?action=save

--- a/apps/web/src/components/team-builder/persistence/__tests__/use-local-team-storage.test.ts
+++ b/apps/web/src/components/team-builder/persistence/__tests__/use-local-team-storage.test.ts
@@ -124,15 +124,16 @@ describe("useLocalTeamStorage", () => {
     expect(result.current.team.name).toBe("Direct Set");
   });
 
-  it("clearLocalTeamStorage removes the key from localStorage", () => {
+  it("clearLocalTeamStorage removes the key from localStorage and returns true", () => {
     localStorageMock.setItem(
       STORAGE_KEY,
       JSON.stringify({ team: {}, updatedAt: "2024-01-01", version: 1 })
     );
     jest.clearAllMocks();
 
-    clearLocalTeamStorage();
+    const result = clearLocalTeamStorage();
 
     expect(localStorageMock.removeItem).toHaveBeenCalledWith(STORAGE_KEY);
+    expect(result).toBe(true);
   });
 });

--- a/apps/web/src/components/team-builder/persistence/local-persistence.ts
+++ b/apps/web/src/components/team-builder/persistence/local-persistence.ts
@@ -19,7 +19,7 @@ import type { BuilderPersistence, ActionResult } from "./types";
 // =============================================================================
 
 /** Start from a timestamp-based negative value so HMR re-evaluation never collides. */
-let nextLocalId = -(Math.trunc(Date.now() / 1000));
+let nextLocalId = -Date.now();
 
 /** Generate a unique negative ID for local pokemon/team_pokemon entries. */
 function generateLocalId(): number {

--- a/apps/web/src/components/team-builder/persistence/local-persistence.ts
+++ b/apps/web/src/components/team-builder/persistence/local-persistence.ts
@@ -18,7 +18,8 @@ import type { BuilderPersistence, ActionResult } from "./types";
 // ID Generator
 // =============================================================================
 
-let nextLocalId = -100;
+/** Start from a timestamp-based negative value so HMR re-evaluation never collides. */
+let nextLocalId = -(Math.trunc(Date.now() / 1000));
 
 /** Generate a unique negative ID for local pokemon/team_pokemon entries. */
 function generateLocalId(): number {

--- a/apps/web/src/components/team-builder/persistence/use-local-team-storage.ts
+++ b/apps/web/src/components/team-builder/persistence/use-local-team-storage.ts
@@ -77,6 +77,9 @@ function readFromStorage(): TeamWithPokemon | null {
     return team;
   } catch (error) {
     logError("localTeamStorage.read", error);
+    toast.error(
+      "Your saved team data was corrupted and couldn't be loaded. Starting fresh."
+    );
     return null;
   }
 }
@@ -84,8 +87,26 @@ function readFromStorage(): TeamWithPokemon | null {
 function writeToStorage(team: TeamWithPokemon): void {
   if (typeof window === "undefined") return;
   try {
+    // Deduplicate before persisting as defense-in-depth against bugs
+    // producing duplicate pokemon_id entries during a session.
+    let teamToWrite = team;
+    if (team.team_pokemon.length > 0) {
+      const seen = new Set<number>();
+      const deduped: typeof team.team_pokemon = [];
+      for (let i = team.team_pokemon.length - 1; i >= 0; i--) {
+        const tp = team.team_pokemon[i]!;
+        if (!seen.has(tp.pokemon_id)) {
+          seen.add(tp.pokemon_id);
+          deduped.unshift(tp);
+        }
+      }
+      if (deduped.length !== team.team_pokemon.length) {
+        teamToWrite = { ...team, team_pokemon: deduped };
+      }
+    }
+
     const data: LocalTeamData = {
-      team,
+      team: teamToWrite,
       updatedAt: new Date().toISOString(),
       version: 1,
     };
@@ -96,12 +117,17 @@ function writeToStorage(team: TeamWithPokemon): void {
   }
 }
 
-export function clearLocalTeamStorage(): void {
-  if (typeof window === "undefined") return;
+export function clearLocalTeamStorage(): boolean {
+  if (typeof window === "undefined") return true;
   try {
     localStorage.removeItem(LOCAL_TEAM_STORAGE_KEY);
+    return true;
   } catch (error) {
     logError("localTeamStorage.clear", error);
+    toast.error(
+      "Could not clear local team data. It may reappear on next visit."
+    );
+    return false;
   }
 }
 

--- a/apps/web/src/components/team-builder/persistence/use-local-team-storage.ts
+++ b/apps/web/src/components/team-builder/persistence/use-local-team-storage.ts
@@ -28,6 +28,27 @@ const DEFAULT_FORMAT = "gen9vgc2026regi";
 // Helpers
 // =============================================================================
 
+/**
+ * Deduplicate team_pokemon entries by pokemon_id.
+ * Keeps the last entry per ID (most recently added) by iterating in reverse.
+ * Returns the original array reference if no duplicates found.
+ */
+function dedupeTeamPokemon(
+  teamPokemon: TeamWithPokemon["team_pokemon"]
+): TeamWithPokemon["team_pokemon"] {
+  if (teamPokemon.length === 0) return teamPokemon;
+  const seen = new Set<number>();
+  const deduped: typeof teamPokemon = [];
+  for (let i = teamPokemon.length - 1; i >= 0; i--) {
+    const tp = teamPokemon[i]!;
+    if (!seen.has(tp.pokemon_id)) {
+      seen.add(tp.pokemon_id);
+      deduped.unshift(tp);
+    }
+  }
+  return deduped.length === teamPokemon.length ? teamPokemon : deduped;
+}
+
 function createEmptyTeam(): TeamWithPokemon {
   return {
     id: -1,
@@ -54,25 +75,8 @@ function readFromStorage(): TeamWithPokemon | null {
     const parsed: LocalTeamData = JSON.parse(raw);
     if (parsed.version !== 1) return null;
 
-    // Deduplicate team_pokemon by pokemon.id — previous HMR counter resets
-    // could produce entries with colliding IDs at different positions. Keep the
-    // last entry per ID (most recently added).
     const team = parsed.team;
-    if (team.team_pokemon.length > 0) {
-      const seen = new Set<number>();
-      const deduped: typeof team.team_pokemon = [];
-      // Iterate in reverse so the last-added entry (highest position) wins.
-      for (let i = team.team_pokemon.length - 1; i >= 0; i--) {
-        const tp = team.team_pokemon[i]!;
-        if (!seen.has(tp.pokemon_id)) {
-          seen.add(tp.pokemon_id);
-          deduped.unshift(tp);
-        }
-      }
-      if (deduped.length !== team.team_pokemon.length) {
-        team.team_pokemon = deduped;
-      }
-    }
+    team.team_pokemon = dedupeTeamPokemon(team.team_pokemon);
 
     return team;
   } catch (error) {
@@ -87,23 +91,11 @@ function readFromStorage(): TeamWithPokemon | null {
 function writeToStorage(team: TeamWithPokemon): void {
   if (typeof window === "undefined") return;
   try {
-    // Deduplicate before persisting as defense-in-depth against bugs
-    // producing duplicate pokemon_id entries during a session.
-    let teamToWrite = team;
-    if (team.team_pokemon.length > 0) {
-      const seen = new Set<number>();
-      const deduped: typeof team.team_pokemon = [];
-      for (let i = team.team_pokemon.length - 1; i >= 0; i--) {
-        const tp = team.team_pokemon[i]!;
-        if (!seen.has(tp.pokemon_id)) {
-          seen.add(tp.pokemon_id);
-          deduped.unshift(tp);
-        }
-      }
-      if (deduped.length !== team.team_pokemon.length) {
-        teamToWrite = { ...team, team_pokemon: deduped };
-      }
-    }
+    // Deduplicate before persisting as defense-in-depth
+    const teamToWrite = {
+      ...team,
+      team_pokemon: dedupeTeamPokemon(team.team_pokemon),
+    };
 
     const data: LocalTeamData = {
       team: teamToWrite,

--- a/apps/web/src/components/team-builder/persistence/use-local-team-storage.ts
+++ b/apps/web/src/components/team-builder/persistence/use-local-team-storage.ts
@@ -8,7 +8,7 @@
  * for the dashboard builder.
  */
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { toast } from "sonner";
 import type { TeamWithPokemon } from "@trainers/supabase";
 import { logError } from "@trainers/utils";
@@ -20,6 +20,9 @@ import type { LocalTeamData } from "./types";
 
 const LOCAL_TEAM_STORAGE_KEY = "trainersgg.builder.localTeam.v1";
 const DEBOUNCE_MS = 300;
+
+/** Module-level ref to the pending debounce timer so clearLocalTeamStorage can cancel it. */
+let pendingWriteTimer: ReturnType<typeof setTimeout> | null = null;
 
 /** Default format for new local teams — current primary VGC format. */
 const DEFAULT_FORMAT = "gen9vgc2026regi";
@@ -81,6 +84,7 @@ function readFromStorage(): TeamWithPokemon | null {
     return team;
   } catch (error) {
     logError("localTeamStorage.read", error);
+    localStorage.removeItem(LOCAL_TEAM_STORAGE_KEY);
     toast.error(
       "Your saved team data was corrupted and couldn't be loaded. Starting fresh."
     );
@@ -112,6 +116,11 @@ function writeToStorage(team: TeamWithPokemon): void {
 export function clearLocalTeamStorage(): boolean {
   if (typeof window === "undefined") return true;
   try {
+    // Cancel any pending debounced write to prevent it from re-creating the key
+    if (pendingWriteTimer) {
+      clearTimeout(pendingWriteTimer);
+      pendingWriteTimer = null;
+    }
     localStorage.removeItem(LOCAL_TEAM_STORAGE_KEY);
     return true;
   } catch (error) {
@@ -141,7 +150,6 @@ interface UseLocalTeamStorageReturn {
 export function useLocalTeamStorage(): UseLocalTeamStorageReturn {
   const [team, setTeamState] = useState<TeamWithPokemon>(createEmptyTeam);
   const [hydrated, setHydrated] = useState(false);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Hydrate from localStorage on mount
   useEffect(() => {
@@ -160,9 +168,10 @@ export function useLocalTeamStorage(): UseLocalTeamStorageReturn {
     setTeamState((prev) => {
       const next = typeof updater === "function" ? updater(prev) : updater;
 
-      // Schedule debounced write
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      debounceRef.current = setTimeout(() => {
+      // Schedule debounced write (module-level so clearLocalTeamStorage can cancel)
+      if (pendingWriteTimer) clearTimeout(pendingWriteTimer);
+      pendingWriteTimer = setTimeout(() => {
+        pendingWriteTimer = null;
         writeToStorage(next);
       }, DEBOUNCE_MS);
 

--- a/apps/web/src/components/team-builder/persistence/use-local-team-storage.ts
+++ b/apps/web/src/components/team-builder/persistence/use-local-team-storage.ts
@@ -51,7 +51,28 @@ function readFromStorage(): TeamWithPokemon | null {
     if (!raw) return null;
     const parsed: LocalTeamData = JSON.parse(raw);
     if (parsed.version !== 1) return null;
-    return parsed.team;
+
+    // Deduplicate team_pokemon by pokemon.id — previous HMR counter resets
+    // could produce entries with colliding IDs at different positions. Keep the
+    // last entry per ID (most recently added).
+    const team = parsed.team;
+    if (team.team_pokemon.length > 0) {
+      const seen = new Set<number>();
+      const deduped: typeof team.team_pokemon = [];
+      // Iterate in reverse so the last-added entry (highest position) wins.
+      for (let i = team.team_pokemon.length - 1; i >= 0; i--) {
+        const tp = team.team_pokemon[i]!;
+        if (!seen.has(tp.pokemon_id)) {
+          seen.add(tp.pokemon_id);
+          deduped.unshift(tp);
+        }
+      }
+      if (deduped.length !== team.team_pokemon.length) {
+        team.team_pokemon = deduped;
+      }
+    }
+
+    return team;
   } catch {
     return null;
   }

--- a/apps/web/src/components/team-builder/persistence/use-local-team-storage.ts
+++ b/apps/web/src/components/team-builder/persistence/use-local-team-storage.ts
@@ -9,7 +9,9 @@
  */
 
 import { useState, useEffect, useRef } from "react";
+import { toast } from "sonner";
 import type { TeamWithPokemon } from "@trainers/supabase";
+import { logError } from "@trainers/utils";
 import type { LocalTeamData } from "./types";
 
 // =============================================================================
@@ -73,7 +75,8 @@ function readFromStorage(): TeamWithPokemon | null {
     }
 
     return team;
-  } catch {
+  } catch (error) {
+    logError("localTeamStorage.read", error);
     return null;
   }
 }
@@ -87,8 +90,9 @@ function writeToStorage(team: TeamWithPokemon): void {
       version: 1,
     };
     localStorage.setItem(LOCAL_TEAM_STORAGE_KEY, JSON.stringify(data));
-  } catch {
-    // Quota exceeded or private mode — non-fatal
+  } catch (error) {
+    logError("localTeamStorage.write", error);
+    toast.error("Could not save your team locally. Storage may be full.");
   }
 }
 
@@ -96,8 +100,8 @@ export function clearLocalTeamStorage(): void {
   if (typeof window === "undefined") return;
   try {
     localStorage.removeItem(LOCAL_TEAM_STORAGE_KEY);
-  } catch {
-    // Non-fatal
+  } catch (error) {
+    logError("localTeamStorage.clear", error);
   }
 }
 
@@ -109,7 +113,9 @@ interface UseLocalTeamStorageReturn {
   /** Current local team state (source of truth for local mode). */
   team: TeamWithPokemon;
   /** Update the team — triggers debounced localStorage write. */
-  setTeam: (updater: TeamWithPokemon | ((prev: TeamWithPokemon) => TeamWithPokemon)) => void;
+  setTeam: (
+    updater: TeamWithPokemon | ((prev: TeamWithPokemon) => TeamWithPokemon)
+  ) => void;
   /** Whether the initial hydration from localStorage is complete. */
   hydrated: boolean;
 }

--- a/apps/web/src/components/team-builder/team-workspace.tsx
+++ b/apps/web/src/components/team-builder/team-workspace.tsx
@@ -274,6 +274,28 @@ function DockbarConnected({
 }
 
 // =============================================================================
+// SpeedTiersPanelConnected — reads weather from CalcStateContext
+// =============================================================================
+
+function SpeedTiersPanelConnected({
+  team,
+  format,
+}: {
+  team: TeamWithPokemon["team_pokemon"];
+  format: GameFormat | undefined;
+}) {
+  const calc = useCalcStateContext();
+  return (
+    <SpeedTiersPanel
+      team={team}
+      format={format}
+      weather={calc.weather}
+      setWeather={calc.setWeather}
+    />
+  );
+}
+
+// =============================================================================
 // WorkspaceMetadata — inline row above the pokemon grid
 // =============================================================================
 
@@ -774,7 +796,7 @@ export function TeamWorkspaceV2({
                           </button>
                         </header>
                         <div className="min-h-0 flex-1 overflow-hidden">
-                          <SpeedTiersPanel
+                          <SpeedTiersPanelConnected
                             team={optimisticTeamPokemon}
                             format={format}
                           />
@@ -1051,7 +1073,7 @@ export function TeamWorkspaceV2({
                 )}
                 {state.sideDrawer === "speed" && (
                   <div className="w-full border-t p-3">
-                    <SpeedTiersPanel
+                    <SpeedTiersPanelConnected
                       team={optimisticTeamPokemon}
                       format={format}
                     />

--- a/apps/web/src/components/team-builder/team-workspace.tsx
+++ b/apps/web/src/components/team-builder/team-workspace.tsx
@@ -277,13 +277,15 @@ function DockbarConnected({
 // SpeedTiersPanelConnected — reads weather from CalcStateContext
 // =============================================================================
 
+interface SpeedTiersPanelConnectedProps {
+  team: TeamWithPokemon["team_pokemon"];
+  format: GameFormat | undefined;
+}
+
 function SpeedTiersPanelConnected({
   team,
   format,
-}: {
-  team: TeamWithPokemon["team_pokemon"];
-  format: GameFormat | undefined;
-}) {
+}: SpeedTiersPanelConnectedProps) {
   const calc = useCalcStateContext();
   return (
     <SpeedTiersPanel

--- a/apps/web/src/components/team-builder/team-workspace.tsx
+++ b/apps/web/src/components/team-builder/team-workspace.tsx
@@ -27,7 +27,11 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 
-import { type GameFormat, getActiveFormats } from "@trainers/pokemon";
+import {
+  type GameFormat,
+  getActiveFormats,
+  getMegaStoneForSpecies,
+} from "@trainers/pokemon";
 import {
   type TeamWithPokemon,
   type Tables,
@@ -173,6 +177,7 @@ type OptimisticAction =
       // invoke the reducer multiple times during reconciliation, and the row
       // must keep the same React key across every call.
       tempId: number;
+      heldItem?: string | null;
     }
   | { kind: "remove"; pokemonId: number };
 
@@ -184,7 +189,8 @@ type OptimisticAction =
 function buildOptimisticTeamPokemon(
   species: string,
   position: number,
-  tempId: number
+  tempId: number,
+  heldItem?: string | null
 ): TeamWithPokemon["team_pokemon"][number] {
   // Numeric and boolean defaults mirror pokemonPayloadSchema's `.default(...)`
   // values — the same defaults the server applies on insert. Without them the
@@ -201,7 +207,7 @@ function buildOptimisticTeamPokemon(
     nature: "Serious",
     nickname: null,
     notes: null,
-    held_item: null,
+    held_item: heldItem ?? null,
     tera_type: null,
     gender: null,
     is_shiny: false,
@@ -460,7 +466,8 @@ export function TeamWorkspaceV2({
             buildOptimisticTeamPokemon(
               action.species,
               action.position,
-              action.tempId
+              action.tempId,
+              action.heldItem
             ),
           ];
         }
@@ -514,18 +521,29 @@ export function TeamWorkspaceV2({
     // editors; nature defaults to the neutral "Serious" so the row
     // validates immediately. Serious is the canonical neutral nature in
     // the picker (Hardy/Docile/Bashful/Quirky are hidden as duplicates).
+
+    // Auto-attach mega stone when adding a mega species.
+    const megaStone = getMegaStoneForSpecies(speciesId);
+
     const pokemon: TablesInsert<"pokemon"> = {
       species: speciesId,
       ability: "",
       move1: "",
       nature: "Serious",
+      ...(megaStone ? { held_item: megaStone } : {}),
     };
     // Generate the temp id here, not in the reducer — the reducer must be
     // pure across React's reconciliation re-invocations.
     const tempId = nextOptimisticIdRef.current--;
 
     startTransition(async () => {
-      applyOptimistic({ kind: "add", position, species: speciesId, tempId });
+      applyOptimistic({
+        kind: "add",
+        position,
+        species: speciesId,
+        tempId,
+        heldItem: megaStone,
+      });
       const result = await persistence.addPokemon(team.id, pokemon, position);
       if (!result.success) {
         toast.error(result.error ?? "Failed to add Pokémon.");
@@ -743,14 +761,14 @@ export function TeamWorkspaceV2({
                     >
                       <div className="flex h-full flex-col overflow-hidden">
                         <header className="flex items-center gap-2 px-3 py-2">
-                          <span className="text-primary font-mono text-[10px] font-bold tracking-wider uppercase">
+                          <span className="text-primary flex-1 text-center font-mono text-[10px] font-bold tracking-wider uppercase">
                             Speed Tiers
                           </span>
                           <button
                             type="button"
                             onClick={() => state.setSideDrawer(null)}
                             aria-label="Close speed tiers"
-                            className="text-muted-foreground hover:text-foreground ml-auto flex size-5 items-center justify-center rounded transition-colors"
+                            className="text-muted-foreground hover:text-foreground flex size-5 items-center justify-center rounded transition-colors"
                           >
                             ×
                           </button>
@@ -790,15 +808,13 @@ export function TeamWorkspaceV2({
                                     (a) => a.id === altId
                                   );
                                   if (!targetAlt) return;
-                                  const result =
-                                    await transferTeam(
-                                      team.id,
-                                      altId
-                                    );
+                                  const result = await transferTeam(
+                                    team.id,
+                                    altId
+                                  );
                                   if (!result.success) {
                                     toast.error(
-                                      result.error ??
-                                        "Failed to transfer team."
+                                      result.error ?? "Failed to transfer team."
                                     );
                                     return;
                                   }
@@ -813,10 +829,9 @@ export function TeamWorkspaceV2({
                         }
                         format={format}
                         onFormatChange={async (formatId) => {
-                          const result = await persistence.updateTeam(
-                            team.id,
-                            { format: formatId }
-                          );
+                          const result = await persistence.updateTeam(team.id, {
+                            format: formatId,
+                          });
                           if (!result.success) {
                             toast.error(
                               result.error ?? "Failed to update format."
@@ -941,11 +956,10 @@ export function TeamWorkspaceV2({
                                   (a) => a.id === altId
                                 );
                                 if (!targetAlt) return;
-                                const result =
-                                  await transferTeam(
-                                    team.id,
-                                    altId
-                                  );
+                                const result = await transferTeam(
+                                  team.id,
+                                  altId
+                                );
                                 if (!result.success) {
                                   toast.error(
                                     result.error ?? "Failed to transfer team."

--- a/apps/web/src/components/team-builder/team-workspace.tsx
+++ b/apps/web/src/components/team-builder/team-workspace.tsx
@@ -933,7 +933,7 @@ export function TeamWorkspaceV2({
                       id="damage-calc"
                       defaultSize={`${state.rightWidthPx}px`}
                       minSize="280px"
-                      maxSize="800px"
+                      maxSize="500px"
                       onResize={(size) => {
                         state.setRightWidthPx(size.inPixels);
                       }}

--- a/apps/web/src/components/team-builder/topbar.tsx
+++ b/apps/web/src/components/team-builder/topbar.tsx
@@ -19,6 +19,28 @@ import { TeamLayoutToggle } from "./team-layout-toggle";
 import { ValidationPopover } from "./validation/validation-popover";
 
 // =============================================================================
+// Shared Icons
+// =============================================================================
+
+const SaveIcon = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="size-4"
+    aria-hidden="true"
+  >
+    <path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" />
+    <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" />
+    <path d="M7 3v4a1 1 0 0 0 1 1h7" />
+  </svg>
+);
+
+// =============================================================================
 // Props
 // =============================================================================
 
@@ -184,21 +206,7 @@ export function Topbar({
                 aria-label={isSaving ? "Saving…" : "Save to account"}
                 className="text-muted-foreground hover:text-primary disabled:text-muted-foreground/40 flex size-7 items-center justify-center rounded-md transition-colors"
               >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="size-4"
-                  aria-hidden="true"
-                >
-                  <path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" />
-                  <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" />
-                  <path d="M7 3v4a1 1 0 0 0 1 1h7" />
-                </svg>
+                {SaveIcon}
               </button>
             ) : (
               <Link
@@ -206,21 +214,7 @@ export function Topbar({
                 aria-label="Sign in to save"
                 className="text-muted-foreground hover:text-primary flex size-7 items-center justify-center rounded-md transition-colors"
               >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="size-4"
-                  aria-hidden="true"
-                >
-                  <path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" />
-                  <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" />
-                  <path d="M7 3v4a1 1 0 0 0 1 1h7" />
-                </svg>
+                {SaveIcon}
               </Link>
             )
           )}

--- a/apps/web/src/components/team-builder/topbar.tsx
+++ b/apps/web/src/components/team-builder/topbar.tsx
@@ -173,8 +173,57 @@ export function Topbar({
     <>
       {/* Center: Team name (absolutely centered) */}
       <div className="pointer-events-none absolute inset-x-0 flex items-center justify-center">
-        <div className="pointer-events-auto">
+        <div className="pointer-events-auto flex items-center gap-1.5">
           <EditableName defaultValue={team.name} onSave={onNameChange} />
+          {isLocalMode && (
+            onSaveToAccount ? (
+              <button
+                type="button"
+                onClick={onSaveToAccount}
+                disabled={isSaving}
+                aria-label={isSaving ? "Saving…" : "Save to account"}
+                className="text-muted-foreground hover:text-primary disabled:text-muted-foreground/40 flex size-7 items-center justify-center rounded-md transition-colors"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="size-4"
+                  aria-hidden="true"
+                >
+                  <path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" />
+                  <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" />
+                  <path d="M7 3v4a1 1 0 0 0 1 1h7" />
+                </svg>
+              </button>
+            ) : (
+              <Link
+                href={`/sign-in?redirect=${encodeURIComponent(signInRedirectPath ?? "/builder?action=save")}`}
+                aria-label="Sign in to save"
+                className="text-muted-foreground hover:text-primary flex size-7 items-center justify-center rounded-md transition-colors"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="size-4"
+                  aria-hidden="true"
+                >
+                  <path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" />
+                  <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" />
+                  <path d="M7 3v4a1 1 0 0 0 1 1h7" />
+                </svg>
+              </Link>
+            )
+          )}
         </div>
       </div>
 
@@ -229,27 +278,7 @@ export function Topbar({
             />
           </PopoverContent>
         </Popover>
-        {isLocalMode ? (
-          onSaveToAccount ? (
-            <Button
-              size="sm"
-              onClick={onSaveToAccount}
-              disabled={isSaving}
-              className="h-7 px-2.5 text-xs sm:h-8 sm:px-3 sm:text-sm"
-            >
-              {isSaving ? "Saving..." : "Save to account"}
-            </Button>
-          ) : (
-            <Link
-              href={`/sign-in?redirect=${encodeURIComponent(signInRedirectPath ?? "/builder?action=save")}`}
-              className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-7 items-center gap-1.5 rounded-md px-2.5 text-xs font-medium shadow-xs transition-colors sm:h-8 sm:px-3 sm:text-sm"
-            >
-              Sign in to save
-            </Link>
-          )
-        ) : (
-          <NotificationsPopover />
-        )}
+        {isLocalMode ? null : <NotificationsPopover />}
       </div>
     </>
   );

--- a/apps/web/src/components/team-builder/use-builder-state.ts
+++ b/apps/web/src/components/team-builder/use-builder-state.ts
@@ -171,7 +171,7 @@ const DEFAULT_FIELD: FieldState = {
 export function useBuilderState(): BuilderState {
   const [activeIdx, setActiveIdx] = useState(0);
   const [sideDrawer, setSideDrawer] = useState<SideDrawerKey>("speed");
-  const [rightDrawer, setRightDrawer] = useState<RightDrawerKey>(null);
+  const [rightDrawer, setRightDrawer] = useState<RightDrawerKey>("calc");
   const [bottomDrawer, setBottomDrawer] = useState<BottomDrawerKey>(null);
 
   const [panelHeightPct, setPanelHeightPctState] = useState<number>(

--- a/apps/web/src/components/team-builder/use-builder-state.ts
+++ b/apps/web/src/components/team-builder/use-builder-state.ts
@@ -118,7 +118,7 @@ function clampSideWidth(n: number): number {
 const RIGHT_WIDTH_STORAGE_KEY = "trainersgg.builder.rightWidthPx.v1";
 const DEFAULT_RIGHT_WIDTH_PX = 380;
 const MIN_RIGHT_WIDTH_PX = 280;
-const MAX_RIGHT_WIDTH_PX = 800;
+const MAX_RIGHT_WIDTH_PX = 500;
 
 function clampRightWidth(n: number): number {
   if (Number.isNaN(n)) return DEFAULT_RIGHT_WIDTH_PX;

--- a/apps/web/src/lib/supabase/client.ts
+++ b/apps/web/src/lib/supabase/client.ts
@@ -1,10 +1,16 @@
 import { createBrowserClient } from "@supabase/ssr";
 import type { Database } from "@trainers/supabase/types";
+import { COOKIE_DOMAIN } from "@trainers/supabase";
 
 export function createClient() {
   return createBrowserClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookieOptions: {
+        domain: COOKIE_DOMAIN,
+      },
+    }
   );
 }
 

--- a/apps/web/src/lib/supabase/middleware.ts
+++ b/apps/web/src/lib/supabase/middleware.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
+import { COOKIE_DOMAIN } from "@trainers/supabase";
 
 /**
  * Cookie domain for cross-subdomain auth (builder.trainers.gg, dashboard.trainers.gg).

--- a/apps/web/src/lib/supabase/middleware.ts
+++ b/apps/web/src/lib/supabase/middleware.ts
@@ -1,6 +1,15 @@
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
 
+/**
+ * Cookie domain for cross-subdomain auth (builder.trainers.gg, dashboard.trainers.gg).
+ * Leading dot makes cookies available to all subdomains of trainers.gg.
+ * Undefined in local dev / preview deploys so cookies use browser defaults.
+ */
+const COOKIE_DOMAIN = process.env.NEXT_PUBLIC_SITE_URL?.includes("trainers.gg")
+  ? ".trainers.gg"
+  : undefined;
+
 export function createClient(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
     request: { headers: request.headers },
@@ -10,6 +19,9 @@ export function createClient(request: NextRequest) {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
+      cookieOptions: {
+        domain: COOKIE_DOMAIN,
+      },
       cookies: {
         getAll() {
           return request.cookies.getAll();
@@ -17,7 +29,10 @@ export function createClient(request: NextRequest) {
         setAll(cookiesToSet) {
           cookiesToSet.forEach(({ name, value, options }) => {
             request.cookies.set(name, value);
-            supabaseResponse.cookies.set(name, value, options);
+            supabaseResponse.cookies.set(name, value, {
+              ...options,
+              domain: COOKIE_DOMAIN ?? options?.domain,
+            });
           });
         },
       },

--- a/apps/web/src/lib/supabase/middleware.ts
+++ b/apps/web/src/lib/supabase/middleware.ts
@@ -2,15 +2,6 @@ import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
 import { COOKIE_DOMAIN } from "@trainers/supabase";
 
-/**
- * Cookie domain for cross-subdomain auth (builder.trainers.gg, dashboard.trainers.gg).
- * Leading dot makes cookies available to all subdomains of trainers.gg.
- * Undefined in local dev / preview deploys so cookies use browser defaults.
- */
-const COOKIE_DOMAIN = process.env.NEXT_PUBLIC_SITE_URL?.includes("trainers.gg")
-  ? ".trainers.gg"
-  : undefined;
-
 export function createClient(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
     request: { headers: request.headers },

--- a/apps/web/src/lib/supabase/server.ts
+++ b/apps/web/src/lib/supabase/server.ts
@@ -3,6 +3,7 @@ import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
 import type { Database } from "@trainers/supabase/types";
 import type { AtprotoDatabase } from "@trainers/supabase";
+import { COOKIE_DOMAIN } from "@trainers/supabase";
 import type { User } from "@supabase/supabase-js";
 
 /**
@@ -23,6 +24,9 @@ export async function createClient() {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
+      cookieOptions: {
+        domain: COOKIE_DOMAIN,
+      },
       cookies: {
         getAll() {
           return cookieStore.getAll();
@@ -30,7 +34,10 @@ export async function createClient() {
         setAll(cookiesToSet) {
           try {
             cookiesToSet.forEach(({ name, value, options }) => {
-              cookieStore.set(name, value, options);
+              cookieStore.set(name, value, {
+                ...options,
+                domain: COOKIE_DOMAIN ?? options?.domain,
+              });
             });
           } catch (error) {
             console.warn("Failed to set cookies in Server Component:", error);
@@ -163,6 +170,9 @@ export async function createAtprotoClient() {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
+      cookieOptions: {
+        domain: COOKIE_DOMAIN,
+      },
       cookies: {
         getAll() {
           return cookieStore.getAll();
@@ -170,7 +180,10 @@ export async function createAtprotoClient() {
         setAll(cookiesToSet) {
           try {
             cookiesToSet.forEach(({ name, value, options }) => {
-              cookieStore.set(name, value, options);
+              cookieStore.set(name, value, {
+                ...options,
+                domain: COOKIE_DOMAIN ?? options?.domain,
+              });
             });
           } catch (error) {
             console.warn("Failed to set cookies in Server Component:", error);

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -49,6 +49,32 @@ const subdomainRewriteMap: Record<string, string> = {
   "dashboard.trainers.gg": "/dashboard",
 };
 
+/** Paths that bypass subdomain rewriting — served as root-level routes even on subdomains. */
+const SUBDOMAIN_EXEMPT_PATHS = ["/sign-in", "/sign-up"];
+
+function isSubdomainExempt(pathname: string): boolean {
+  return SUBDOMAIN_EXEMPT_PATHS.some(
+    (p) => pathname === p || pathname.startsWith(`${p}/`)
+  );
+}
+
+/**
+ * Create a redirect URL that accounts for subdomain rewriting.
+ * When on a subdomain, strips the rewrite base prefix from the target path
+ * so the subdomain rewrite doesn't double-prefix it.
+ */
+function createSubdomainAwareUrl(
+  request: NextRequest,
+  targetPath: string,
+  rewriteBase: string | undefined
+): URL {
+  if (rewriteBase && targetPath.startsWith(rewriteBase)) {
+    const stripped = targetPath.slice(rewriteBase.length) || "/";
+    return new URL(stripped, request.url);
+  }
+  return new URL(targetPath, request.url);
+}
+
 /**
  * If the request came in on a mapped subdomain, rewrite the response to the
  * effective path and copy session-refresh cookies from the auth response.
@@ -85,9 +111,12 @@ export default async function proxy(request: NextRequest) {
   // Determine if this is a subdomain request that needs rewriting.
   // We compute the effective pathname so all auth/route checks run against
   // the intended destination (e.g. dashboard.trainers.gg/ → /dashboard).
+  // Auth paths (/sign-in, /sign-up) are exempt from rewriting to prevent
+  // redirect loops (e.g. dashboard.trainers.gg/sign-in → /dashboard/sign-in → protected → loop).
   const hostname = request.headers.get("host")?.replace(/:\d+$/, "") ?? "";
   const rewriteBase = subdomainRewriteMap[hostname];
-  const effectivePathname = rewriteBase
+  const shouldRewrite = rewriteBase && !isSubdomainExempt(pathname);
+  const effectivePathname = shouldRewrite
     ? `${rewriteBase}${pathname === "/" ? "" : pathname}`
     : pathname;
 
@@ -209,13 +238,16 @@ export default async function proxy(request: NextRequest) {
     user &&
     (effectivePathname === "/sign-in" || effectivePathname === "/sign-up")
   ) {
-    return NextResponse.redirect(new URL("/dashboard", request.url));
+    return NextResponse.redirect(
+      createSubdomainAwareUrl(request, "/dashboard", rewriteBase)
+    );
   }
 
   // Protected routes always require authentication
   if (!user && isProtectedRoute(effectivePathname)) {
     const signInUrl = new URL("/sign-in", request.url);
-    signInUrl.searchParams.set("redirect", effectivePathname);
+    // Use raw pathname on subdomains (the rewrite will re-add the prefix after auth)
+    signInUrl.searchParams.set("redirect", rewriteBase ? pathname : effectivePathname);
     return NextResponse.redirect(signInUrl);
   }
 
@@ -226,7 +258,9 @@ export default async function proxy(request: NextRequest) {
     !isOnboardingExempt(effectivePathname) &&
     needsOnboarding(user.user_metadata?.username)
   ) {
-    return NextResponse.redirect(new URL("/dashboard/onboarding", request.url));
+    return NextResponse.redirect(
+      createSubdomainAwareUrl(request, "/dashboard/onboarding", rewriteBase)
+    );
   }
 
   // Reverse gate: if user is on /dashboard/onboarding but already has a
@@ -236,10 +270,17 @@ export default async function proxy(request: NextRequest) {
     effectivePathname.startsWith("/dashboard/onboarding") &&
     !needsOnboarding(user.user_metadata?.username)
   ) {
-    return NextResponse.redirect(new URL("/dashboard/overview", request.url));
+    return NextResponse.redirect(
+      createSubdomainAwareUrl(request, "/dashboard/overview", rewriteBase)
+    );
   }
 
-  return applyRewrite(request, rewriteBase, pathname, response);
+  return applyRewrite(
+    request,
+    shouldRewrite ? rewriteBase : undefined,
+    pathname,
+    response
+  );
 }
 
 export const config = {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -76,7 +76,18 @@ function createSubdomainAwareUrl(
 }
 
 /**
- * If the request came in on a mapped subdomain, rewrite the response to the
+ * Compute the rewritten pathname, guarding against double-prefixing.
+ * e.g. dashboard.trainers.gg/dashboard/teams → /dashboard/teams (not /dashboard/dashboard/teams)
+ */
+function getRewrittenPath(rewriteBase: string, pathname: string): string {
+  if (pathname === "/" || pathname === rewriteBase) return rewriteBase;
+  return pathname.startsWith(`${rewriteBase}/`)
+    ? pathname
+    : `${rewriteBase}${pathname}`;
+}
+
+/**
+ * When the request matches a subdomain host, rewrite the URL to the mapped
  * effective path and copy session-refresh cookies from the auth response.
  * Otherwise, return the auth response as-is.
  */
@@ -89,18 +100,13 @@ function applyRewrite(
   if (!rewriteBase) return response;
 
   const url = request.nextUrl.clone();
-  // Guard against double-prefixing (e.g., links like /dashboard/teams on dashboard.trainers.gg)
-  url.pathname =
-    pathname === "/" || pathname === rewriteBase
-      ? rewriteBase
-      : pathname.startsWith(`${rewriteBase}/`)
-        ? pathname
-        : `${rewriteBase}${pathname}`;
+  url.pathname = getRewrittenPath(rewriteBase, pathname);
   const rewrite = NextResponse.rewrite(url);
 
-  // Carry response headers (e.g., x-impersonation-session) — skip set-cookie
+  // Carry response headers (e.g., x-impersonation-session) — skip set-cookie and internal x-middleware-* headers
   for (const [name, value] of response.headers.entries()) {
-    if (name.toLowerCase() !== "set-cookie") {
+    const lower = name.toLowerCase();
+    if (lower !== "set-cookie" && !lower.startsWith("x-middleware-")) {
       rewrite.headers.set(name, value);
     }
   }
@@ -129,13 +135,10 @@ export default async function proxy(request: NextRequest) {
   const hostname = request.headers.get("host")?.replace(/:\d+$/, "") ?? "";
   const rewriteBase = subdomainRewriteMap[hostname];
   const shouldRewrite = rewriteBase && !isSubdomainExempt(pathname);
-  const effectivePathname = shouldRewrite
-    ? pathname === "/" || pathname === rewriteBase
-      ? rewriteBase
-      : pathname.startsWith(`${rewriteBase}/`)
-        ? pathname
-        : `${rewriteBase}${pathname}`
-    : pathname;
+  const effectivePathname =
+    shouldRewrite && rewriteBase
+      ? getRewrittenPath(rewriteBase, pathname)
+      : pathname;
 
   // Create Supabase client and refresh session
   const { supabase, response } = createClient(request);

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -89,8 +89,21 @@ function applyRewrite(
   if (!rewriteBase) return response;
 
   const url = request.nextUrl.clone();
-  url.pathname = `${rewriteBase}${pathname === "/" ? "" : pathname}`;
+  // Guard against double-prefixing (e.g., links like /dashboard/teams on dashboard.trainers.gg)
+  url.pathname =
+    pathname === "/" || pathname === rewriteBase
+      ? rewriteBase
+      : pathname.startsWith(`${rewriteBase}/`)
+        ? pathname
+        : `${rewriteBase}${pathname}`;
   const rewrite = NextResponse.rewrite(url);
+
+  // Carry response headers (e.g., x-impersonation-session) — skip set-cookie
+  for (const [name, value] of response.headers.entries()) {
+    if (name.toLowerCase() !== "set-cookie") {
+      rewrite.headers.set(name, value);
+    }
+  }
 
   // Carry session-refresh cookies from the Supabase middleware response
   for (const cookie of response.cookies.getAll()) {
@@ -117,7 +130,11 @@ export default async function proxy(request: NextRequest) {
   const rewriteBase = subdomainRewriteMap[hostname];
   const shouldRewrite = rewriteBase && !isSubdomainExempt(pathname);
   const effectivePathname = shouldRewrite
-    ? `${rewriteBase}${pathname === "/" ? "" : pathname}`
+    ? pathname === "/" || pathname === rewriteBase
+      ? rewriteBase
+      : pathname.startsWith(`${rewriteBase}/`)
+        ? pathname
+        : `${rewriteBase}${pathname}`
     : pathname;
 
   // Create Supabase client and refresh session

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -42,11 +42,37 @@ import {
  *    - See isOnboardingExempt() in proxy-routes.ts for the exemption list
  */
 
-// Subdomain rewrites: <sub>.trainers.gg → /<sub>/*
+// Auth/onboarding/admin checks run against the effective (rewritten) path,
+// so subdomain requests receive the same protection as direct path access.
 const subdomainRewriteMap: Record<string, string> = {
   "builder.trainers.gg": "/builder",
   "dashboard.trainers.gg": "/dashboard",
 };
+
+/**
+ * If the request came in on a mapped subdomain, rewrite the response to the
+ * effective path and copy session-refresh cookies from the auth response.
+ * Otherwise, return the auth response as-is.
+ */
+function applyRewrite(
+  request: NextRequest,
+  rewriteBase: string | undefined,
+  pathname: string,
+  response: NextResponse
+): NextResponse {
+  if (!rewriteBase) return response;
+
+  const url = request.nextUrl.clone();
+  url.pathname = `${rewriteBase}${pathname === "/" ? "" : pathname}`;
+  const rewrite = NextResponse.rewrite(url);
+
+  // Carry session-refresh cookies from the Supabase middleware response
+  for (const cookie of response.cookies.getAll()) {
+    rewrite.cookies.set(cookie);
+  }
+
+  return rewrite;
+}
 
 export default async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -56,13 +82,14 @@ export default async function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
-  const hostname = request.headers.get("host") ?? "";
+  // Determine if this is a subdomain request that needs rewriting.
+  // We compute the effective pathname so all auth/route checks run against
+  // the intended destination (e.g. dashboard.trainers.gg/ → /dashboard).
+  const hostname = request.headers.get("host")?.replace(/:\d+$/, "") ?? "";
   const rewriteBase = subdomainRewriteMap[hostname];
-  if (rewriteBase) {
-    const url = request.nextUrl.clone();
-    url.pathname = `${rewriteBase}${pathname === "/" ? "" : pathname}`;
-    return NextResponse.rewrite(url);
-  }
+  const effectivePathname = rewriteBase
+    ? `${rewriteBase}${pathname === "/" ? "" : pathname}`
+    : pathname;
 
   // Create Supabase client and refresh session
   const { supabase, response } = createClient(request);
@@ -86,10 +113,10 @@ export default async function proxy(request: NextRequest) {
   }
 
   // Admin routes require site_admin role in JWT AND active sudo mode
-  if (isAdminRoute(pathname)) {
+  if (isAdminRoute(effectivePathname)) {
     // Allow sudo-required page without sudo check (would cause infinite redirect)
-    if (pathname === "/admin/sudo-required") {
-      return response;
+    if (effectivePathname === "/admin/sudo-required") {
+      return applyRewrite(request, rewriteBase, pathname, response);
     }
 
     if (!user) {
@@ -137,7 +164,7 @@ export default async function proxy(request: NextRequest) {
     }
 
     // Admin routes always use the admin's real identity — no impersonation header
-    return response;
+    return applyRewrite(request, rewriteBase, pathname, response);
   }
 
   // === IMPERSONATION ===
@@ -163,8 +190,9 @@ export default async function proxy(request: NextRequest) {
           ) as { site_roles?: string[] };
           isAdmin = payload?.site_roles?.includes("site_admin") ?? false;
         }
-      } catch {
+      } catch (error) {
         // If JWT parsing fails, don't propagate impersonation
+        console.error("[proxy] Failed to decode impersonation JWT:", error);
       }
 
       if (isAdmin) {
@@ -177,14 +205,17 @@ export default async function proxy(request: NextRequest) {
   }
 
   // Authenticated users on auth pages should go to the dashboard
-  if (user && (pathname === "/sign-in" || pathname === "/sign-up")) {
+  if (
+    user &&
+    (effectivePathname === "/sign-in" || effectivePathname === "/sign-up")
+  ) {
     return NextResponse.redirect(new URL("/dashboard", request.url));
   }
 
   // Protected routes always require authentication
-  if (!user && isProtectedRoute(pathname)) {
+  if (!user && isProtectedRoute(effectivePathname)) {
     const signInUrl = new URL("/sign-in", request.url);
-    signInUrl.searchParams.set("redirect", pathname);
+    signInUrl.searchParams.set("redirect", effectivePathname);
     return NextResponse.redirect(signInUrl);
   }
 
@@ -192,7 +223,7 @@ export default async function proxy(request: NextRequest) {
   // Applies to ALL routes except auth flows, API, and the onboarding page itself
   if (
     user &&
-    !isOnboardingExempt(pathname) &&
+    !isOnboardingExempt(effectivePathname) &&
     needsOnboarding(user.user_metadata?.username)
   ) {
     return NextResponse.redirect(new URL("/dashboard/onboarding", request.url));
@@ -202,13 +233,13 @@ export default async function proxy(request: NextRequest) {
   // permanent username, redirect them to the dashboard
   if (
     user &&
-    pathname.startsWith("/dashboard/onboarding") &&
+    effectivePathname.startsWith("/dashboard/onboarding") &&
     !needsOnboarding(user.user_metadata?.username)
   ) {
     return NextResponse.redirect(new URL("/dashboard/overview", request.url));
   }
 
-  return response;
+  return applyRewrite(request, rewriteBase, pathname, response);
 }
 
 export const config = {

--- a/packages/supabase/src/__tests__/constants.test.ts
+++ b/packages/supabase/src/__tests__/constants.test.ts
@@ -4,6 +4,68 @@ import {
   getInvitationExpiryDate,
 } from "../constants";
 
+// =============================================================================
+// COOKIE_DOMAIN tests — use dynamic require to test env var behavior
+// =============================================================================
+
+describe("COOKIE_DOMAIN", () => {
+  const originalEnv = process.env.NEXT_PUBLIC_SITE_URL;
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.NEXT_PUBLIC_SITE_URL = originalEnv;
+    } else {
+      delete process.env.NEXT_PUBLIC_SITE_URL;
+    }
+    jest.resetModules();
+  });
+
+  it("returns '.trainers.gg' when NEXT_PUBLIC_SITE_URL contains trainers.gg", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "https://trainers.gg";
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { COOKIE_DOMAIN } = require("../constants");
+    expect(COOKIE_DOMAIN).toBe(".trainers.gg");
+  });
+
+  it("returns '.trainers.gg' for subdomain URLs", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "https://builder.trainers.gg";
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { COOKIE_DOMAIN } = require("../constants");
+    expect(COOKIE_DOMAIN).toBe(".trainers.gg");
+  });
+
+  it("returns undefined for localhost", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "http://localhost:3000";
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { COOKIE_DOMAIN } = require("../constants");
+    expect(COOKIE_DOMAIN).toBeUndefined();
+  });
+
+  it("returns undefined when NEXT_PUBLIC_SITE_URL is not set", () => {
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { COOKIE_DOMAIN } = require("../constants");
+    expect(COOKIE_DOMAIN).toBeUndefined();
+  });
+
+  it("returns undefined for Vercel preview URLs", () => {
+    process.env.NEXT_PUBLIC_SITE_URL =
+      "https://trainers-gg-git-fix-branch.vercel.app";
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { COOKIE_DOMAIN } = require("../constants");
+    expect(COOKIE_DOMAIN).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// Invitation constants tests
+// =============================================================================
+
 describe("INVITATION_EXPIRY_DAYS", () => {
   it("equals 7", () => {
     expect(INVITATION_EXPIRY_DAYS).toBe(7);

--- a/packages/supabase/src/clients/base/browser-client.ts
+++ b/packages/supabase/src/clients/base/browser-client.ts
@@ -12,15 +12,6 @@ import type { TypedSupabaseClient } from "../../client";
 import { COOKIE_DOMAIN } from "../../constants";
 
 /**
- * Cookie domain for cross-subdomain auth (builder.trainers.gg, dashboard.trainers.gg).
- * Leading dot makes cookies available to all subdomains of trainers.gg.
- * Undefined in local dev / preview deploys so cookies use browser defaults.
- */
-const COOKIE_DOMAIN = process.env.NEXT_PUBLIC_SITE_URL?.includes("trainers.gg")
-  ? ".trainers.gg"
-  : undefined;
-
-/**
  * Create a Supabase client for Next.js client-side rendering.
  * Singleton pattern - returns the same instance across the app.
  */

--- a/packages/supabase/src/clients/base/browser-client.ts
+++ b/packages/supabase/src/clients/base/browser-client.ts
@@ -9,6 +9,7 @@
 
 import { createBrowserClient } from "@supabase/ssr";
 import type { TypedSupabaseClient } from "../../client";
+import { COOKIE_DOMAIN } from "../../constants";
 
 /**
  * Cookie domain for cross-subdomain auth (builder.trainers.gg, dashboard.trainers.gg).

--- a/packages/supabase/src/clients/base/browser-client.ts
+++ b/packages/supabase/src/clients/base/browser-client.ts
@@ -11,6 +11,15 @@ import { createBrowserClient } from "@supabase/ssr";
 import type { TypedSupabaseClient } from "../../client";
 
 /**
+ * Cookie domain for cross-subdomain auth (builder.trainers.gg, dashboard.trainers.gg).
+ * Leading dot makes cookies available to all subdomains of trainers.gg.
+ * Undefined in local dev / preview deploys so cookies use browser defaults.
+ */
+const COOKIE_DOMAIN = process.env.NEXT_PUBLIC_SITE_URL?.includes("trainers.gg")
+  ? ".trainers.gg"
+  : undefined;
+
+/**
  * Create a Supabase client for Next.js client-side rendering.
  * Singleton pattern - returns the same instance across the app.
  */
@@ -23,7 +32,12 @@ export function createBrowserSupabaseClient(): TypedSupabaseClient {
 
   browserClient = createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookieOptions: {
+        domain: COOKIE_DOMAIN,
+      },
+    }
   ) as TypedSupabaseClient;
 
   return browserClient;

--- a/packages/supabase/src/clients/base/server-client.ts
+++ b/packages/supabase/src/clients/base/server-client.ts
@@ -12,6 +12,15 @@ import { cookies } from "next/headers";
 import type { TypedSupabaseClient } from "../../client";
 
 /**
+ * Cookie domain for cross-subdomain auth (builder.trainers.gg, dashboard.trainers.gg).
+ * Leading dot makes cookies available to all subdomains of trainers.gg.
+ * Undefined in local dev / preview deploys so cookies use browser defaults.
+ */
+const COOKIE_DOMAIN = process.env.NEXT_PUBLIC_SITE_URL?.includes("trainers.gg")
+  ? ".trainers.gg"
+  : undefined;
+
+/**
  * Create a Supabase client for Next.js server-side rendering.
  * Reads and writes session cookies automatically.
  */
@@ -22,6 +31,9 @@ export async function createServerSupabaseClient(): Promise<TypedSupabaseClient>
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
+      cookieOptions: {
+        domain: COOKIE_DOMAIN,
+      },
       cookies: {
         getAll() {
           return cookieStore.getAll();
@@ -37,7 +49,12 @@ export async function createServerSupabaseClient(): Promise<TypedSupabaseClient>
                 name: string;
                 value: string;
                 options: Record<string, unknown>;
-              }) => cookieStore.set(name, value, options)
+              }) =>
+                cookieStore.set(name, value, {
+                  ...(options as object),
+                  domain:
+                    COOKIE_DOMAIN ?? (options?.domain as string | undefined),
+                } as Parameters<typeof cookieStore.set>[2])
             );
           } catch {
             // Called from Server Component - can't mutate cookies here

--- a/packages/supabase/src/clients/base/server-client.ts
+++ b/packages/supabase/src/clients/base/server-client.ts
@@ -13,15 +13,6 @@ import type { TypedSupabaseClient } from "../../client";
 import { COOKIE_DOMAIN } from "../../constants";
 
 /**
- * Cookie domain for cross-subdomain auth (builder.trainers.gg, dashboard.trainers.gg).
- * Leading dot makes cookies available to all subdomains of trainers.gg.
- * Undefined in local dev / preview deploys so cookies use browser defaults.
- */
-const COOKIE_DOMAIN = process.env.NEXT_PUBLIC_SITE_URL?.includes("trainers.gg")
-  ? ".trainers.gg"
-  : undefined;
-
-/**
  * Create a Supabase client for Next.js server-side rendering.
  * Reads and writes session cookies automatically.
  */

--- a/packages/supabase/src/clients/base/server-client.ts
+++ b/packages/supabase/src/clients/base/server-client.ts
@@ -10,6 +10,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import type { TypedSupabaseClient } from "../../client";
+import { COOKIE_DOMAIN } from "../../constants";
 
 /**
  * Cookie domain for cross-subdomain auth (builder.trainers.gg, dashboard.trainers.gg).

--- a/packages/supabase/src/constants.ts
+++ b/packages/supabase/src/constants.ts
@@ -33,6 +33,19 @@ function deriveCookieDomain(): string | undefined {
 
 export const COOKIE_DOMAIN: string | undefined = deriveCookieDomain();
 
+// Warn if running in production without cross-subdomain cookies configured
+if (
+  typeof process !== "undefined" &&
+  process.env.NODE_ENV === "production" &&
+  !COOKIE_DOMAIN
+) {
+  console.warn(
+    "[supabase] COOKIE_DOMAIN is undefined in production. " +
+      "Cross-subdomain auth will not work. " +
+      "Ensure NEXT_PUBLIC_SITE_URL contains 'trainers.gg'."
+  );
+}
+
 // =============================================================================
 // Invitations
 // =============================================================================

--- a/packages/supabase/src/constants.ts
+++ b/packages/supabase/src/constants.ts
@@ -25,7 +25,11 @@ function deriveCookieDomain(): string | undefined {
       return ".trainers.gg";
     }
   } catch {
-    // Invalid URL — fall through to undefined
+    // Invalid URL — log for visibility but fall through to undefined
+    console.warn(
+      "[supabase] Invalid NEXT_PUBLIC_SITE_URL, cannot derive cookie domain:",
+      siteUrl
+    );
   }
 
   return undefined;

--- a/packages/supabase/src/constants.ts
+++ b/packages/supabase/src/constants.ts
@@ -2,6 +2,41 @@
  * Constants for the Supabase backend package
  */
 
+// =============================================================================
+// Cookie Domain (cross-subdomain auth)
+// =============================================================================
+
+/**
+ * Derive the cookie domain from NEXT_PUBLIC_SITE_URL using strict hostname parsing.
+ * Returns ".trainers.gg" in production so cookies are shared across subdomains
+ * (builder.trainers.gg, dashboard.trainers.gg). Returns undefined in local dev
+ * and preview deploys so cookies use browser defaults.
+ */
+function deriveCookieDomain(): string | undefined {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+  if (!siteUrl) return undefined;
+
+  try {
+    const { hostname } = new URL(siteUrl);
+    if (
+      hostname === "trainers.gg" ||
+      hostname.endsWith(".trainers.gg")
+    ) {
+      return ".trainers.gg";
+    }
+  } catch {
+    // Invalid URL — fall through to undefined
+  }
+
+  return undefined;
+}
+
+export const COOKIE_DOMAIN: string | undefined = deriveCookieDomain();
+
+// =============================================================================
+// Invitations
+// =============================================================================
+
 /**
  * Number of days before an invitation expires
  */

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -40,6 +40,9 @@ export {
   type CheckInOpenResult,
 } from "./utils/registration";
 
+// Constants
+export { COOKIE_DOMAIN } from "./constants";
+
 // Storage exports
 export {
   STORAGE_BUCKETS,


### PR DESCRIPTION
## Summary

Major overhaul of the team builder experience: redesigned speed tiers panel, weather state sync between calc and speed tiers, subdomain routing with cross-subdomain auth cookies, builder footer/branding, and hardened local persistence.

## Changes

### Speed Tiers Panel Redesign
- Complete layout and UX overhaul with expanded field controls and modifiers
- Weather state now syncs bidirectionally between the damage calc and speed tiers panels
- Validated weather type conversion (replaces unsafe `as Weather` casts with lookup maps)
- Hoisted `getGroupValue` above `.map()` to avoid per-row function recreation

### Subdomain Routing & Auth
- `builder.trainers.gg` → `/builder`, `dashboard.trainers.gg` → `/dashboard`
- Rewrites run **after** auth/onboarding/admin checks (defense-in-depth)
- Session-refresh cookies carried onto rewrite responses
- Port suffixes stripped from Host header for matching
- Cross-subdomain auth cookies via extracted `COOKIE_DOMAIN` constant
- `deriveCookieDomain()` utility shared across browser/server Supabase clients

### Local Builder Improvements
- Prevent concurrent auth lock contention (uses `user.id` directly instead of redundant `getUser()`)
- Replace deprecated `getCurrentUserAlts` with `getAltsByUserId`
- Extract `dedupeTeamPokemon` helper (eliminates 20 lines of duplication)
- Millisecond-precision IDs for localStorage hydration (reduces HMR collision)
- `fetchingRef` reset on unmount to prevent StrictMode lockout
- `logError` + toast for localStorage write/read/clear failures
- `getErrorMessage()` for save/load error toasts (structured error info)
- User null guard in `handleSaveToAccount` (removes non-null assertions)
- Missing useEffect deps fixed (stale closure risk)

### Builder Topbar & Footer
- Save-to-account / Sign-in actions moved inline next to the team name
- Extracted `SaveIcon` constant (DRY across builder-topbar and topbar)
- Full-width footer with Beanie logo integrated into builder dockbar

### Heatmap Panel
- Consistent 6-row grid with placeholder slots and "Add Pokémon…" cue
- Stable keys using absolute slot index (not relative array index)

### Security & Quality
- Subdomain rewrite no longer bypasses auth gates
- Impersonation JWT decode catch now logs errors
- `console.warn` in `deriveCookieDomain` catch for invalid URL visibility
- Removed dead `"use client"` directives from test files
- Deleted redundant restating comments

### Test Coverage
- 6 new subdomain rewrite proxy tests (host map hit/miss/port/auth/cookies)
- 4 new weather prop tests for speed tiers panel
- New test suites: builder-topbar, calc-reverse-card, local-builder-workspace, local-persistence, use-local-team-storage
- Cookie domain constants test suite
- +2400 lines of test code

## Files Changed
33 files, +3240 / −833

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded Speed Tiers panel with Field controls (Trick Room, Weather) and comprehensive Modifiers section (EVs, Nature, Stages, etc.)
  * Enhanced Export menu with Copy as Showdown and Open in Pokepaste options
  * Auto-attach Mega Stones to eligible Pokémon when adding to team

* **Improvements**
  * Refined Team Builder layout with improved account controls positioning
  * Fixed heatmap grid display with consistent row structure and placeholder support
  * Enhanced local team persistence with better deduplication and recovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->