### PR TITLE
feat: add builder.trainers.gg subdomain rewrite

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -50,6 +50,14 @@ export default async function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
+  // Subdomain rewrites: builder.trainers.gg → /builder/*
+  const hostname = request.headers.get("host") ?? "";
+  if (hostname === "builder.trainers.gg") {
+    const url = request.nextUrl.clone();
+    url.pathname = `/builder${pathname === "/" ? "" : pathname}`;
+    return NextResponse.rewrite(url);
+  }
+
   // Create Supabase client and refresh session
   const { supabase, response } = createClient(request);
 

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -42,6 +42,12 @@ import {
  *    - See isOnboardingExempt() in proxy-routes.ts for the exemption list
  */
 
+// Subdomain rewrites: <sub>.trainers.gg → /<sub>/*
+const subdomainRewriteMap: Record<string, string> = {
+  "builder.trainers.gg": "/builder",
+  "dashboard.trainers.gg": "/dashboard",
+};
+
 export default async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
@@ -50,12 +56,7 @@ export default async function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // Subdomain rewrites: <sub>.trainers.gg → /<sub>/*
   const hostname = request.headers.get("host") ?? "";
-  const subdomainRewriteMap: Record<string, string> = {
-    "builder.trainers.gg": "/builder",
-    "dashboard.trainers.gg": "/dashboard",
-  };
   const rewriteBase = subdomainRewriteMap[hostname];
   if (rewriteBase) {
     const url = request.nextUrl.clone();

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -50,11 +50,16 @@ export default async function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // Subdomain rewrites: builder.trainers.gg → /builder/*
+  // Subdomain rewrites: <sub>.trainers.gg → /<sub>/*
   const hostname = request.headers.get("host") ?? "";
-  if (hostname === "builder.trainers.gg") {
+  const subdomainRewriteMap: Record<string, string> = {
+    "builder.trainers.gg": "/builder",
+    "dashboard.trainers.gg": "/dashboard",
+  };
+  const rewriteBase = subdomainRewriteMap[hostname];
+  if (rewriteBase) {
     const url = request.nextUrl.clone();
-    url.pathname = `/builder${pathname === "/" ? "" : pathname}`;
+    url.pathname = `${rewriteBase}${pathname === "/" ? "" : pathname}`;
     return NextResponse.rewrite(url);
   }
 


### PR DESCRIPTION
## Summary

- Adds hostname-based rewrite in `proxy.ts` so `builder.trainers.gg` serves content from `/builder/*`
- Enables the team builder to be accessed via its own subdomain once DNS is configured in Vercel

## DNS Setup Required

1. Add CNAME record: `builder` → `cname.vercel-dns.com` in Vercel DNS
2. Add `builder.trainers.gg` as a domain on the Vercel project