### PR TITLE
fix: share auth cookies across subdomains

### DIFF
--- a/apps/web/src/lib/supabase/client.ts
+++ b/apps/web/src/lib/supabase/client.ts
@@ -1,10 +1,16 @@
 import { createBrowserClient } from "@supabase/ssr";
 import type { Database } from "@trainers/supabase/types";
+import { COOKIE_DOMAIN } from "@trainers/supabase";
 
 export function createClient() {
   return createBrowserClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookieOptions: {
+        domain: COOKIE_DOMAIN,
+      },
+    }
   );
 }
 

--- a/apps/web/src/lib/supabase/middleware.ts
+++ b/apps/web/src/lib/supabase/middleware.ts
@@ -1,14 +1,6 @@
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
-
-/**
- * Cookie domain for cross-subdomain auth (builder.trainers.gg, dashboard.trainers.gg).
- * Leading dot makes cookies available to all subdomains of trainers.gg.
- * Undefined in local dev / preview deploys so cookies use browser defaults.
- */
-const COOKIE_DOMAIN = process.env.NEXT_PUBLIC_SITE_URL?.includes("trainers.gg")
-  ? ".trainers.gg"
-  : undefined;
+import { COOKIE_DOMAIN } from "@trainers/supabase";
 
 export function createClient(request: NextRequest) {
   let supabaseResponse = NextResponse.next({

--- a/apps/web/src/lib/supabase/middleware.ts
+++ b/apps/web/src/lib/supabase/middleware.ts
@@ -1,6 +1,15 @@
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
 
+/**
+ * Cookie domain for cross-subdomain auth (builder.trainers.gg, dashboard.trainers.gg).
+ * Leading dot makes cookies available to all subdomains of trainers.gg.
+ * Undefined in local dev / preview deploys so cookies use browser defaults.
+ */
+const COOKIE_DOMAIN = process.env.NEXT_PUBLIC_SITE_URL?.includes("trainers.gg")
+  ? ".trainers.gg"
+  : undefined;
+
 export function createClient(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
     request: { headers: request.headers },
@@ -10,6 +19,9 @@ export function createClient(request: NextRequest) {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
+      cookieOptions: {
+        domain: COOKIE_DOMAIN,
+      },
       cookies: {
         getAll() {
           return request.cookies.getAll();
@@ -17,7 +29,10 @@ export function createClient(request: NextRequest) {
         setAll(cookiesToSet) {
           cookiesToSet.forEach(({ name, value, options }) => {
             request.cookies.set(name, value);
-            supabaseResponse.cookies.set(name, value, options);
+            supabaseResponse.cookies.set(name, value, {
+              ...options,
+              domain: COOKIE_DOMAIN ?? options?.domain,
+            });
           });
         },
       },

--- a/apps/web/src/lib/supabase/server.ts
+++ b/apps/web/src/lib/supabase/server.ts
@@ -3,6 +3,7 @@ import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
 import type { Database } from "@trainers/supabase/types";
 import type { AtprotoDatabase } from "@trainers/supabase";
+import { COOKIE_DOMAIN } from "@trainers/supabase";
 import type { User } from "@supabase/supabase-js";
 
 /**
@@ -23,6 +24,9 @@ export async function createClient() {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
+      cookieOptions: {
+        domain: COOKIE_DOMAIN,
+      },
       cookies: {
         getAll() {
           return cookieStore.getAll();
@@ -30,7 +34,10 @@ export async function createClient() {
         setAll(cookiesToSet) {
           try {
             cookiesToSet.forEach(({ name, value, options }) => {
-              cookieStore.set(name, value, options);
+              cookieStore.set(name, value, {
+                ...options,
+                domain: COOKIE_DOMAIN ?? options?.domain,
+              });
             });
           } catch (error) {
             console.warn("Failed to set cookies in Server Component:", error);
@@ -163,6 +170,9 @@ export async function createAtprotoClient() {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
+      cookieOptions: {
+        domain: COOKIE_DOMAIN,
+      },
       cookies: {
         getAll() {
           return cookieStore.getAll();
@@ -170,7 +180,10 @@ export async function createAtprotoClient() {
         setAll(cookiesToSet) {
           try {
             cookiesToSet.forEach(({ name, value, options }) => {
-              cookieStore.set(name, value, options);
+              cookieStore.set(name, value, {
+                ...options,
+                domain: COOKIE_DOMAIN ?? options?.domain,
+              });
             });
           } catch (error) {
             console.warn("Failed to set cookies in Server Component:", error);

--- a/packages/supabase/src/clients/base/browser-client.ts
+++ b/packages/supabase/src/clients/base/browser-client.ts
@@ -9,15 +9,7 @@
 
 import { createBrowserClient } from "@supabase/ssr";
 import type { TypedSupabaseClient } from "../../client";
-
-/**
- * Cookie domain for cross-subdomain auth (builder.trainers.gg, dashboard.trainers.gg).
- * Leading dot makes cookies available to all subdomains of trainers.gg.
- * Undefined in local dev / preview deploys so cookies use browser defaults.
- */
-const COOKIE_DOMAIN = process.env.NEXT_PUBLIC_SITE_URL?.includes("trainers.gg")
-  ? ".trainers.gg"
-  : undefined;
+import { COOKIE_DOMAIN } from "../../constants";
 
 /**
  * Create a Supabase client for Next.js client-side rendering.

--- a/packages/supabase/src/clients/base/browser-client.ts
+++ b/packages/supabase/src/clients/base/browser-client.ts
@@ -11,6 +11,15 @@ import { createBrowserClient } from "@supabase/ssr";
 import type { TypedSupabaseClient } from "../../client";
 
 /**
+ * Cookie domain for cross-subdomain auth (builder.trainers.gg, dashboard.trainers.gg).
+ * Leading dot makes cookies available to all subdomains of trainers.gg.
+ * Undefined in local dev / preview deploys so cookies use browser defaults.
+ */
+const COOKIE_DOMAIN = process.env.NEXT_PUBLIC_SITE_URL?.includes("trainers.gg")
+  ? ".trainers.gg"
+  : undefined;
+
+/**
  * Create a Supabase client for Next.js client-side rendering.
  * Singleton pattern - returns the same instance across the app.
  */
@@ -23,7 +32,12 @@ export function createBrowserSupabaseClient(): TypedSupabaseClient {
 
   browserClient = createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookieOptions: {
+        domain: COOKIE_DOMAIN,
+      },
+    }
   ) as TypedSupabaseClient;
 
   return browserClient;

--- a/packages/supabase/src/clients/base/server-client.ts
+++ b/packages/supabase/src/clients/base/server-client.ts
@@ -12,6 +12,15 @@ import { cookies } from "next/headers";
 import type { TypedSupabaseClient } from "../../client";
 
 /**
+ * Cookie domain for cross-subdomain auth (builder.trainers.gg, dashboard.trainers.gg).
+ * Leading dot makes cookies available to all subdomains of trainers.gg.
+ * Undefined in local dev / preview deploys so cookies use browser defaults.
+ */
+const COOKIE_DOMAIN = process.env.NEXT_PUBLIC_SITE_URL?.includes("trainers.gg")
+  ? ".trainers.gg"
+  : undefined;
+
+/**
  * Create a Supabase client for Next.js server-side rendering.
  * Reads and writes session cookies automatically.
  */
@@ -22,6 +31,9 @@ export async function createServerSupabaseClient(): Promise<TypedSupabaseClient>
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
+      cookieOptions: {
+        domain: COOKIE_DOMAIN,
+      },
       cookies: {
         getAll() {
           return cookieStore.getAll();
@@ -37,7 +49,12 @@ export async function createServerSupabaseClient(): Promise<TypedSupabaseClient>
                 name: string;
                 value: string;
                 options: Record<string, unknown>;
-              }) => cookieStore.set(name, value, options)
+              }) =>
+                cookieStore.set(name, value, {
+                  ...(options as object),
+                  domain:
+                    COOKIE_DOMAIN ?? (options?.domain as string | undefined),
+                } as Parameters<typeof cookieStore.set>[2])
             );
           } catch {
             // Called from Server Component - can't mutate cookies here

--- a/packages/supabase/src/clients/base/server-client.ts
+++ b/packages/supabase/src/clients/base/server-client.ts
@@ -10,15 +10,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import type { TypedSupabaseClient } from "../../client";
-
-/**
- * Cookie domain for cross-subdomain auth (builder.trainers.gg, dashboard.trainers.gg).
- * Leading dot makes cookies available to all subdomains of trainers.gg.
- * Undefined in local dev / preview deploys so cookies use browser defaults.
- */
-const COOKIE_DOMAIN = process.env.NEXT_PUBLIC_SITE_URL?.includes("trainers.gg")
-  ? ".trainers.gg"
-  : undefined;
+import { COOKIE_DOMAIN } from "../../constants";
 
 /**
  * Create a Supabase client for Next.js server-side rendering.

--- a/packages/supabase/src/constants.ts
+++ b/packages/supabase/src/constants.ts
@@ -2,6 +2,41 @@
  * Constants for the Supabase backend package
  */
 
+// =============================================================================
+// Cookie Domain (cross-subdomain auth)
+// =============================================================================
+
+/**
+ * Derive the cookie domain from NEXT_PUBLIC_SITE_URL using strict hostname parsing.
+ * Returns ".trainers.gg" in production so cookies are shared across subdomains
+ * (builder.trainers.gg, dashboard.trainers.gg). Returns undefined in local dev
+ * and preview deploys so cookies use browser defaults.
+ */
+function deriveCookieDomain(): string | undefined {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+  if (!siteUrl) return undefined;
+
+  try {
+    const { hostname } = new URL(siteUrl);
+    if (
+      hostname === "trainers.gg" ||
+      hostname.endsWith(".trainers.gg")
+    ) {
+      return ".trainers.gg";
+    }
+  } catch {
+    // Invalid URL — fall through to undefined
+  }
+
+  return undefined;
+}
+
+export const COOKIE_DOMAIN: string | undefined = deriveCookieDomain();
+
+// =============================================================================
+// Invitations
+// =============================================================================
+
 /**
  * Number of days before an invitation expires
  */

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -40,6 +40,9 @@ export {
   type CheckInOpenResult,
 } from "./utils/registration";
 
+// Constants
+export { COOKIE_DOMAIN } from "./constants";
+
 // Storage exports
 export {
   STORAGE_BUCKETS,


### PR DESCRIPTION
## Summary

- Sets `cookieOptions.domain` to `.trainers.gg` on all Supabase client creation points (middleware, server, browser) so auth cookies are shared across subdomains
- Fixes `builder.trainers.gg` and `dashboard.trainers.gg` showing users as logged out despite being authenticated on `trainers.gg`
- Conditional on `NEXT_PUBLIC_SITE_URL` — local dev and Vercel preview deploys are unaffected

## Root Cause

Supabase auth cookies were set without an explicit `domain` attribute. Browsers scope such cookies to the exact hostname, so a cookie set on `trainers.gg` is never sent to `builder.trainers.gg` even though it's the same Next.js app doing a rewrite.

## Note

Existing users will need to re-login once after deployment since their current cookies are scoped to the bare `trainers.gg` hostname.