### PR TITLE
fix: mute empty row headers in builder and link beanie logo to X profile

### DIFF
--- a/apps/web/src/app/(marketing)/layout.tsx
+++ b/apps/web/src/app/(marketing)/layout.tsx
@@ -20,13 +20,15 @@ export default function MarketingLayout({
             Freak.
           </p>
           <p className="flex items-center gap-1 whitespace-nowrap">
-            <Image
-              src="/icons/beanie_logo.png"
-              alt="Beanie LLC"
-              width={28}
-              height={28}
-              className="inline-block"
-            />
+            <a href="https://x.com/thatguyinabeani" target="_blank" rel="noopener noreferrer">
+              <Image
+                src="/icons/beanie_logo.png"
+                alt="Beanie LLC"
+                width={28}
+                height={28}
+                className="inline-block"
+              />
+            </a>
             &copy; {new Date().getFullYear()} Beanie LLC
           </p>
         </div>

--- a/apps/web/src/components/team-builder/dock/dockbar.tsx
+++ b/apps/web/src/components/team-builder/dock/dockbar.tsx
@@ -186,13 +186,15 @@ export function Dockbar({
 
       {/* Footer copyright — right side, absolutely positioned */}
       <p className="text-muted-foreground absolute top-1/2 right-3 hidden -translate-y-1/2 items-center gap-1 text-[10px] whitespace-nowrap @[900px]/dock:flex">
-        <Image
-          src="/icons/beanie_logo.png"
-          alt="Beanie LLC"
-          width={28}
-          height={28}
-          className="inline-block"
-        />
+        <a href="https://x.com/thatguyinabeani" target="_blank" rel="noopener noreferrer">
+          <Image
+            src="/icons/beanie_logo.png"
+            alt="Beanie LLC"
+            width={28}
+            height={28}
+            className="inline-block"
+          />
+        </a>
         &copy; {new Date().getFullYear()} Beanie LLC
       </p>
     </div>

--- a/apps/web/src/components/team-builder/lanes/identity/identity-lane-ghost.tsx
+++ b/apps/web/src/components/team-builder/lanes/identity/identity-lane-ghost.tsx
@@ -204,7 +204,7 @@ function FormRowsGhost() {
     <>
       {(["Item", "Abil", "Nat"] as const).map((label) => (
         <div key={label} className={"grid grid-cols-[60px_minmax(0,1fr)] items-center gap-1.5 px-1 py-[3px] rounded cursor-pointer bg-transparent text-left w-full transition-colors hover:bg-muted"}>
-          <span className={"text-[9px] font-bold tracking-[0.08em] uppercase text-muted-foreground font-mono whitespace-nowrap overflow-hidden text-ellipsis shrink-0"}>{label}</span>
+          <span className={"text-[9px] font-bold tracking-[0.08em] uppercase text-muted-foreground/30 font-mono whitespace-nowrap overflow-hidden text-ellipsis shrink-0"}>{label}</span>
           <span className={cn("text-[11.5px] text-foreground overflow-hidden text-ellipsis whitespace-nowrap min-w-0", "text-muted-foreground/25 italic")}>
             —
           </span>
@@ -212,7 +212,7 @@ function FormRowsGhost() {
       ))}
       {/* Type row — two circle placeholders matching TypePill size */}
       <div className={cn("grid grid-cols-[60px_minmax(0,1fr)] items-center gap-1.5 px-1 py-[3px] rounded cursor-pointer bg-transparent text-left w-full transition-colors hover:bg-muted", "cursor-default hover:bg-transparent")}>
-        <span className={"text-[9px] font-bold tracking-[0.08em] uppercase text-muted-foreground font-mono whitespace-nowrap overflow-hidden text-ellipsis shrink-0"}>Type</span>
+        <span className={"text-[9px] font-bold tracking-[0.08em] uppercase text-muted-foreground/30 font-mono whitespace-nowrap overflow-hidden text-ellipsis shrink-0"}>Type</span>
         <div className={cn("text-[11.5px] text-foreground overflow-hidden text-ellipsis whitespace-nowrap min-w-0", "flex items-center gap-1")}>
           <div className="bg-muted/40 size-[18px] rounded-full" />
           <div className="bg-muted/40 size-[18px] rounded-full" />
@@ -227,7 +227,7 @@ function MidFormRowsGhost() {
     <>
       {(["Item", "Abil", "Nat"] as const).map((label) => (
         <div key={label} className={cellClasses.midFormCell}>
-          <span className={cellClasses.midFormLbl}>{label}</span>
+          <span className={cn(cellClasses.midFormLbl, "text-muted-foreground/30")}>{label}</span>
           <span
             className={cn(
               cellClasses.midFormVal,
@@ -239,7 +239,7 @@ function MidFormRowsGhost() {
         </div>
       ))}
       <div className={cn(cellClasses.midFormCell, "cursor-default hover:bg-transparent")}>
-        <span className={cellClasses.midFormLbl}>Type</span>
+        <span className={cn(cellClasses.midFormLbl, "text-muted-foreground/30")}>Type</span>
         <div className={cn(cellClasses.midFormVal, "items-center")}>
           <div className="bg-muted/40 size-[18px] rounded-full" />
           <div className="bg-muted/40 size-[18px] rounded-full" />

--- a/apps/web/src/components/team-builder/lanes/moves-lane.tsx
+++ b/apps/web/src/components/team-builder/lanes/moves-lane.tsx
@@ -463,27 +463,27 @@ function MovesLaneTileGhost() {
       <TableRow className="border-none">
         <TableHead className="!h-auto w-6 border-none p-0 pb-0.5"><span className="sr-only">Type</span></TableHead>
         <TableHead className="!h-auto w-8 border-none p-0 pb-0.5"><span className="sr-only">Category</span></TableHead>
-        <TableHead className="text-muted-foreground !h-auto border-none p-0 pb-0.5 text-[9.5px] font-medium tracking-[0.04em] uppercase">
+        <TableHead className="text-muted-foreground/30 !h-auto border-none p-0 pb-0.5 text-[9.5px] font-medium tracking-[0.04em] uppercase">
           NAME
         </TableHead>
-        <TableHead className="text-muted-foreground !h-auto w-11 border-none p-0 pb-0.5 text-[9.5px] font-medium tracking-[0.04em] uppercase">
+        <TableHead className="text-muted-foreground/30 !h-auto w-11 border-none p-0 pb-0.5 text-[9.5px] font-medium tracking-[0.04em] uppercase">
           BP
         </TableHead>
-        <TableHead className="text-muted-foreground !h-auto w-12 border-none p-0 pb-0.5 text-[9.5px] font-medium tracking-[0.04em] uppercase">
+        <TableHead className="text-muted-foreground/30 !h-auto w-12 border-none p-0 pb-0.5 text-[9.5px] font-medium tracking-[0.04em] uppercase">
           ACC
         </TableHead>
         {calcEnabled && (
-          <TableHead className="text-muted-foreground !h-auto border-none p-0 pb-0.5">
+          <TableHead className="text-muted-foreground/30 !h-auto border-none p-0 pb-0.5">
             DAMAGE
           </TableHead>
         )}
         {calcEnabled && (
-          <TableHead className="text-muted-foreground !h-auto border-none p-0 pb-0.5">
+          <TableHead className="text-muted-foreground/30 !h-auto border-none p-0 pb-0.5">
             %
           </TableHead>
         )}
         {calcEnabled && (
-          <TableHead className="text-muted-foreground !h-auto border-none p-0 pb-0.5">
+          <TableHead className="text-muted-foreground/30 !h-auto border-none p-0 pb-0.5">
             HITS
           </TableHead>
         )}


### PR DESCRIPTION
## Summary
- Mute empty row column headers (NAME, BP, ACC, DAMAGE, %, HITS, ITEM, ABIL, NAT, TYPE) in the team builder to match the existing muted style of BASE and EVS/SP
- Link the beanie logo in the footer and dockbar to https://x.com/thatguyinabeani