### PR TITLE
feat: speed tiers panel UX improvements

### DIFF
--- a/apps/web/src/components/team-builder/__tests__/move-list-shared.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/move-list-shared.test.tsx
@@ -1,0 +1,232 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+// =============================================================================
+// Mocks
+// =============================================================================
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => <img {...props} />,
+}));
+
+jest.mock("../type-symbol-icon", () => ({
+  TypeSymbolIcon: ({ type }: { type: string }) => (
+    <span data-testid={`type-icon-${type}`}>{type}</span>
+  ),
+}));
+
+jest.mock("../pickers/role-registry", () => ({
+  getRolesForMove: (name: string) => {
+    if (name === "Flamethrower") return ["burn"];
+    return [];
+  },
+  getRoleById: (id: string) => {
+    if (id === "burn") return { id: "burn", label: "Burn", group: "status" };
+    return null;
+  },
+}));
+
+jest.mock("../pickers/role-chip", () => ({
+  RoleChip: ({ roleId }: { roleId: string }) => (
+    <span data-testid={`role-${roleId}`}>{roleId}</span>
+  ),
+}));
+
+jest.mock("../move-category-ui", () => ({
+  CATEGORY_ICON_URLS: {
+    Physical: "/physical.png",
+    Special: "/special.png",
+    Status: "/status.png",
+  },
+}));
+
+// Import after mocks
+import {
+  sortMoveData,
+  MoveListHeader,
+  MoveListRow,
+  type MoveListSortState,
+} from "../pickers/move-list-shared";
+import type { MoveData } from "@trainers/pokemon";
+
+// =============================================================================
+// Test Data
+// =============================================================================
+
+const moves: MoveData[] = [
+  { name: "Flamethrower", type: "Fire", category: "Special", basePower: 90, accuracy: 100, shortDesc: "Burns" },
+  { name: "Earthquake", type: "Ground", category: "Physical", basePower: 100, accuracy: 100, shortDesc: "Spread" },
+  { name: "Protect", type: "Normal", category: "Status", basePower: 0, accuracy: true, shortDesc: "Blocks" },
+  { name: "Air Slash", type: "Flying", category: "Special", basePower: 75, accuracy: 95, shortDesc: "Flinch" },
+];
+
+// =============================================================================
+// sortMoveData tests
+// =============================================================================
+
+describe("sortMoveData", () => {
+  it("sorts by name ascending", () => {
+    const result = sortMoveData([...moves], { col: "name", dir: "asc" });
+    expect(result.map((m) => m.name)).toEqual([
+      "Air Slash",
+      "Earthquake",
+      "Flamethrower",
+      "Protect",
+    ]);
+  });
+
+  it("sorts by name descending", () => {
+    const result = sortMoveData([...moves], { col: "name", dir: "desc" });
+    expect(result.map((m) => m.name)).toEqual([
+      "Protect",
+      "Flamethrower",
+      "Earthquake",
+      "Air Slash",
+    ]);
+  });
+
+  it("sorts by bp descending (higher first)", () => {
+    const result = sortMoveData([...moves], { col: "bp", dir: "desc" });
+    expect(result.map((m) => m.basePower)).toEqual([100, 90, 75, 0]);
+  });
+
+  it("sorts by bp ascending (lower first)", () => {
+    const result = sortMoveData([...moves], { col: "bp", dir: "asc" });
+    expect(result.map((m) => m.basePower)).toEqual([0, 75, 90, 100]);
+  });
+
+  it("sorts by accuracy descending (treats true as 101)", () => {
+    const result = sortMoveData([...moves], { col: "acc", dir: "desc" });
+    // Protect (true=101) > Flamethrower/Earthquake (100) > Air Slash (95)
+    expect(result[0]!.name).toBe("Protect");
+    expect(result[3]!.name).toBe("Air Slash");
+  });
+
+  it("sorts by type alphabetically", () => {
+    const result = sortMoveData([...moves], { col: "type", dir: "asc" });
+    expect(result.map((m) => m.type)).toEqual([
+      "Fire",
+      "Flying",
+      "Ground",
+      "Normal",
+    ]);
+  });
+
+  it("sorts by category alphabetically", () => {
+    const result = sortMoveData([...moves], { col: "category", dir: "asc" });
+    expect(result.map((m) => m.category)).toEqual([
+      "Physical",
+      "Special",
+      "Special",
+      "Status",
+    ]);
+  });
+});
+
+// =============================================================================
+// MoveListRow tests
+// =============================================================================
+
+describe("MoveListRow", () => {
+  const baseMove: MoveData = {
+    name: "Flamethrower",
+    type: "Fire",
+    category: "Special",
+    basePower: 90,
+    accuracy: 100,
+    shortDesc: "Burns",
+  };
+
+  it("renders move name, BP value, accuracy with %", () => {
+    render(<MoveListRow move={baseMove} />);
+    expect(screen.getByText("Flamethrower")).toBeInTheDocument();
+    expect(screen.getByText("90")).toBeInTheDocument();
+    expect(screen.getByText("100%")).toBeInTheDocument();
+  });
+
+  it("shows dash for BP when basePower is 0", () => {
+    render(
+      <MoveListRow move={{ ...baseMove, name: "Protect", basePower: 0 }} />
+    );
+    // Multiple dashes exist; find BP dash in context
+    const dashes = screen.getAllByText("—");
+    expect(dashes.length).toBeGreaterThan(0);
+  });
+
+  it("shows dash for accuracy when accuracy is true", () => {
+    render(
+      <MoveListRow move={{ ...baseMove, name: "Protect", accuracy: true }} />
+    );
+    const dashes = screen.getAllByText("—");
+    expect(dashes.length).toBeGreaterThan(0);
+  });
+
+  it("applies bg-primary/10 when isHighlighted is true", () => {
+    const { container } = render(
+      <MoveListRow move={baseMove} isHighlighted />
+    );
+    const row = container.firstElementChild;
+    expect(row?.className).toContain("bg-primary/10");
+  });
+
+  it("shows role chips", () => {
+    render(<MoveListRow move={baseMove} />);
+    expect(screen.getByTestId("role-burn")).toBeInTheDocument();
+  });
+
+  it("calls onSelect when row is clicked", async () => {
+    const user = userEvent.setup();
+    const onSelect = jest.fn();
+    render(<MoveListRow move={baseMove} onSelect={onSelect} />);
+    await user.click(screen.getByRole("row"));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onTypeFilter when type icon button is clicked", async () => {
+    const user = userEvent.setup();
+    const onTypeFilter = jest.fn();
+    render(
+      <MoveListRow move={baseMove} onSelect={() => {}} onTypeFilter={onTypeFilter} />
+    );
+    await user.click(screen.getByRole("button", { name: /filter by fire/i }));
+    expect(onTypeFilter).toHaveBeenCalledWith("Fire");
+  });
+
+  it("renders without role=row when onSelect is not provided", () => {
+    render(<MoveListRow move={baseMove} />);
+    expect(screen.queryByRole("row")).not.toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// MoveListHeader tests
+// =============================================================================
+
+describe("MoveListHeader", () => {
+  const defaultSort: MoveListSortState = { col: "bp", dir: "desc" };
+
+  it("renders three sort buttons", () => {
+    render(<MoveListHeader sort={defaultSort} onSort={() => {}} />);
+    expect(screen.getByRole("button", { name: /sort by name/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /sort by base power/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /sort by accuracy/i })).toBeInTheDocument();
+  });
+
+  it("shows aria-pressed=true for active column", () => {
+    render(<MoveListHeader sort={defaultSort} onSort={() => {}} />);
+    const bpBtn = screen.getByRole("button", { name: /sort by base power/i });
+    expect(bpBtn).toHaveAttribute("aria-pressed", "true");
+    const nameBtn = screen.getByRole("button", { name: /sort by name/i });
+    expect(nameBtn).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("calls onSort with column name when clicked", async () => {
+    const user = userEvent.setup();
+    const onSort = jest.fn();
+    render(<MoveListHeader sort={defaultSort} onSort={onSort} />);
+    await user.click(screen.getByRole("button", { name: /sort by name/i }));
+    expect(onSort).toHaveBeenCalledWith("name");
+  });
+});

--- a/apps/web/src/components/team-builder/__tests__/move-picker.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/move-picker.test.tsx
@@ -417,13 +417,13 @@ describe("MovePicker", () => {
     it("renders sortable column headers for Name, BP, and Acc", () => {
       render(<MovePicker {...defaultProps()} />);
       expect(
-        screen.getByRole("button", { name: "Sort by name" })
+        screen.getByRole("button", { name: /sort by name/i })
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: "Sort by base power" })
+        screen.getByRole("button", { name: /sort by base power/i })
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: "Sort by accuracy" })
+        screen.getByRole("button", { name: /sort by accuracy/i })
       ).toBeInTheDocument();
     });
   });
@@ -645,7 +645,7 @@ describe("MovePicker", () => {
     it("clicking 'Sort by name' again toggles to descending", async () => {
       const user = userEvent.setup();
       render(<MovePicker {...defaultProps()} />);
-      await user.click(screen.getByRole("button", { name: "Sort by name" }));
+      await user.click(screen.getByRole("button", { name: /sort by name/i }));
       expect(screen.getByText("↓")).toBeInTheDocument();
     });
 
@@ -653,7 +653,7 @@ describe("MovePicker", () => {
       const user = userEvent.setup();
       render(<MovePicker {...defaultProps()} />);
       await user.click(
-        screen.getByRole("button", { name: "Sort by base power" })
+        screen.getByRole("button", { name: /sort by base power/i })
       );
       expect(screen.getByText("↓")).toBeInTheDocument();
     });
@@ -662,7 +662,7 @@ describe("MovePicker", () => {
       const user = userEvent.setup();
       render(<MovePicker {...defaultProps()} />);
       await user.click(
-        screen.getByRole("button", { name: "Sort by accuracy" })
+        screen.getByRole("button", { name: /sort by accuracy/i })
       );
       expect(screen.getByText("↓")).toBeInTheDocument();
     });
@@ -672,12 +672,12 @@ describe("MovePicker", () => {
       render(<MovePicker {...defaultProps()} />);
       // Click BP once → desc
       await user.click(
-        screen.getByRole("button", { name: "Sort by base power" })
+        screen.getByRole("button", { name: /sort by base power/i })
       );
       expect(screen.getByText("↓")).toBeInTheDocument();
       // Click BP again → asc
       await user.click(
-        screen.getByRole("button", { name: "Sort by base power" })
+        screen.getByRole("button", { name: /sort by base power/i })
       );
       expect(screen.getByText("↑")).toBeInTheDocument();
     });

--- a/apps/web/src/components/team-builder/__tests__/move-sidebar.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/move-sidebar.test.tsx
@@ -98,19 +98,4 @@ describe("MoveSidebar", () => {
     );
   });
 
-  it("Clear all resets to DEFAULT_MOVE_FILTERS", async () => {
-    const user = userEvent.setup();
-    const onChange = jest.fn();
-    renderSidebar({
-      filters: {
-        search: "fire",
-        types: ["Fire"],
-        categories: ["Special"],
-        roles: ["spread"],
-      },
-      onFiltersChange: onChange,
-    });
-    await user.click(screen.getByRole("button", { name: /clear/i }));
-    expect(onChange).toHaveBeenCalledWith(DEFAULT_MOVE_FILTERS);
-  });
 });

--- a/apps/web/src/components/team-builder/__tests__/moves-lane.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/moves-lane.test.tsx
@@ -501,8 +501,8 @@ describe("MovesLane — move tile display", () => {
       .map((el) => el.textContent);
     expect(tooltipBodies).not.toContain(undefined);
     expect(tooltipBodies).not.toContain("");
-    // Only the type-icon tooltip should remain.
-    expect(tooltipBodies).toEqual(["Normal"]);
+    // TypeSymbolIcon no longer renders a tooltip, so array is empty.
+    expect(tooltipBodies).toEqual([]);
   });
 });
 

--- a/apps/web/src/components/team-builder/__tests__/species-expanded-panel.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/species-expanded-panel.test.tsx
@@ -138,7 +138,7 @@ describe("SpeciesExpandedPanel", () => {
   });
 
   it("highlights moves that match filteredMoves", () => {
-    const { container } = render(
+    render(
       <SpeciesExpandedPanel
         species="Charizard"
         formatId="gen9vgc2024regg"

--- a/apps/web/src/components/team-builder/__tests__/species-expanded-panel.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/species-expanded-panel.test.tsx
@@ -1,0 +1,322 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+// =============================================================================
+// Mocks
+// =============================================================================
+
+const mockGetLegalMoves = jest.fn();
+const mockGetMoveData = jest.fn();
+
+jest.mock("@trainers/pokemon", () => ({
+  getLegalMoves: (...args: unknown[]) => mockGetLegalMoves(...args),
+  getMoveData: (...args: unknown[]) => mockGetMoveData(...args),
+}));
+
+jest.mock("../pickers/role-registry", () => ({
+  getRolesForMove: (name: string) => {
+    if (name === "Earthquake") return ["spread"];
+    if (name === "Flamethrower") return ["burn"];
+    return [];
+  },
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => <img {...props} />,
+}));
+
+jest.mock("../type-symbol-icon", () => ({
+  TypeSymbolIcon: ({ type }: { type: string }) => (
+    <span data-testid={`type-icon-${type}`}>{type}</span>
+  ),
+}));
+
+jest.mock("../move-category-ui", () => ({
+  CATEGORY_ICON_URLS: {
+    Physical: "/physical.png",
+    Special: "/special.png",
+    Status: "/status.png",
+  },
+}));
+
+jest.mock("../pickers/role-chip", () => ({
+  RoleChip: ({ roleId }: { roleId: string }) => (
+    <span data-testid={`role-${roleId}`}>{roleId}</span>
+  ),
+}));
+
+// Import component after mocks
+import { SpeciesExpandedPanel } from "../pickers/species-expanded-panel";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const MOVE_DATA = {
+  Flamethrower: {
+    name: "Flamethrower",
+    type: "Fire",
+    category: "Special",
+    basePower: 90,
+    accuracy: 100,
+    shortDesc: "Burns target",
+  },
+  Earthquake: {
+    name: "Earthquake",
+    type: "Ground",
+    category: "Physical",
+    basePower: 100,
+    accuracy: 100,
+    shortDesc: "Hits all adjacent",
+  },
+  Protect: {
+    name: "Protect",
+    type: "Normal",
+    category: "Status",
+    basePower: 0,
+    accuracy: true,
+    shortDesc: "Blocks attacks",
+  },
+};
+
+function setupMocks() {
+  mockGetLegalMoves.mockReturnValue(["Flamethrower", "Earthquake", "Protect"]);
+  mockGetMoveData.mockImplementation(
+    (name: string) => MOVE_DATA[name as keyof typeof MOVE_DATA] ?? null
+  );
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("SpeciesExpandedPanel", () => {
+  beforeEach(() => {
+    setupMocks();
+  });
+
+  it("renders move rows for all legal moves", () => {
+    render(
+      <SpeciesExpandedPanel
+        species="Charizard"
+        formatId="gen9vgc2024regg"
+        filteredMoves={[]}
+        filteredRoles={[]}
+      />
+    );
+    expect(screen.getByText("Flamethrower")).toBeInTheDocument();
+    expect(screen.getByText("Earthquake")).toBeInTheDocument();
+    expect(screen.getByText("Protect")).toBeInTheDocument();
+  });
+
+  it("shows unavailable message when getLegalMoves returns undefined", () => {
+    mockGetLegalMoves.mockReturnValue(undefined);
+    render(
+      <SpeciesExpandedPanel
+        species="Charizard"
+        formatId="gen9vgc2024regg"
+        filteredMoves={[]}
+        filteredRoles={[]}
+      />
+    );
+    expect(screen.getByText(/Learnset data unavailable/)).toBeInTheDocument();
+  });
+
+  it("shows unavailable message when getLegalMoves returns a Symbol", () => {
+    mockGetLegalMoves.mockReturnValue(Symbol("loading"));
+    render(
+      <SpeciesExpandedPanel
+        species="Charizard"
+        formatId="gen9vgc2024regg"
+        filteredMoves={[]}
+        filteredRoles={[]}
+      />
+    );
+    expect(screen.getByText(/Learnset data unavailable/)).toBeInTheDocument();
+  });
+
+  it("highlights moves that match filteredMoves", () => {
+    const { container } = render(
+      <SpeciesExpandedPanel
+        species="Charizard"
+        formatId="gen9vgc2024regg"
+        filteredMoves={["Earthquake"]}
+        filteredRoles={[]}
+      />
+    );
+    // Find the row containing Earthquake text — its parent grid div should have bg-primary/10
+    const eqText = screen.getByText("Earthquake");
+    const row = eqText.closest("[class*='grid']");
+    expect(row?.className).toContain("bg-primary/10");
+  });
+
+  it("filters by roles — only matching moves shown", () => {
+    render(
+      <SpeciesExpandedPanel
+        species="Charizard"
+        formatId="gen9vgc2024regg"
+        filteredMoves={[]}
+        filteredRoles={["spread"]}
+      />
+    );
+    expect(screen.getByText("Earthquake")).toBeInTheDocument();
+    expect(screen.queryByText("Flamethrower")).not.toBeInTheDocument();
+    expect(screen.queryByText("Protect")).not.toBeInTheDocument();
+  });
+
+  it("renders sort header with Name, BP, ACC buttons", () => {
+    render(
+      <SpeciesExpandedPanel
+        species="Charizard"
+        formatId="gen9vgc2024regg"
+        filteredMoves={[]}
+        filteredRoles={[]}
+      />
+    );
+    expect(
+      screen.getByRole("button", { name: /sort by name/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /sort by base power/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /sort by accuracy/i })
+    ).toBeInTheDocument();
+  });
+
+  it("passes id prop to root element", () => {
+    const { container } = render(
+      <SpeciesExpandedPanel
+        id="test-panel"
+        species="Charizard"
+        formatId="gen9vgc2024regg"
+        filteredMoves={[]}
+        filteredRoles={[]}
+      />
+    );
+    expect(container.querySelector("#test-panel")).toBeInTheDocument();
+  });
+
+  it("renders the resize handle", () => {
+    render(
+      <SpeciesExpandedPanel
+        species="Charizard"
+        formatId="gen9vgc2024regg"
+        filteredMoves={[]}
+        filteredRoles={[]}
+      />
+    );
+    expect(screen.getByRole("separator")).toBeInTheDocument();
+  });
+
+  it("clicking sort by name triggers sort order change", async () => {
+    const user = userEvent.setup();
+    render(
+      <SpeciesExpandedPanel
+        species="Charizard"
+        formatId="gen9vgc2024regg"
+        filteredMoves={[]}
+        filteredRoles={[]}
+      />
+    );
+
+    const nameBtn = screen.getByRole("button", { name: /sort by name/i });
+    await user.click(nameBtn);
+
+    // After clicking name (default was bp desc), moves should be sorted alphabetically
+    const moveNames = screen
+      .getAllByTitle(/Flamethrower|Earthquake|Protect/)
+      .filter((el) => el.tagName === "SPAN" && el.className.includes("font-medium"))
+      .map((el) => el.textContent);
+
+    expect(moveNames).toEqual(["Earthquake", "Flamethrower", "Protect"]);
+  });
+
+  it("resize handle initiates pointer capture on pointerdown", () => {
+    render(
+      <SpeciesExpandedPanel
+        species="Charizard"
+        formatId="gen9vgc2024regg"
+        filteredMoves={[]}
+        filteredRoles={[]}
+      />
+    );
+
+    const handle = screen.getByRole("separator");
+    const setPointerCapture = jest.fn();
+    Object.defineProperty(handle, "setPointerCapture", {
+      value: setPointerCapture,
+    });
+
+    // Fire pointerdown via fireEvent (triggers React synthetic handler)
+    fireEvent.pointerDown(handle, { clientY: 400, pointerId: 1 });
+
+    expect(setPointerCapture).toHaveBeenCalledWith(1);
+  });
+
+  it("resize drag updates the panel height", () => {
+    const { container } = render(
+      <SpeciesExpandedPanel
+        species="Charizard"
+        formatId="gen9vgc2024regg"
+        filteredMoves={[]}
+        filteredRoles={[]}
+      />
+    );
+
+    const handle = screen.getByRole("separator");
+    Object.defineProperty(handle, "setPointerCapture", {
+      value: jest.fn(),
+    });
+
+    // Start drag at Y=400
+    fireEvent.pointerDown(handle, { clientY: 400, pointerId: 1 });
+
+    // Move pointer 100px down — height should increase from 320 to 420
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { clientY: 500, bubbles: true })
+    );
+
+    // Check that the scrollable container height changed
+    const scrollDiv = container.querySelector('[style*="max-height"]');
+    expect(scrollDiv).toHaveStyle({ maxHeight: "420px" });
+  });
+
+  it("pointerup ends the drag and removes listeners", () => {
+    const { container } = render(
+      <SpeciesExpandedPanel
+        species="Charizard"
+        formatId="gen9vgc2024regg"
+        filteredMoves={[]}
+        filteredRoles={[]}
+      />
+    );
+
+    const handle = screen.getByRole("separator");
+    Object.defineProperty(handle, "setPointerCapture", {
+      value: jest.fn(),
+    });
+
+    // Start drag
+    fireEvent.pointerDown(handle, { clientY: 400, pointerId: 1 });
+
+    // End drag
+    fireEvent(
+      document,
+      new PointerEvent("pointerup", { bubbles: true })
+    );
+
+    // Subsequent pointermove should NOT change height (listener removed)
+    fireEvent(
+      document,
+      new PointerEvent("pointermove", { clientY: 700, bubbles: true })
+    );
+
+    // Height should still be 320 (unchanged from initial, since no move happened before up)
+    const scrollDiv = container.querySelector('[style*="max-height"]');
+    expect(scrollDiv).toHaveStyle({ maxHeight: "320px" });
+  });
+});

--- a/apps/web/src/components/team-builder/__tests__/species-picker.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/species-picker.test.tsx
@@ -167,6 +167,14 @@ jest.mock("../pickers/ability-cell", () => ({
     ),
 }));
 
+jest.mock("../pickers/species-expanded-panel", () => ({
+  SpeciesExpandedPanel: ({ id, species }: { id?: string; species: string }) => (
+    <div data-testid={`expanded-panel-${species}`} id={id}>
+      Learnset for {species}
+    </div>
+  ),
+}));
+
 jest.mock("../pickers/role-chip", () => ({
   RoleChip: ({
     roleId,
@@ -909,5 +917,147 @@ describe("SpeciesPicker", () => {
     expect(
       screen.getByRole("button", { name: /Clear 1 active filter/i })
     ).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Expand / Collapse
+  // ---------------------------------------------------------------------------
+
+  describe("expand/collapse", () => {
+    it("renders a chevron button for each species row", () => {
+      render(
+        <SpeciesPicker
+          value={null}
+          format={undefined}
+          onPick={jest.fn()}
+          onClose={jest.fn()}
+        />
+      );
+      expect(
+        screen.getByRole("button", { name: /expand bulbasaur/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /expand garchomp/i })
+      ).toBeInTheDocument();
+    });
+
+    it("chevron button starts with aria-expanded=false", () => {
+      render(
+        <SpeciesPicker
+          value={null}
+          format={undefined}
+          onPick={jest.fn()}
+          onClose={jest.fn()}
+        />
+      );
+      const btn = screen.getByRole("button", { name: /expand bulbasaur/i });
+      expect(btn).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("clicking chevron expands the species and shows the expanded panel", async () => {
+      const user = userEvent.setup();
+      render(
+        <SpeciesPicker
+          value={null}
+          format={undefined}
+          onPick={jest.fn()}
+          onClose={jest.fn()}
+        />
+      );
+      const btn = screen.getByRole("button", { name: /expand bulbasaur/i });
+      await user.click(btn);
+
+      // Panel should now be visible
+      expect(screen.getByTestId("expanded-panel-Bulbasaur")).toBeInTheDocument();
+      // aria-expanded should be true, label changes to "Collapse"
+      expect(
+        screen.getByRole("button", { name: /collapse bulbasaur/i })
+      ).toHaveAttribute("aria-expanded", "true");
+    });
+
+    it("clicking chevron again collapses the panel", async () => {
+      const user = userEvent.setup();
+      render(
+        <SpeciesPicker
+          value={null}
+          format={undefined}
+          onPick={jest.fn()}
+          onClose={jest.fn()}
+        />
+      );
+      // Expand
+      await user.click(
+        screen.getByRole("button", { name: /expand bulbasaur/i })
+      );
+      expect(screen.getByTestId("expanded-panel-Bulbasaur")).toBeInTheDocument();
+
+      // Collapse
+      await user.click(
+        screen.getByRole("button", { name: /collapse bulbasaur/i })
+      );
+      expect(
+        screen.queryByTestId("expanded-panel-Bulbasaur")
+      ).not.toBeInTheDocument();
+    });
+
+    it("expanded panel has aria-controls id matching the panel id", async () => {
+      const user = userEvent.setup();
+      render(
+        <SpeciesPicker
+          value={null}
+          format={undefined}
+          onPick={jest.fn()}
+          onClose={jest.fn()}
+        />
+      );
+      const btn = screen.getByRole("button", { name: /expand garchomp/i });
+      expect(btn).toHaveAttribute("aria-controls", "panel-Garchomp");
+      await user.click(btn);
+      const panel = screen.getByTestId("expanded-panel-Garchomp");
+      expect(panel).toHaveAttribute("id", "panel-Garchomp");
+    });
+
+    it("clicking chevron does NOT trigger row selection (onPick)", async () => {
+      const user = userEvent.setup();
+      const onPick = jest.fn();
+      render(
+        <SpeciesPicker
+          value={null}
+          format={undefined}
+          onPick={onPick}
+          onClose={jest.fn()}
+        />
+      );
+      await user.click(
+        screen.getByRole("button", { name: /expand bulbasaur/i })
+      );
+      expect(onPick).not.toHaveBeenCalled();
+    });
+
+    it("only one row can be expanded at a time", async () => {
+      const user = userEvent.setup();
+      render(
+        <SpeciesPicker
+          value={null}
+          format={undefined}
+          onPick={jest.fn()}
+          onClose={jest.fn()}
+        />
+      );
+      // Expand Bulbasaur
+      await user.click(
+        screen.getByRole("button", { name: /expand bulbasaur/i })
+      );
+      expect(screen.getByTestId("expanded-panel-Bulbasaur")).toBeInTheDocument();
+
+      // Expand Garchomp — Bulbasaur should collapse
+      await user.click(
+        screen.getByRole("button", { name: /expand garchomp/i })
+      );
+      expect(screen.getByTestId("expanded-panel-Garchomp")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("expanded-panel-Bulbasaur")
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/components/team-builder/__tests__/team-workspace-v2.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/team-workspace-v2.test.tsx
@@ -592,23 +592,11 @@ describe("TeamWorkspaceV2 — add pokemon flow", () => {
 // =============================================================================
 
 describe("TeamWorkspaceV2 — remove pokemon flow", () => {
-  it("opens the remove confirmation dialog when remove is clicked", async () => {
+  it("calls persistence.removePokemon when remove is clicked", async () => {
     const user = userEvent.setup();
     renderWorkspace();
 
     await user.click(screen.getByTestId("remove-0"));
-
-    // AlertDialog should be open
-    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
-    expect(screen.getByText(/remove pokémon\?/i)).toBeInTheDocument();
-  });
-
-  it("calls persistence.removePokemon after the user confirms removal", async () => {
-    const user = userEvent.setup();
-    renderWorkspace();
-
-    await user.click(screen.getByTestId("remove-0")); // open dialog
-    await user.click(screen.getByRole("button", { name: /^remove$/i })); // confirm
 
     await waitFor(() => {
       expect(MOCK_PERSISTENCE.removePokemon).toHaveBeenCalledWith(1, 10);
@@ -620,7 +608,6 @@ describe("TeamWorkspaceV2 — remove pokemon flow", () => {
     renderWorkspace();
 
     await user.click(screen.getByTestId("remove-0"));
-    await user.click(screen.getByRole("button", { name: /^remove$/i }));
 
     await waitFor(() => {
       expect(mockToastSuccess).toHaveBeenCalledWith("Pokémon removed.");
@@ -643,7 +630,6 @@ describe("TeamWorkspaceV2 — remove pokemon flow", () => {
     expect(screen.getByTestId("species-0")).toHaveTextContent("Garchomp");
 
     await user.click(screen.getByTestId("remove-0"));
-    await user.click(screen.getByRole("button", { name: /^remove$/i }));
 
     await waitFor(() => {
       expect(screen.getByTestId("species-0")).toHaveTextContent("empty");
@@ -666,7 +652,6 @@ describe("TeamWorkspaceV2 — remove pokemon flow", () => {
     renderWorkspace();
 
     await user.click(screen.getByTestId("remove-0"));
-    await user.click(screen.getByRole("button", { name: /^remove$/i }));
 
     await waitFor(() => {
       expect(mockToastError).toHaveBeenCalledWith("Permission denied.");
@@ -683,25 +668,9 @@ describe("TeamWorkspaceV2 — remove pokemon flow", () => {
     renderWorkspace();
 
     await user.click(screen.getByTestId("remove-0"));
-    await user.click(screen.getByRole("button", { name: /^remove$/i }));
 
     await waitFor(() => {
       expect(mockToastError).toHaveBeenCalledWith("Failed to remove Pokémon.");
-    });
-  });
-
-  it("closes the dialog and does nothing when Cancel is clicked", async () => {
-    const user = userEvent.setup();
-    renderWorkspace();
-
-    await user.click(screen.getByTestId("remove-0"));
-    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: /cancel/i }));
-
-    await waitFor(() => {
-      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
-      expect(MOCK_PERSISTENCE.removePokemon).not.toHaveBeenCalled();
     });
   });
 
@@ -709,11 +678,9 @@ describe("TeamWorkspaceV2 — remove pokemon flow", () => {
     const user = userEvent.setup();
     renderWorkspace(EMPTY_TEAM);
 
-    await user.click(screen.getByTestId("remove-0")); // opens dialog for empty slot
-    await user.click(screen.getByRole("button", { name: /^remove$/i })); // confirm
+    await user.click(screen.getByTestId("remove-0"));
 
     await waitFor(() => {
-      // No pokemon in slot → action should not be called
       expect(MOCK_PERSISTENCE.removePokemon).not.toHaveBeenCalled();
     });
   });
@@ -753,7 +720,6 @@ describe("TeamWorkspaceV2 — optimistic placeholder guards", () => {
     renderWorkspace(PENDING_TEAM);
 
     await user.click(screen.getByTestId("remove-0"));
-    await user.click(screen.getByRole("button", { name: /^remove$/i }));
 
     await waitFor(() => {
       expect(mockToastInfo).toHaveBeenCalledWith(

--- a/apps/web/src/components/team-builder/__tests__/type-symbol-icon.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/type-symbol-icon.test.tsx
@@ -1,18 +1,6 @@
-import { describe, it, expect, jest } from "@jest/globals";
+import { describe, it, expect } from "@jest/globals";
 import { render, screen } from "@testing-library/react";
 import React from "react";
-
-// Tooltip uses Base UI — mock to a simple pass-through so the icon renders
-// without needing a full JSDOM provider setup for portal positioning.
-jest.mock("@/components/ui/tooltip", () => ({
-  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  TooltipTrigger: ({ render: renderProp }: { render: React.ReactNode }) => (
-    <>{renderProp}</>
-  ),
-  TooltipContent: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="tooltip-content">{children}</div>
-  ),
-}));
 
 import { TypeSymbolIcon } from "../type-symbol-icon";
 
@@ -25,11 +13,6 @@ describe("TypeSymbolIcon", () => {
     render(<TypeSymbolIcon type="Fire" />);
     const icon = screen.getByRole("img", { name: "Fire" });
     expect(icon).toBeInTheDocument();
-  });
-
-  it("renders the tooltip content with the full type name", () => {
-    render(<TypeSymbolIcon type="Water" />);
-    expect(screen.getByTestId("tooltip-content")).toHaveTextContent("Water");
   });
 
   it("applies a size style matching the size prop", () => {

--- a/apps/web/src/components/team-builder/calc/calc-defender-moves.tsx
+++ b/apps/web/src/components/team-builder/calc/calc-defender-moves.tsx
@@ -116,7 +116,7 @@ function DefenderMoveTile({
 
       <DialogContent
         showCloseButton={false}
-        className="flex h-[calc(100vh-2rem)] max-h-[1080px] w-[calc(100vw-2rem)] max-w-[1600px] flex-col gap-0 overflow-hidden rounded-xl p-0 sm:max-w-[1600px]"
+        className="ring-primary/50 flex h-[calc(100vh-2rem)] max-h-[1080px] w-[calc(100vw-2rem)] max-w-[1600px] flex-col gap-0 overflow-hidden rounded-xl p-0 ring-2 sm:max-w-[1600px]"
       >
         <DialogTitle className="sr-only">Choose move</DialogTitle>
         <MovePicker

--- a/apps/web/src/components/team-builder/dock/speed-tiers-panel.tsx
+++ b/apps/web/src/components/team-builder/dock/speed-tiers-panel.tsx
@@ -338,10 +338,8 @@ function metaToScored(
         ? 0.9
         : 1.0;
 
-  // EVs: if custom set use that; otherwise max EVs for +/neutral, 0 for -
-  const evs =
-    customEvs ??
-    (toggle.theirs.nature === "negative" ? 0 : champions ? 0 : 252);
+  // EVs: if custom set use that; otherwise 0 baseline
+  const evs = customEvs ?? 0;
 
   const rawSpeed = champions
     ? calculateChampionsStat(b, evs, natureMult)

--- a/apps/web/src/components/team-builder/dock/speed-tiers-panel.tsx
+++ b/apps/web/src/components/team-builder/dock/speed-tiers-panel.tsx
@@ -103,8 +103,8 @@ const DEFAULT_YOURS: SideModifiers = {
   unburden: false,
   stage: 0,
   status: "healthy",
-  evs: null,
-  nature: "positive",
+  evs: 0,
+  nature: "neutral",
 };
 
 const DEFAULT_THEIRS: SideModifiers = {
@@ -113,8 +113,8 @@ const DEFAULT_THEIRS: SideModifiers = {
   unburden: false,
   stage: 0,
   status: "healthy",
-  evs: null,
-  nature: "positive",
+  evs: 0,
+  nature: "neutral",
 };
 
 const DEFAULT_TOGGLE: ToggleState = {
@@ -341,7 +341,7 @@ function metaToScored(
   // EVs: if custom set use that; otherwise max EVs for +/neutral, 0 for -
   const evs =
     customEvs ??
-    (toggle.theirs.nature === "negative" ? 0 : champions ? 32 : 252);
+    (toggle.theirs.nature === "negative" ? 0 : champions ? 0 : 252);
 
   const rawSpeed = champions
     ? calculateChampionsStat(b, evs, natureMult)
@@ -453,6 +453,8 @@ function TierMonRow({
           "border-border/30 [&:hover>td]:bg-muted/50 border-b hover:bg-transparent [&:hover>td:first-child]:rounded-l-lg [&:hover>td:last-child]:rounded-r-lg",
           mon.isSelected && "bg-primary/10",
           mon.isYours && !mon.isSelected && "bg-primary/5",
+          mon.isYours &&
+            "[&>td:first-child]:rounded-l-lg [&>td:last-child]:rounded-r-lg [&>td]:border-y [&>td]:border-primary/25 [&>td:first-child]:border-l [&>td:last-child]:border-r",
           isFaster && "opacity-40"
         )}
       >
@@ -739,7 +741,7 @@ export function SpeedTiersPanel({
 
       {/* Tier table */}
       <div className="min-h-0 flex-1 overflow-y-auto px-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-        <table className="w-full table-fixed caption-bottom text-sm">
+        <table className="w-full table-fixed border-separate border-spacing-0 caption-bottom text-sm">
           <colgroup>
             <col className="w-full" />
             <col className="w-14" />
@@ -863,7 +865,7 @@ export function SpeedTiersPanel({
                 aria-label="Our Scarf"
               />
             </div>
-            <span className="text-center text-[11px]">Scarf</span>
+            <span className="text-center text-[11px]">Choice Scarf</span>
             <div className="flex justify-start">
               <Switch
                 size="sm"
@@ -950,7 +952,7 @@ export function SpeedTiersPanel({
 
             {/* Nature — theirs only */}
             <div />
-            <span className="text-center text-[11px]">Nature</span>
+            <span className="text-center text-[11px]">SPE Nature</span>
             <div className="flex justify-start gap-0.5">
               {(["negative", "neutral", "positive"] as const).map((n) => (
                 <button

--- a/apps/web/src/components/team-builder/lanes/identity/use-identity-state.ts
+++ b/apps/web/src/components/team-builder/lanes/identity/use-identity-state.ts
@@ -110,7 +110,7 @@ export function useIdentityState(
     onUpdate({
       species,
       nickname: null,
-      held_item: null,
+      held_item: getMegaStoneForSpecies(species) ?? null,
       ability: "",
       nature: "Serious",
       tera_type: null,

--- a/apps/web/src/components/team-builder/lanes/moves-lane.tsx
+++ b/apps/web/src/components/team-builder/lanes/moves-lane.tsx
@@ -425,7 +425,7 @@ function MoveTile({
       >
         <DialogContent
           showCloseButton={false}
-          className="flex h-[calc(100vh-2rem)] max-h-[1080px] w-[calc(100vw-2rem)] max-w-[1600px] flex-col gap-0 overflow-hidden rounded-xl p-0 sm:max-w-[1600px]"
+          className="ring-primary/50 flex h-[calc(100vh-2rem)] max-h-[1080px] w-[calc(100vw-2rem)] max-w-[1600px] flex-col gap-0 overflow-hidden rounded-xl p-0 ring-2 sm:max-w-[1600px]"
         >
           <DialogTitle className="sr-only">Choose move</DialogTitle>
           <MovePicker

--- a/apps/web/src/components/team-builder/pickers/move-list-shared.tsx
+++ b/apps/web/src/components/team-builder/pickers/move-list-shared.tsx
@@ -1,0 +1,377 @@
+"use client";
+
+/**
+ * Shared move list components used by both the MovePicker dialog and the
+ * SpeciesExpandedPanel learnset. Keeps the grid layout, sort logic, header,
+ * and row rendering in one place.
+ */
+
+import Image from "next/image";
+
+import { type MoveData } from "@trainers/pokemon";
+
+import { cn } from "@/lib/utils";
+
+import { TypeSymbolIcon } from "../type-symbol-icon";
+import { CATEGORY_ICON_URLS } from "../move-category-ui";
+import { RoleChip } from "./role-chip";
+import { getRolesForMove, type RoleId } from "./role-registry";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type MoveListSortCol = "type" | "name" | "category" | "bp" | "acc";
+export type MoveListSortDir = "asc" | "desc";
+export type MoveListSortState = { col: MoveListSortCol; dir: MoveListSortDir };
+
+// =============================================================================
+// Grid template
+// =============================================================================
+
+/**
+ * Shared grid template for move list rows.
+ *
+ *   56px                — type icon
+ *   56px                — category icon
+ *   minmax(140px,1.4fr) — name
+ *   40px                — BP
+ *   48px                — Accuracy
+ *   48px                — Usage (coming soon)
+ *   minmax(0,2fr)       — effect (short description)
+ *   minmax(140px,1fr)   — roles chips
+ */
+export const MOVE_LIST_GRID =
+  "grid-cols-[56px_56px_minmax(140px,1.4fr)_40px_48px_48px_minmax(0,2fr)_minmax(140px,1fr)]";
+
+// =============================================================================
+// Sort logic
+// =============================================================================
+
+export function sortMoveData(
+  moves: MoveData[],
+  sort: MoveListSortState
+): MoveData[] {
+  const out = [...moves];
+  out.sort((a, b) => {
+    let cmp = 0;
+    switch (sort.col) {
+      case "name":
+        cmp = a.name.localeCompare(b.name);
+        break;
+      case "type":
+        cmp = a.type.localeCompare(b.type);
+        break;
+      case "category":
+        cmp = a.category.localeCompare(b.category);
+        break;
+      case "bp": {
+        const ap = a.basePower ?? 0;
+        const bp = b.basePower ?? 0;
+        cmp = ap - bp;
+        break;
+      }
+      case "acc": {
+        const aa = a.accuracy === true ? 101 : (a.accuracy || 0);
+        const ba = b.accuracy === true ? 101 : (b.accuracy || 0);
+        cmp = aa - ba;
+        break;
+      }
+    }
+    return sort.dir === "asc" ? cmp : -cmp;
+  });
+  return out;
+}
+
+// =============================================================================
+// SortArrow
+// =============================================================================
+
+function SortArrow({
+  active,
+  dir,
+}: {
+  active: boolean;
+  dir: MoveListSortDir;
+}) {
+  if (!active) return null;
+  return (
+    <span aria-hidden="true" className="ml-0.5 inline-block leading-none">
+      {dir === "asc" ? "↑" : "↓"}
+    </span>
+  );
+}
+
+// =============================================================================
+// MoveListHeader
+// =============================================================================
+
+interface MoveListHeaderProps {
+  sort: MoveListSortState;
+  onSort: (col: MoveListSortCol) => void;
+  className?: string;
+}
+
+export function MoveListHeader({ sort, onSort, className }: MoveListHeaderProps) {
+  function headerBtnClass(col: MoveListSortCol) {
+    return sort.col === col
+      ? "text-foreground"
+      : "text-muted-foreground hover:text-foreground";
+  }
+
+  return (
+    <div
+      className={cn(
+        "grid items-center gap-2 border-b px-3 py-1.5 text-[10px] font-semibold tracking-wide uppercase",
+        MOVE_LIST_GRID,
+        className
+      )}
+    >
+      {/* Type — no label */}
+      <span />
+      {/* Category — no label */}
+      <span />
+
+      {/* Name */}
+      <button
+        type="button"
+        className={cn(headerBtnClass("name"), "flex items-center gap-0.5")}
+        onClick={() => onSort("name")}
+        aria-label="Sort by name"
+      >
+        Name
+        <SortArrow active={sort.col === "name"} dir={sort.dir} />
+      </button>
+
+      {/* BP */}
+      <button
+        type="button"
+        className={cn(
+          headerBtnClass("bp"),
+          "flex items-center justify-end gap-0.5"
+        )}
+        onClick={() => onSort("bp")}
+        aria-label="Sort by base power"
+      >
+        BP
+        <SortArrow active={sort.col === "bp"} dir={sort.dir} />
+      </button>
+
+      {/* Accuracy */}
+      <button
+        type="button"
+        className={cn(
+          headerBtnClass("acc"),
+          "flex items-center justify-end gap-0.5"
+        )}
+        onClick={() => onSort("acc")}
+        aria-label="Sort by accuracy"
+      >
+        ACC
+        <SortArrow active={sort.col === "acc"} dir={sort.dir} />
+      </button>
+
+      {/* Usage — placeholder */}
+      <span
+        className="text-muted-foreground/50 cursor-default"
+        title="Coming soon"
+      >
+        Use%
+      </span>
+
+      {/* Effect */}
+      <span className="text-muted-foreground">Effect</span>
+
+      {/* Roles */}
+      <span className="text-muted-foreground">Roles</span>
+    </div>
+  );
+}
+
+// =============================================================================
+// MoveListRow
+// =============================================================================
+
+interface MoveListRowProps {
+  move: MoveData;
+  /** Whether this row is visually highlighted (e.g. matches a filter). */
+  isHighlighted?: boolean;
+  /** Whether this row is selected (e.g. current move in picker). */
+  isSelected?: boolean;
+  /** Called when the row is clicked (e.g. to pick a move). */
+  onSelect?: () => void;
+  /** Called when the type icon is clicked (filter affordance). */
+  onTypeFilter?: (type: string) => void;
+  /** Called when the category icon is clicked (filter affordance). */
+  onCategoryFilter?: (category: string) => void;
+  /** Called when a role chip is clicked (filter affordance). */
+  onRoleFilter?: (roleId: RoleId) => void;
+}
+
+export function MoveListRow({
+  move,
+  isHighlighted,
+  isSelected,
+  onSelect,
+  onTypeFilter,
+  onCategoryFilter,
+  onRoleFilter,
+}: MoveListRowProps) {
+  const roles = getRolesForMove(move.name);
+
+  function handleKey(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (!onSelect) return;
+    if (e.currentTarget !== e.target) return;
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onSelect();
+    }
+  }
+
+  return (
+    <div
+      role={onSelect ? "row" : undefined}
+      aria-label={onSelect ? `Select ${move.name}` : undefined}
+      tabIndex={onSelect ? 0 : undefined}
+      onClick={onSelect}
+      onKeyDown={onSelect ? handleKey : undefined}
+      className={cn(
+        "grid items-center gap-2 border-b px-3 py-1 text-xs transition-colors",
+        onSelect && "cursor-pointer focus:outline-none",
+        onSelect &&
+          "hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
+        isSelected && "bg-accent text-accent-foreground",
+        isHighlighted && !isSelected && "bg-primary/10",
+        MOVE_LIST_GRID
+      )}
+    >
+      {/* Type icon */}
+      {move.type ? (
+        onTypeFilter ? (
+          <button
+            type="button"
+            aria-label={`Filter by ${move.type}`}
+            title={`Filter by ${move.type}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              onTypeFilter(move.type);
+            }}
+            onKeyDown={(e) => e.stopPropagation()}
+            className="focus-visible:ring-primary flex cursor-pointer items-center justify-center rounded outline-none focus-visible:ring-2"
+          >
+            <TypeSymbolIcon
+              type={move.type as Parameters<typeof TypeSymbolIcon>[0]["type"]}
+              size={24}
+            />
+          </button>
+        ) : (
+          <div className="flex items-center justify-center">
+            <TypeSymbolIcon
+              type={move.type as Parameters<typeof TypeSymbolIcon>[0]["type"]}
+              size={24}
+            />
+          </div>
+        )
+      ) : (
+        <span className="text-muted-foreground flex justify-center text-xs">
+          —
+        </span>
+      )}
+
+      {/* Category icon */}
+      {move.category && CATEGORY_ICON_URLS[move.category] ? (
+        onCategoryFilter ? (
+          <button
+            type="button"
+            aria-label={`Filter by ${move.category}`}
+            title={`Filter by ${move.category}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              onCategoryFilter(move.category);
+            }}
+            onKeyDown={(e) => e.stopPropagation()}
+            className="focus-visible:ring-primary flex cursor-pointer items-center justify-center rounded outline-none focus-visible:ring-2"
+          >
+            <Image
+              src={CATEGORY_ICON_URLS[move.category]!}
+              alt={move.category}
+              width={32}
+              height={14}
+              unoptimized
+              className="h-6 w-auto [image-rendering:pixelated]"
+            />
+          </button>
+        ) : (
+          <div className="flex items-center justify-center">
+            <Image
+              src={CATEGORY_ICON_URLS[move.category]!}
+              alt={move.category}
+              width={32}
+              height={14}
+              unoptimized
+              className="h-6 w-auto [image-rendering:pixelated]"
+            />
+          </div>
+        )
+      ) : (
+        <span className="text-muted-foreground flex justify-center font-mono text-xs">
+          —
+        </span>
+      )}
+
+      {/* Name */}
+      <span
+        className={cn(
+          "min-w-0 truncate text-sm font-medium",
+          isHighlighted && "text-foreground"
+        )}
+        title={move.name}
+      >
+        {move.name}
+      </span>
+
+      {/* BP */}
+      <span className="text-muted-foreground text-right font-mono text-xs tabular-nums">
+        {move.basePower > 0 ? move.basePower : "—"}
+      </span>
+
+      {/* Accuracy */}
+      <span className="text-muted-foreground text-right font-mono text-xs tabular-nums">
+        {move.accuracy === true || !move.accuracy
+          ? "—"
+          : `${move.accuracy}%`}
+      </span>
+
+      {/* Usage — coming soon placeholder */}
+      <span
+        className="text-muted-foreground/30 cursor-default text-right font-mono text-xs tabular-nums"
+        title="Coming soon"
+      >
+        —
+      </span>
+
+      {/* Effect (shortDesc) */}
+      <span
+        className="text-muted-foreground min-w-0 truncate text-xs"
+        title={move.shortDesc}
+      >
+        {move.shortDesc !== "No additional effect." ? move.shortDesc : ""}
+      </span>
+
+      {/* Roles */}
+      <div
+        role="presentation"
+        onClick={onRoleFilter ? (e) => e.stopPropagation() : undefined}
+        className="flex min-w-0 flex-wrap gap-1"
+      >
+        {roles.map((roleId) => (
+          <RoleChip
+            key={roleId}
+            roleId={roleId}
+            onClick={onRoleFilter}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/team-builder/pickers/move-list-shared.tsx
+++ b/apps/web/src/components/team-builder/pickers/move-list-shared.tsx
@@ -14,6 +14,7 @@ import { cn } from "@/lib/utils";
 
 import { TypeSymbolIcon } from "../type-symbol-icon";
 import { CATEGORY_ICON_URLS } from "../move-category-ui";
+import { type MoveCategory } from "./move-filter-state";
 import { RoleChip } from "./role-chip";
 import { getRolesForMove, type RoleId } from "./role-registry";
 
@@ -137,7 +138,8 @@ export function MoveListHeader({ sort, onSort, className }: MoveListHeaderProps)
         type="button"
         className={cn(headerBtnClass("name"), "flex items-center gap-0.5")}
         onClick={() => onSort("name")}
-        aria-label="Sort by name"
+        aria-pressed={sort.col === "name"}
+        aria-label={`Sort by name${sort.col === "name" ? `, ${sort.dir === "asc" ? "ascending" : "descending"}` : ""}`}
       >
         Name
         <SortArrow active={sort.col === "name"} dir={sort.dir} />
@@ -151,7 +153,8 @@ export function MoveListHeader({ sort, onSort, className }: MoveListHeaderProps)
           "flex items-center justify-end gap-0.5"
         )}
         onClick={() => onSort("bp")}
-        aria-label="Sort by base power"
+        aria-pressed={sort.col === "bp"}
+        aria-label={`Sort by base power${sort.col === "bp" ? `, ${sort.dir === "asc" ? "ascending" : "descending"}` : ""}`}
       >
         BP
         <SortArrow active={sort.col === "bp"} dir={sort.dir} />
@@ -165,7 +168,8 @@ export function MoveListHeader({ sort, onSort, className }: MoveListHeaderProps)
           "flex items-center justify-end gap-0.5"
         )}
         onClick={() => onSort("acc")}
-        aria-label="Sort by accuracy"
+        aria-pressed={sort.col === "acc"}
+        aria-label={`Sort by accuracy${sort.col === "acc" ? `, ${sort.dir === "asc" ? "ascending" : "descending"}` : ""}`}
       >
         ACC
         <SortArrow active={sort.col === "acc"} dir={sort.dir} />
@@ -203,7 +207,7 @@ interface MoveListRowProps {
   /** Called when the type icon is clicked (filter affordance). */
   onTypeFilter?: (type: string) => void;
   /** Called when the category icon is clicked (filter affordance). */
-  onCategoryFilter?: (category: string) => void;
+  onCategoryFilter?: (category: MoveCategory) => void;
   /** Called when a role chip is clicked (filter affordance). */
   onRoleFilter?: (roleId: RoleId) => void;
 }

--- a/apps/web/src/components/team-builder/pickers/move-list-shared.tsx
+++ b/apps/web/src/components/team-builder/pickers/move-list-shared.tsx
@@ -34,15 +34,15 @@ export type MoveListSortState = { col: MoveListSortCol; dir: MoveListSortDir };
  *
  *   56px                — type icon
  *   56px                — category icon
- *   minmax(140px,1.4fr) — name
+ *   minmax(100px,1fr)   — name
  *   40px                — BP
  *   48px                — Accuracy
- *   48px                — Usage (coming soon)
+ *   56px                — Usage (coming soon)
  *   minmax(0,2fr)       — effect (short description)
  *   minmax(140px,1fr)   — roles chips
  */
 export const MOVE_LIST_GRID =
-  "grid-cols-[56px_56px_minmax(140px,1.4fr)_40px_48px_48px_minmax(0,2fr)_minmax(140px,1fr)]";
+  "grid-cols-[56px_56px_minmax(100px,1fr)_40px_48px_56px_minmax(0,2fr)_minmax(140px,1fr)]";
 
 // =============================================================================
 // Sort logic
@@ -173,10 +173,10 @@ export function MoveListHeader({ sort, onSort, className }: MoveListHeaderProps)
 
       {/* Usage — placeholder */}
       <span
-        className="text-muted-foreground/50 cursor-default"
+        className="text-muted-foreground/50 cursor-default text-center"
         title="Coming soon"
       >
-        Use%
+        USE%
       </span>
 
       {/* Effect */}
@@ -344,7 +344,7 @@ export function MoveListRow({
 
       {/* Usage — coming soon placeholder */}
       <span
-        className="text-muted-foreground/30 cursor-default text-right font-mono text-xs tabular-nums"
+        className="text-muted-foreground/30 cursor-default text-center font-mono text-xs tabular-nums"
         title="Coming soon"
       >
         —

--- a/apps/web/src/components/team-builder/pickers/move-list-shared.tsx
+++ b/apps/web/src/components/team-builder/pickers/move-list-shared.tsx
@@ -236,7 +236,7 @@ export function MoveListRow({
       onClick={onSelect}
       onKeyDown={onSelect ? handleKey : undefined}
       className={cn(
-        "grid items-center gap-2 border-b px-3 py-1 text-xs transition-colors",
+        "grid h-full items-center gap-2 border-b px-3 py-1 text-xs transition-colors",
         onSelect && "cursor-pointer focus:outline-none",
         onSelect &&
           "hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
@@ -362,7 +362,7 @@ export function MoveListRow({
       <div
         role="presentation"
         onClick={onRoleFilter ? (e) => e.stopPropagation() : undefined}
-        className="flex min-w-0 flex-wrap gap-1"
+        className="flex min-w-0 gap-1 overflow-x-auto"
       >
         {roles.map((roleId) => (
           <RoleChip

--- a/apps/web/src/components/team-builder/pickers/move-picker.tsx
+++ b/apps/web/src/components/team-builder/pickers/move-picker.tsx
@@ -374,7 +374,7 @@ export function MovePicker({
                         }}
                         onTypeFilter={handleTypeFilter}
                         onCategoryFilter={(cat) =>
-                          handleCategoryFilter(cat as MoveCategory)
+                          handleCategoryFilter(cat)
                         }
                         onRoleFilter={handleRoleFilter}
                       />

--- a/apps/web/src/components/team-builder/pickers/move-picker.tsx
+++ b/apps/web/src/components/team-builder/pickers/move-picker.tsx
@@ -14,7 +14,6 @@
 import { useRef, useState } from "react";
 
 import { useVirtualizer } from "@tanstack/react-virtual";
-import Image from "next/image";
 
 import {
   getLearnableMoves,
@@ -22,32 +21,28 @@ import {
   getMoveData,
   legalSetOrPermissive,
   type GameFormat,
+  type MoveData,
 } from "@trainers/pokemon";
 import { cn } from "@/lib/utils";
 
-import { CATEGORY_ICON_URLS } from "../move-category-ui";
-import { TypeSymbolIcon } from "../type-symbol-icon";
 import {
   DEFAULT_MOVE_FILTERS,
   type MoveCategory,
   type MoveFilterState,
 } from "./move-filter-state";
+import {
+  MoveListHeader,
+  MoveListRow,
+  type MoveListSortCol,
+  type MoveListSortState,
+} from "./move-list-shared";
 import { MoveSidebar } from "./move-sidebar";
-import { RoleChip } from "./role-chip";
 import { RolePresetsPanel } from "./role-presets-panel";
 import { getRolesForMove, type RoleId } from "./role-registry";
 
 // =============================================================================
 // Types
 // =============================================================================
-
-type SortCol = "type" | "name" | "category" | "bp" | "acc";
-type SortDir = "asc" | "desc";
-
-interface SortState {
-  col: SortCol;
-  dir: SortDir;
-}
 
 interface MovePickerProps {
   value: string | null | undefined;
@@ -59,32 +54,14 @@ interface MovePickerProps {
 
 type MoveRow = {
   name: string;
-  data: ReturnType<typeof getMoveData>;
+  data: MoveData | null;
 };
-
-// =============================================================================
-// Constants
-// =============================================================================
-
-/**
- * Shared grid template for header and data rows.
- *
- *   56px              — type icon (h-6 Showdown badge)
- *   56px              — category icon (h-6 Showdown badge)
- *   minmax(140px,1.4fr) — name (fits longest competitive move names)
- *   minmax(0,2fr)     — effect (short description, truncates if cramped)
- *   40px              — BP
- *   48px              — Accuracy
- *   minmax(140px,1fr) — roles chips
- */
-const ROW_GRID =
-  "grid-cols-[56px_56px_minmax(140px,1.4fr)_minmax(0,2fr)_40px_48px_minmax(140px,1fr)]";
 
 // =============================================================================
 // Helpers
 // =============================================================================
 
-function sortMoves(rows: MoveRow[], sort: SortState): MoveRow[] {
+function sortMoves(rows: MoveRow[], sort: MoveListSortState): MoveRow[] {
   const out = [...rows];
   out.sort((a, b) => {
     let cmp = 0;
@@ -117,162 +94,6 @@ function sortMoves(rows: MoveRow[], sort: SortState): MoveRow[] {
 }
 
 // =============================================================================
-// SortArrow
-// =============================================================================
-
-function SortArrow({ active, dir }: { active: boolean; dir: SortDir }) {
-  if (!active) return null;
-  return (
-    <span aria-hidden="true" className="ml-0.5 inline-block leading-none">
-      {dir === "asc" ? "↑" : "↓"}
-    </span>
-  );
-}
-
-// =============================================================================
-// MoveRow — one row in the virtualized list
-// =============================================================================
-
-interface MoveRowProps {
-  row: MoveRow;
-  isSelected: boolean;
-  onSelect: () => void;
-  onTypeFilter: (type: string) => void;
-  onCategoryFilter: (cat: MoveCategory) => void;
-  onRoleFilter: (roleId: RoleId) => void;
-}
-
-function MoveRowItem({
-  row,
-  isSelected,
-  onSelect,
-  onTypeFilter,
-  onCategoryFilter,
-  onRoleFilter,
-}: MoveRowProps) {
-  const { name, data } = row;
-  const roles = getRolesForMove(name);
-
-  function handleKey(e: React.KeyboardEvent<HTMLDivElement>) {
-    // Only handle Enter/Space when the row itself is focused. Nested
-    // interactive elements (RoleChip <button>, the Type/Category buttons)
-    // bubble keyboard events up to this handler, so without this guard
-    // pressing Enter on a chip would both toggle the chip AND select the
-    // row (closing the picker).
-    if (e.currentTarget !== e.target) return;
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      onSelect();
-    }
-  }
-
-  return (
-    <div
-      role="row"
-      aria-label={`Select ${name}`}
-      tabIndex={0}
-      onClick={onSelect}
-      onKeyDown={handleKey}
-      className={cn(
-        "grid h-full w-full cursor-pointer items-center gap-2 border-b px-3 transition-colors focus:outline-none",
-        "hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
-        isSelected && "bg-accent text-accent-foreground",
-        ROW_GRID
-      )}
-    >
-      {/* Type icon — clickable filter affordance. Real <button> for keyboard
-          accessibility; stopPropagation prevents the row select from firing. */}
-      {data?.type ? (
-        <button
-          type="button"
-          aria-label={`Filter by ${data.type}`}
-          title={`Filter by ${data.type}`}
-          onClick={(e) => {
-            e.stopPropagation();
-            onTypeFilter(data.type!);
-          }}
-          onKeyDown={(e) => e.stopPropagation()}
-          className="focus-visible:ring-primary flex cursor-pointer items-center justify-center rounded outline-none focus-visible:ring-2"
-        >
-          <TypeSymbolIcon
-            type={data.type as Parameters<typeof TypeSymbolIcon>[0]["type"]}
-            size={24}
-          />
-        </button>
-      ) : (
-        <span className="text-muted-foreground flex justify-center text-xs">
-          —
-        </span>
-      )}
-
-      {/* Category icon — clickable filter affordance (real <button>). */}
-      {data?.category && CATEGORY_ICON_URLS[data.category] ? (
-        <button
-          type="button"
-          aria-label={`Filter by ${data.category}`}
-          title={`Filter by ${data.category}`}
-          onClick={(e) => {
-            e.stopPropagation();
-            onCategoryFilter(data.category as MoveCategory);
-          }}
-          onKeyDown={(e) => e.stopPropagation()}
-          className="focus-visible:ring-primary flex cursor-pointer items-center justify-center rounded outline-none focus-visible:ring-2"
-        >
-          <Image
-            src={CATEGORY_ICON_URLS[data.category]!}
-            alt={data.category}
-            width={32}
-            height={14}
-            unoptimized
-            className="h-6 w-auto [image-rendering:pixelated]"
-          />
-        </button>
-      ) : (
-        <span className="text-muted-foreground flex justify-center font-mono text-xs">
-          —
-        </span>
-      )}
-
-      {/* Name */}
-      <span className="min-w-0 truncate text-sm font-medium" title={name}>
-        {name}
-      </span>
-
-      {/* Effect (shortDesc) */}
-      <span
-        className="text-muted-foreground min-w-0 truncate text-xs"
-        title={data?.shortDesc ?? undefined}
-      >
-        {data?.shortDesc && data.shortDesc !== "No additional effect."
-          ? data.shortDesc
-          : ""}
-      </span>
-
-      {/* BP */}
-      <span className="text-muted-foreground text-right font-mono text-xs tabular-nums">
-        {data?.basePower && data.basePower > 0 ? data.basePower : "—"}
-      </span>
-
-      {/* Accuracy */}
-      <span className="text-muted-foreground text-right font-mono text-xs tabular-nums">
-        {data?.accuracy === true || !data?.accuracy ? "—" : `${data.accuracy}%`}
-      </span>
-
-      {/* Roles — click-to-filter, stopPropagation on the container */}
-      <div
-        role="presentation"
-        onClick={(e) => e.stopPropagation()}
-        className="flex min-w-0 flex-wrap gap-1"
-      >
-        {roles.map((roleId) => (
-          <RoleChip key={roleId} roleId={roleId} onClick={onRoleFilter} />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-// =============================================================================
 // MovePicker
 // =============================================================================
 
@@ -294,7 +115,7 @@ export function MovePicker({
   onClose,
 }: MovePickerProps) {
   const [filters, setFilters] = useState<MoveFilterState>(DEFAULT_MOVE_FILTERS);
-  const [sort, setSort] = useState<SortState>({ col: "name", dir: "asc" });
+  const [sort, setSort] = useState<MoveListSortState>({ col: "name", dir: "asc" });
 
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -376,7 +197,7 @@ export function MovePicker({
   // Handlers
   // -------------------------------------------------------------------------
 
-  function handleSort(col: SortCol) {
+  function handleSort(col: MoveListSortCol) {
     setSort((prev) =>
       prev.col === col
         ? { col, dir: prev.dir === "asc" ? "desc" : "asc" }
@@ -405,16 +226,6 @@ export function MovePicker({
       f.roles.includes(roleId)
         ? { ...f, roles: f.roles.filter((r) => r !== roleId) }
         : { ...f, roles: [...f.roles, roleId] }
-    );
-  }
-
-  // -------------------------------------------------------------------------
-  // -------------------------------------------------------------------------
-
-  function headerBtnClass(col: SortCol) {
-    return cn(
-      "cursor-pointer select-none transition-colors hover:text-foreground",
-      sort.col === col ? "text-foreground" : "text-muted-foreground"
     );
   }
 
@@ -510,66 +321,11 @@ export function MovePicker({
             produced layout shift the user objected to). */}
         <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
           {/* Sticky table header */}
-          <div
-            className={cn(
-              "bg-card sticky top-0 z-20 grid shrink-0 items-center gap-2 border-b px-3 py-1.5 text-[10px] font-semibold tracking-wide uppercase",
-              ROW_GRID
-            )}
-          >
-            {/* Type — icon only, no header label */}
-            <span />
-
-            {/* Category — icon only, no header label */}
-            <span />
-
-            {/* Name — sortable */}
-            <button
-              type="button"
-              className={cn(
-                headerBtnClass("name"),
-                "flex items-center gap-0.5"
-              )}
-              onClick={() => handleSort("name")}
-              aria-label="Sort by name"
-            >
-              Name
-              <SortArrow active={sort.col === "name"} dir={sort.dir} />
-            </button>
-
-            {/* Effect — plain label */}
-            <span className="text-muted-foreground">Effect</span>
-
-            {/* BP — sortable */}
-            <button
-              type="button"
-              className={cn(
-                headerBtnClass("bp"),
-                "flex items-center justify-end gap-0.5"
-              )}
-              onClick={() => handleSort("bp")}
-              aria-label="Sort by base power"
-            >
-              BP
-              <SortArrow active={sort.col === "bp"} dir={sort.dir} />
-            </button>
-
-            {/* Accuracy — sortable */}
-            <button
-              type="button"
-              className={cn(
-                headerBtnClass("acc"),
-                "flex items-center justify-end gap-0.5"
-              )}
-              onClick={() => handleSort("acc")}
-              aria-label="Sort by accuracy"
-            >
-              Acc
-              <SortArrow active={sort.col === "acc"} dir={sort.dir} />
-            </button>
-
-            {/* Roles — plain label */}
-            <span className="text-muted-foreground">Roles</span>
-          </div>
+          <MoveListHeader
+            sort={sort}
+            onSort={handleSort}
+            className="bg-card sticky top-0 z-20 shrink-0"
+          />
 
           {/* Virtualized rows */}
           <div
@@ -587,7 +343,11 @@ export function MovePicker({
               >
                 {rowVirtualizer.getVirtualItems().map((virtualRow) => {
                   const item = sorted[virtualRow.index];
-                  if (!item) return null;
+                  if (!item || !item.data) return null;
+                  // Ensure `name` is present — getMoveData includes it in
+                  // production but test mocks may omit it. item.name is the
+                  // canonical source.
+                  const moveData = { ...item.data, name: item.name };
                   return (
                     <div
                       key={item.name}
@@ -597,15 +357,17 @@ export function MovePicker({
                         transform: `translateY(${virtualRow.start}px)`,
                       }}
                     >
-                      <MoveRowItem
-                        row={item}
+                      <MoveListRow
+                        move={moveData}
                         isSelected={item.name === value}
                         onSelect={() => {
                           onPick(item.name);
                           onClose();
                         }}
                         onTypeFilter={handleTypeFilter}
-                        onCategoryFilter={handleCategoryFilter}
+                        onCategoryFilter={(cat) =>
+                          handleCategoryFilter(cat as MoveCategory)
+                        }
                         onRoleFilter={handleRoleFilter}
                       />
                     </div>

--- a/apps/web/src/components/team-builder/pickers/move-picker.tsx
+++ b/apps/web/src/components/team-builder/pickers/move-picker.tsx
@@ -301,18 +301,26 @@ export function MovePicker({
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* Left rail — sidebar on top, role presets below */}
         <div className="border-border flex w-[380px] flex-shrink-0 flex-col border-r">
-          <div className="min-h-0 flex-1 overflow-y-auto">
+          <div className="shrink-0">
             <MoveSidebar filters={filters} onFiltersChange={setFilters} />
           </div>
-          <div className="border-border min-h-0 flex-1 overflow-hidden border-t">
+          <div className="bg-muted/20 border-border min-h-0 flex-1 overflow-y-auto border-t">
             <RolePresetsPanel
               selected={filters.roles}
               onChange={(roles) =>
                 setFilters((f) => ({ ...f, roles }))
               }
               bucketCount={bucketCount}
-              className="h-full"
             />
+          </div>
+          <div className="border-border shrink-0 border-t p-2.5">
+            <button
+              type="button"
+              onClick={() => setFilters((f) => ({ ...DEFAULT_MOVE_FILTERS, search: f.search }))}
+              className="border-border bg-background text-muted-foreground hover:border-destructive/50 hover:text-destructive w-full rounded-md border py-1 text-[11px] transition-colors"
+            >
+              Clear all filters
+            </button>
           </div>
         </div>
 

--- a/apps/web/src/components/team-builder/pickers/move-sidebar.tsx
+++ b/apps/web/src/components/team-builder/pickers/move-sidebar.tsx
@@ -1,12 +1,11 @@
 /**
  * MoveSidebar — left-column panel of the move picker.
  *
- * Renders two filter sections in a fixed-width aside:
- *   1. Type grid (18 types, multi-select OR, 3 columns)
- *   2. Category chips (Physical / Special / Status, multi-select OR)
- *   3. Clear all filters — pinned at bottom, always visible
+ * Renders two filter sections:
+ *   1. Category chips (Physical / Special / Status, multi-select OR)
+ *   2. Type grid (18 types, multi-select OR, 3 columns)
  *
- * Pairs with <RolePresetsPanel> for the middle column inside <MovePicker>.
+ * Pairs with <RolePresetsPanel> for the role section below.
  * Filter state is managed externally via `filters` + `onFiltersChange`.
  */
 "use client";
@@ -14,13 +13,22 @@
 import { ALL_TYPES } from "@trainers/pokemon";
 
 import { cn } from "@/lib/utils";
+import { getTypeStyle } from "@/lib/pokemon/type-colors";
 
 import { TypeSymbolIcon } from "../type-symbol-icon";
 import {
-  DEFAULT_MOVE_FILTERS,
   type MoveCategory,
   type MoveFilterState,
 } from "./move-filter-state";
+
+// =============================================================================
+// Shared section styles (same as species-sidebar)
+// =============================================================================
+
+const SECTION_HEADER =
+  "text-muted-foreground mb-1.5 block text-[9px] font-bold tracking-widest uppercase";
+
+const SECTION_PADDING = "px-3 py-2.5";
 
 // =============================================================================
 // Constants
@@ -65,57 +73,17 @@ export function MoveSidebar({ filters, onFiltersChange }: MoveSidebarProps) {
     onFiltersChange({ ...filters, categories: next });
   }
 
-  function clearAll() {
-    onFiltersChange(DEFAULT_MOVE_FILTERS);
-  }
-
   // ---------------------------------------------------------------------------
   // Render
   // ---------------------------------------------------------------------------
 
   return (
-    <div className="bg-muted/30 flex h-full w-full flex-col">
+    <div className="flex w-full flex-col divide-y divide-border/40">
       {/* ------------------------------------------------------------------ */}
-      {/* 1. Type grid                                                        */}
+      {/* 1. Category chips                                                   */}
       {/* ------------------------------------------------------------------ */}
-      <div className="border-border/60 border-b p-2.5">
-        <span className="text-muted-foreground mb-1.5 block text-[8.5px] font-bold tracking-widest uppercase">
-          Type
-        </span>
-        <div className="grid grid-cols-3 gap-1">
-          {(ALL_TYPES as readonly string[]).map((type) => {
-            const isActive = filters.types.includes(type);
-            return (
-              <button
-                key={type}
-                type="button"
-                aria-label={type}
-                aria-pressed={isActive}
-                onClick={() => toggleType(type)}
-                className={cn(
-                  "flex items-center justify-center rounded px-1 py-1 transition-all",
-                  isActive
-                    ? "ring-primary bg-background ring-2 ring-offset-1"
-                    : "bg-muted/40 opacity-70 hover:opacity-100"
-                )}
-              >
-                <TypeSymbolIcon
-                  type={type as Parameters<typeof TypeSymbolIcon>[0]["type"]}
-                  size={28}
-                />
-              </button>
-            );
-          })}
-        </div>
-      </div>
-
-      {/* ------------------------------------------------------------------ */}
-      {/* 2. Category chips                                                   */}
-      {/* ------------------------------------------------------------------ */}
-      <div className="border-border/60 border-b p-2.5">
-        <span className="text-muted-foreground mb-1.5 block text-[8.5px] font-bold tracking-widest uppercase">
-          Category
-        </span>
+      <div className={SECTION_PADDING}>
+        <span className={SECTION_HEADER}>Category</span>
         <div className="flex flex-wrap gap-1">
           {(["Physical", "Special", "Status"] as const).map((cat) => {
             const isActive = filters.categories.includes(cat);
@@ -146,16 +114,38 @@ export function MoveSidebar({ filters, onFiltersChange }: MoveSidebarProps) {
       </div>
 
       {/* ------------------------------------------------------------------ */}
-      {/* 3. Clear all filters                                                */}
+      {/* 2. Type grid                                                        */}
       {/* ------------------------------------------------------------------ */}
-      <div className="border-border mt-auto border-t p-2.5">
-        <button
-          type="button"
-          onClick={clearAll}
-          className="border-border bg-background text-muted-foreground hover:border-destructive/50 hover:text-destructive w-full rounded-md border py-1 text-[11px] transition-colors"
-        >
-          Clear all filters
-        </button>
+      <div className={SECTION_PADDING}>
+        <span className={SECTION_HEADER}>Type</span>
+        <div className="grid grid-cols-3 gap-1">
+          {(ALL_TYPES as readonly string[]).map((type) => {
+            const isActive = filters.types.includes(type);
+            const typeStyle = getTypeStyle(type);
+            return (
+              <button
+                key={type}
+                type="button"
+                aria-label={type}
+                aria-pressed={isActive}
+                onClick={() => toggleType(type)}
+                className={cn(
+                  "relative flex items-center justify-center rounded border border-transparent px-1 py-1 transition-all",
+                  typeStyle.bg,
+                  isActive
+                    ? cn(typeStyle.border, "ring-primary ring-2 ring-offset-background ring-offset-1")
+                    : cn(typeStyle.borderHover, "before:absolute before:inset-0 before:rounded before:bg-background/50 before:transition-opacity before:pointer-events-none hover:before:opacity-0")
+                )}
+              >
+                <TypeSymbolIcon
+                  type={type as Parameters<typeof TypeSymbolIcon>[0]["type"]}
+                  size={28}
+                  className="relative z-10"
+                />
+              </button>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/team-builder/pickers/role-chip.tsx
+++ b/apps/web/src/components/team-builder/pickers/role-chip.tsx
@@ -21,7 +21,7 @@ export function RoleChip({ roleId, onClick, className }: RoleChipProps) {
   if (!role) return null;
   const colors = GROUP_COLORS[role.group];
   const baseClass = cn(
-    "inline-flex items-center rounded-full border px-1.5 py-0.5 text-[9.5px] font-semibold transition-all",
+    "inline-flex shrink-0 items-center whitespace-nowrap rounded-full border px-1.5 py-0.5 text-[9.5px] font-semibold transition-all",
     colors.chip,
     className
   );

--- a/apps/web/src/components/team-builder/pickers/role-presets-panel.tsx
+++ b/apps/web/src/components/team-builder/pickers/role-presets-panel.tsx
@@ -59,11 +59,11 @@ export function RolePresetsPanel({
   return (
     <div
       className={cn(
-        "bg-muted/20 flex flex-col overflow-hidden px-0 py-2.5",
+        "flex flex-col px-0 py-2.5",
         className
       )}
     >
-      <span className="text-muted-foreground block px-3 pb-1.5 text-[8.5px] font-bold tracking-widest uppercase">
+      <span className="text-muted-foreground block px-3 pb-1.5 text-[9px] font-bold tracking-widest uppercase">
         Role
       </span>
 

--- a/apps/web/src/components/team-builder/pickers/species-expanded-panel.tsx
+++ b/apps/web/src/components/team-builder/pickers/species-expanded-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { getLegalMoves, getMoveData, type MoveData } from "@trainers/pokemon";
 
@@ -18,6 +18,7 @@ import { getRolesForMove, type RoleId } from "./role-registry";
 // =============================================================================
 
 interface SpeciesExpandedPanelProps {
+  id?: string;
   species: string;
   formatId: string;
   /** Currently-active "learns move" filter values — these get highlighted. */
@@ -37,6 +38,7 @@ interface SpeciesExpandedPanelProps {
  * highlighted. The panel is vertically resizable via a drag handle.
  */
 export function SpeciesExpandedPanel({
+  id,
   species,
   formatId,
   filteredMoves,
@@ -48,6 +50,21 @@ export function SpeciesExpandedPanel({
   });
   const [height, setHeight] = useState(320);
   const dragRef = useRef<{ startY: number; startHeight: number } | null>(null);
+  const moveHandlerRef = useRef<((ev: PointerEvent) => void) | null>(null);
+  const upHandlerRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (moveHandlerRef.current) {
+        document.removeEventListener("pointermove", moveHandlerRef.current);
+      }
+      if (upHandlerRef.current) {
+        document.removeEventListener("pointerup", upHandlerRef.current);
+        document.removeEventListener("pointercancel", upHandlerRef.current);
+      }
+      dragRef.current = null;
+    };
+  }, []);
 
   const legalMovesResult = getLegalMoves(species, formatId);
 
@@ -91,7 +108,7 @@ export function SpeciesExpandedPanel({
   }
 
   return (
-    <div className="bg-muted/30 border-border/60 border-t">
+    <div id={id} className="bg-muted/30 border-border/60 border-t">
       {/* Sticky header */}
       <MoveListHeader
         sort={sort}
@@ -116,12 +133,13 @@ export function SpeciesExpandedPanel({
         aria-orientation="horizontal"
         aria-label="Resize learnset panel"
         className="group flex h-2 cursor-row-resize items-center justify-center"
-        onMouseDown={(e) => {
+        onPointerDown={(e) => {
           e.preventDefault();
           e.stopPropagation();
+          e.currentTarget.setPointerCapture(e.pointerId);
           dragRef.current = { startY: e.clientY, startHeight: height };
 
-          function onMouseMove(ev: MouseEvent) {
+          function onPointerMove(ev: PointerEvent) {
             if (!dragRef.current) return;
             const delta = ev.clientY - dragRef.current.startY;
             const next = Math.max(
@@ -131,14 +149,21 @@ export function SpeciesExpandedPanel({
             setHeight(next);
           }
 
-          function onMouseUp() {
+          function onPointerUp() {
             dragRef.current = null;
-            document.removeEventListener("mousemove", onMouseMove);
-            document.removeEventListener("mouseup", onMouseUp);
+            document.removeEventListener("pointermove", onPointerMove);
+            document.removeEventListener("pointerup", onPointerUp);
+            document.removeEventListener("pointercancel", onPointerUp);
+            moveHandlerRef.current = null;
+            upHandlerRef.current = null;
           }
 
-          document.addEventListener("mousemove", onMouseMove);
-          document.addEventListener("mouseup", onMouseUp);
+          moveHandlerRef.current = onPointerMove;
+          upHandlerRef.current = onPointerUp;
+
+          document.addEventListener("pointermove", onPointerMove);
+          document.addEventListener("pointerup", onPointerUp);
+          document.addEventListener("pointercancel", onPointerUp);
         }}
       >
         <div className="bg-border group-hover:bg-foreground/30 h-0.5 w-12 rounded-full transition-colors" />

--- a/apps/web/src/components/team-builder/pickers/species-expanded-panel.tsx
+++ b/apps/web/src/components/team-builder/pickers/species-expanded-panel.tsx
@@ -11,6 +11,7 @@ import {
   type MoveListSortCol,
   type MoveListSortState,
 } from "./move-list-shared";
+import { getRolesForMove, type RoleId } from "./role-registry";
 
 // =============================================================================
 // Types
@@ -21,6 +22,8 @@ interface SpeciesExpandedPanelProps {
   formatId: string;
   /** Currently-active "learns move" filter values — these get highlighted. */
   filteredMoves: readonly string[];
+  /** Currently-active role filters — moves are filtered to only show matches. */
+  filteredRoles: readonly RoleId[];
 }
 
 // =============================================================================
@@ -37,6 +40,7 @@ export function SpeciesExpandedPanel({
   species,
   formatId,
   filteredMoves,
+  filteredRoles,
 }: SpeciesExpandedPanelProps) {
   const [sort, setSort] = useState<MoveListSortState>({
     col: "bp",
@@ -63,7 +67,16 @@ export function SpeciesExpandedPanel({
     if (data) allMoves.push(data);
   }
 
-  const sorted = sortMoveData(allMoves, sort);
+  // Filter by active roles — a move must carry ALL selected roles (AND logic)
+  const visibleMoves =
+    filteredRoles.length > 0
+      ? allMoves.filter((move) => {
+          const moveRoles = getRolesForMove(move.name);
+          return filteredRoles.some((role) => moveRoles.includes(role));
+        })
+      : allMoves;
+
+  const sorted = sortMoveData(visibleMoves, sort);
 
   const filteredMovesLower = new Set(
     filteredMoves.map((m) => m.toLowerCase())
@@ -79,16 +92,6 @@ export function SpeciesExpandedPanel({
 
   return (
     <div className="bg-muted/30 border-border/60 border-t">
-      {/* Label */}
-      <div className="flex items-center gap-2 px-3 pt-2 pb-1">
-        <span className="text-muted-foreground text-[10px] font-semibold uppercase tracking-wider">
-          Learnset
-        </span>
-        <span className="text-muted-foreground/70 text-[10px]">
-          {allMoves.length} moves
-        </span>
-      </div>
-
       {/* Sticky header */}
       <MoveListHeader
         sort={sort}

--- a/apps/web/src/components/team-builder/pickers/species-expanded-panel.tsx
+++ b/apps/web/src/components/team-builder/pickers/species-expanded-panel.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+import { getLegalMoves, getMoveData, type MoveData } from "@trainers/pokemon";
+
+import {
+  MoveListHeader,
+  MoveListRow,
+  sortMoveData,
+  type MoveListSortCol,
+  type MoveListSortState,
+} from "./move-list-shared";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface SpeciesExpandedPanelProps {
+  species: string;
+  formatId: string;
+  /** Currently-active "learns move" filter values — these get highlighted. */
+  filteredMoves: readonly string[];
+}
+
+// =============================================================================
+// SpeciesExpandedPanel
+// =============================================================================
+
+/**
+ * Expanded content panel for a species row in the picker.
+ * Shows the full learnset as a sortable move list matching the move picker
+ * dialog layout. Filtered moves (from the "learns move" filter) are
+ * highlighted. The panel is vertically resizable via a drag handle.
+ */
+export function SpeciesExpandedPanel({
+  species,
+  formatId,
+  filteredMoves,
+}: SpeciesExpandedPanelProps) {
+  const [sort, setSort] = useState<MoveListSortState>({
+    col: "bp",
+    dir: "desc",
+  });
+  const [height, setHeight] = useState(320);
+  const dragRef = useRef<{ startY: number; startHeight: number } | null>(null);
+
+  const legalMovesResult = getLegalMoves(species, formatId);
+
+  // Handle unavailable/undefined results
+  if (!legalMovesResult || typeof legalMovesResult === "symbol") {
+    return (
+      <div className="text-muted-foreground px-4 py-3 text-xs">
+        Learnset data unavailable for this format.
+      </div>
+    );
+  }
+
+  // Build move data list
+  const allMoves: MoveData[] = [];
+  for (const moveName of legalMovesResult) {
+    const data = getMoveData(moveName);
+    if (data) allMoves.push(data);
+  }
+
+  const sorted = sortMoveData(allMoves, sort);
+
+  const filteredMovesLower = new Set(
+    filteredMoves.map((m) => m.toLowerCase())
+  );
+
+  function handleSort(col: MoveListSortCol) {
+    setSort((prev) =>
+      prev.col === col
+        ? { col, dir: prev.dir === "asc" ? "desc" : "asc" }
+        : { col, dir: col === "name" ? "asc" : "desc" }
+    );
+  }
+
+  return (
+    <div className="bg-muted/30 border-border/60 border-t">
+      {/* Label */}
+      <div className="flex items-center gap-2 px-3 pt-2 pb-1">
+        <span className="text-muted-foreground text-[10px] font-semibold uppercase tracking-wider">
+          Learnset
+        </span>
+        <span className="text-muted-foreground/70 text-[10px]">
+          {allMoves.length} moves
+        </span>
+      </div>
+
+      {/* Sticky header */}
+      <MoveListHeader
+        sort={sort}
+        onSort={handleSort}
+        className="bg-muted/50 sticky top-0 z-10"
+      />
+
+      {/* Scrollable move rows — resizable via drag handle */}
+      <div className="overflow-y-auto" style={{ maxHeight: `${height}px` }}>
+        {sorted.map((move) => (
+          <MoveListRow
+            key={move.name}
+            move={move}
+            isHighlighted={filteredMovesLower.has(move.name.toLowerCase())}
+          />
+        ))}
+      </div>
+
+      {/* Resize handle */}
+      <div
+        role="separator"
+        aria-orientation="horizontal"
+        aria-label="Resize learnset panel"
+        className="group flex h-2 cursor-row-resize items-center justify-center"
+        onMouseDown={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          dragRef.current = { startY: e.clientY, startHeight: height };
+
+          function onMouseMove(ev: MouseEvent) {
+            if (!dragRef.current) return;
+            const delta = ev.clientY - dragRef.current.startY;
+            const next = Math.max(
+              120,
+              Math.min(800, dragRef.current.startHeight + delta)
+            );
+            setHeight(next);
+          }
+
+          function onMouseUp() {
+            dragRef.current = null;
+            document.removeEventListener("mousemove", onMouseMove);
+            document.removeEventListener("mouseup", onMouseUp);
+          }
+
+          document.addEventListener("mousemove", onMouseMove);
+          document.addEventListener("mouseup", onMouseUp);
+        }}
+      >
+        <div className="bg-border group-hover:bg-foreground/30 h-0.5 w-12 rounded-full transition-colors" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/team-builder/pickers/species-picker-dialog.tsx
+++ b/apps/web/src/components/team-builder/pickers/species-picker-dialog.tsx
@@ -44,7 +44,7 @@ export function SpeciesPickerDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         showCloseButton={false}
-        className="flex h-[min(calc(100vh-2rem),1400px)] w-[calc(100vw-2rem)] max-w-[1600px] flex-col gap-0 overflow-hidden rounded-xl p-0 sm:max-w-[1600px]"
+        className="ring-primary/50 flex h-[min(calc(100vh-2rem),1400px)] w-[calc(100vw-2rem)] max-w-[1600px] flex-col gap-0 overflow-hidden rounded-xl p-0 ring-2 sm:max-w-[1600px]"
       >
         <DialogTitle className="sr-only">Choose species</DialogTitle>
         <SpeciesPicker

--- a/apps/web/src/components/team-builder/pickers/species-picker.tsx
+++ b/apps/web/src/components/team-builder/pickers/species-picker.tsx
@@ -290,7 +290,6 @@ function SpeciesRow({
       <div
         role="row"
         aria-label={`Select ${entry.species}`}
-        aria-expanded={isExpanded}
         tabIndex={0}
         onClick={onSelect}
         onKeyDown={handleRowKey}
@@ -304,6 +303,8 @@ function SpeciesRow({
         <button
           type="button"
           aria-label={isExpanded ? `Collapse ${entry.species}` : `Expand ${entry.species}`}
+          aria-expanded={isExpanded}
+          aria-controls={`panel-${entry.species}`}
           onClick={(e) => {
             e.stopPropagation();
             onToggleExpand();
@@ -370,21 +371,21 @@ function SpeciesRow({
               onFilter={onFilterAbility}
             />
           </div>
-          {(entry.abilitySlot2 || entry.hiddenAbility) && (
+          {entry.abilitySlot2 && (
             <div className="flex min-w-0 items-baseline gap-1">
               <span className="text-muted-foreground/50 inline-block w-2.5 shrink-0 text-center text-[8px]">●</span>
               <AbilityCell
-                name={entry.abilitySlot2 ?? null}
+                name={entry.abilitySlot2}
                 slot="slot2"
                 onFilter={onFilterAbility}
               />
             </div>
           )}
-          {(entry.abilitySlot2 || entry.hiddenAbility) && (
+          {entry.hiddenAbility && (
             <div className="flex min-w-0 items-baseline gap-1">
               <span className="text-amber-400/70 inline-block w-2.5 shrink-0 text-center text-[8px]">★</span>
               <AbilityCell
-                name={entry.hiddenAbility ?? null}
+                name={entry.hiddenAbility}
                 slot="hidden"
                 onFilter={onFilterAbility}
               />
@@ -469,6 +470,7 @@ function SpeciesRow({
       {isExpanded && (
         <div className="border-b">
           <SpeciesExpandedPanel
+            id={`panel-${entry.species}`}
             species={entry.species}
             formatId={formatId}
             filteredMoves={filteredMoves}

--- a/apps/web/src/components/team-builder/pickers/species-picker.tsx
+++ b/apps/web/src/components/team-builder/pickers/species-picker.tsx
@@ -4,7 +4,16 @@ import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { ChevronRight, Search } from "lucide-react";
+import {
+  ChevronRight,
+  Filter,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Search,
+  Sparkles,
+  Swords,
+  Zap,
+} from "lucide-react";
 
 import {
   ALL_TYPES,
@@ -46,14 +55,14 @@ const HIGH_STAT_THRESHOLD = 110;
  *   20px               — expand/collapse chevron
  *   56px               — sprite circle
  *   minmax(170px,2fr)  — name
- *   60px               — types (two icons)
+ *   72px               — types (two icons + right padding)
  *   minmax(120px,1.5fr)— abilities (stacked: ● slot1, ● slot2, ★ hidden)
- *   repeat(6,38px)     — HP/Atk/Def/SpA/SpD/Spe
- *   42px               — BST
+ *   repeat(6,48px)     — HP/Atk/Def/SpA/SpD/Spe (label + sort arrow)
+ *   48px               — BST
  *   minmax(0,2fr)      — matching move chips (collapses when empty)
  */
 const ROW_GRID =
-  "grid-cols-[20px_56px_minmax(170px,2fr)_60px_minmax(120px,1.5fr)_repeat(6,38px)_42px_minmax(0,2fr)]";
+  "grid-cols-[20px_56px_minmax(170px,2fr)_72px_minmax(120px,1.5fr)_repeat(6,48px)_48px_minmax(0,2fr)]";
 
 /** Default format ID used when no format is active. */
 const DEFAULT_FORMAT_ID = "gen9vgc2025regg";
@@ -189,11 +198,15 @@ function SortHeaderButton({
       )}
     >
       {label}
-      {isActive && (
-        <span aria-hidden="true" className="text-[8px] leading-none">
-          {sort.dir === "asc" ? "↑" : "↓"}
-        </span>
-      )}
+      <span
+        aria-hidden="true"
+        className={cn(
+          "text-[8px] leading-none",
+          !isActive && "invisible"
+        )}
+      >
+        {isActive && sort.dir === "asc" ? "↑" : "↓"}
+      </span>
     </button>
   );
 }
@@ -304,15 +317,15 @@ function SpeciesRow({
           <ChevronRight className="size-4" />
         </button>
 
-        {/* Sprite — 64px circle */}
-        <div className="bg-primary/10 relative z-10 flex size-16 shrink-0 items-center justify-center rounded-full">
+        {/* Sprite — 48px circle inside 56px column */}
+        <div className="bg-primary/10 relative z-10 flex size-12 shrink-0 items-center justify-center self-center rounded-full">
           <Image
             src={sprite.url}
             alt={entry.species}
-            width={56}
-            height={56}
+            width={40}
+            height={40}
             className={cn(
-              "size-14 object-contain",
+              "size-10 object-contain",
               sprite.pixelated && "[image-rendering:pixelated]"
             )}
             unoptimized
@@ -481,6 +494,143 @@ export function warmSpeciesIndex(formatId: string): void {
 }
 
 // =============================================================================
+// CollapsedSidebarStrip
+// =============================================================================
+
+/**
+ * Thin icon strip shown when the filter sidebar is collapsed.
+ *
+ * Shows vertically stacked icon buttons representing each filter section,
+ * with small badges indicating active filter counts. Clicking any icon
+ * expands the sidebar. The top button is the expand toggle.
+ */
+function CollapsedSidebarStrip({
+  filters,
+  onExpand,
+}: {
+  filters: SpeciesFilterState;
+  onExpand: () => void;
+}) {
+  const typeCount = filters.types.length;
+  const moveCount = filters.moves.length;
+  const roleCount = filters.roles.length;
+  const hasAbility = filters.ability !== null;
+  const totalActive =
+    typeCount + moveCount + roleCount + (hasAbility ? 1 : 0) + (filters.megaOnly ? 1 : 0);
+
+  return (
+    <div className="bg-muted/50 flex h-full flex-col items-center gap-1 py-2">
+      {/* Expand toggle */}
+      <button
+        type="button"
+        onClick={onExpand}
+        aria-label="Expand filter sidebar"
+        className="text-muted-foreground hover:text-foreground hover:bg-accent relative rounded p-1.5 transition-colors"
+      >
+        <PanelLeftOpen className="size-4" />
+      </button>
+
+      <div className="bg-border my-1 h-px w-6" />
+
+      {/* Filter indicator — total count */}
+      <button
+        type="button"
+        onClick={onExpand}
+        aria-label={`${totalActive} active filters — expand sidebar`}
+        className={cn(
+          "relative rounded p-1.5 transition-colors",
+          totalActive > 0
+            ? "text-primary hover:bg-primary/10"
+            : "text-muted-foreground hover:text-foreground hover:bg-accent"
+        )}
+      >
+        <Filter className="size-4" />
+        {totalActive > 0 && (
+          <span className="bg-primary absolute -top-0.5 -right-0.5 flex size-3.5 items-center justify-center rounded-full text-[8px] font-bold text-white">
+            {totalActive}
+          </span>
+        )}
+      </button>
+
+      {/* Type filter indicator */}
+      <button
+        type="button"
+        onClick={onExpand}
+        aria-label={`${typeCount} type filters — expand sidebar`}
+        className={cn(
+          "relative rounded p-1.5 transition-colors",
+          typeCount > 0
+            ? "text-primary hover:bg-primary/10"
+            : "text-muted-foreground hover:text-foreground hover:bg-accent"
+        )}
+      >
+        <Sparkles className="size-4" />
+        {typeCount > 0 && (
+          <span className="bg-primary absolute -top-0.5 -right-0.5 flex size-3.5 items-center justify-center rounded-full text-[8px] font-bold text-white">
+            {typeCount}
+          </span>
+        )}
+      </button>
+
+      {/* Ability indicator */}
+      <button
+        type="button"
+        onClick={onExpand}
+        aria-label={hasAbility ? `Ability: ${filters.ability} — expand sidebar` : "Ability filter — expand sidebar"}
+        className={cn(
+          "relative rounded p-1.5 transition-colors",
+          hasAbility
+            ? "text-primary hover:bg-primary/10"
+            : "text-muted-foreground hover:text-foreground hover:bg-accent"
+        )}
+      >
+        <Zap className="size-4" />
+        {hasAbility && (
+          <span className="bg-primary absolute -top-0.5 -right-0.5 flex size-3.5 items-center justify-center rounded-full text-[8px] font-bold text-white">
+            1
+          </span>
+        )}
+      </button>
+
+      {/* Move filter indicator */}
+      <button
+        type="button"
+        onClick={onExpand}
+        aria-label={`${moveCount} move filters — expand sidebar`}
+        className={cn(
+          "relative rounded p-1.5 transition-colors",
+          moveCount > 0
+            ? "text-primary hover:bg-primary/10"
+            : "text-muted-foreground hover:text-foreground hover:bg-accent"
+        )}
+      >
+        <Swords className="size-4" />
+        {moveCount > 0 && (
+          <span className="bg-primary absolute -top-0.5 -right-0.5 flex size-3.5 items-center justify-center rounded-full text-[8px] font-bold text-white">
+            {moveCount}
+          </span>
+        )}
+      </button>
+
+      {/* Role filter indicator */}
+      {roleCount > 0 && (
+        <button
+          type="button"
+          onClick={onExpand}
+          aria-label={`${roleCount} role filters — expand sidebar`}
+          className="text-primary hover:bg-primary/10 relative rounded p-1.5 transition-colors"
+        >
+          <span className="text-[10px] font-bold leading-none">R</span>
+          <span className="bg-primary absolute -top-0.5 -right-0.5 flex size-3.5 items-center justify-center rounded-full text-[8px] font-bold text-white">
+            {roleCount}
+          </span>
+        </button>
+      )}
+    </div>
+  );
+}
+
+// =============================================================================
 // SpeciesPicker
 // =============================================================================
 
@@ -514,6 +664,9 @@ export function SpeciesPicker({
 
   // Track which species row is expanded (null = none expanded)
   const [expandedSpecies, setExpandedSpecies] = useState<string | null>(null);
+
+  // Sidebar collapsed state
+  const [sidebarOpen, setSidebarOpen] = useState(true);
 
   // Scroll container ref for the virtualizer
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -760,7 +913,7 @@ export function SpeciesPicker({
             <button
               type="button"
               onClick={clearAllFilters}
-              className="text-primary hover:bg-primary/10 border-primary/30 bg-primary/5 inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] font-medium transition-colors"
+              className="text-primary hover:bg-primary/10 border-primary/30 bg-primary/5 inline-flex items-center gap-1 whitespace-nowrap rounded-md border px-2 py-0.5 text-[11px] font-medium transition-colors"
               aria-label={`Clear ${activeFilterCount} active ${activeFilterCount === 1 ? "filter" : "filters"}`}
             >
               {activeFilterCount}{" "}
@@ -780,41 +933,70 @@ export function SpeciesPicker({
       {/* 3-column body                                                          */}
       {/* -------------------------------------------------------------------- */}
       <div className="flex min-h-0 flex-1 overflow-hidden">
-        {/* Left rail — sidebar (top) + role presets (bottom). Single column,
-            stacked vertically. Sidebar takes natural height, roles fill rest. */}
-        <div className="border-border flex w-[380px] flex-shrink-0 flex-col border-r">
-          <div className="min-h-0 overflow-y-auto">
-            <SpeciesSidebar
-              filters={filters}
-              onFiltersChange={setFilters}
-              format={format}
-              currentTeam={currentTeam}
-            />
-          </div>
-          <div className="border-border min-h-0 flex-1 overflow-hidden border-t">
-            <RolePresetsPanel
-              selected={filters.roles}
-              onChange={(next) =>
-                setFilters((prev) => ({
-                  ...prev,
-                  roles: next,
-                }))
-              }
-              bucketCount={bucketCount}
-              className="h-full"
-            />
-          </div>
+        {/* Left rail — collapsible sidebar with smooth transition.
+            Expanded: full filter panel (sidebar + roles + clear).
+            Collapsed: thin icon strip with filter indicators. */}
+        <div
+          className={cn(
+            "border-border flex flex-shrink-0 flex-col border-r transition-[width] duration-200 ease-in-out",
+            sidebarOpen ? "w-[340px]" : "w-12"
+          )}
+        >
+          {sidebarOpen ? (
+            <>
+              {/* Collapse toggle — top of expanded sidebar */}
+              <div className="border-border flex shrink-0 items-center justify-between border-b px-3 py-1.5">
+                <span className="text-muted-foreground text-[9px] font-bold tracking-widest uppercase">
+                  Filters
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setSidebarOpen(false)}
+                  aria-label="Collapse filter sidebar"
+                  className="text-muted-foreground hover:text-foreground -mr-1 rounded p-0.5 transition-colors"
+                >
+                  <PanelLeftClose className="size-4" />
+                </button>
+              </div>
 
-          {/* Clear all filters — pinned at bottom of left rail */}
-          <div className="border-border shrink-0 border-t px-3 py-2">
-            <button
-              type="button"
-              onClick={clearAllFilters}
-              className="bg-muted text-muted-foreground hover:bg-accent hover:text-accent-foreground w-full rounded px-2 py-1.5 text-[11px] font-medium transition-colors"
-            >
-              Clear all filters
-            </button>
-          </div>
+              <div className="min-h-0 overflow-y-auto">
+                <SpeciesSidebar
+                  filters={filters}
+                  onFiltersChange={setFilters}
+                  format={format}
+                  currentTeam={currentTeam}
+                />
+              </div>
+              <div className="bg-muted/20 border-border min-h-0 flex-1 overflow-y-auto border-t">
+                <RolePresetsPanel
+                  selected={filters.roles}
+                  onChange={(next) =>
+                    setFilters((prev) => ({
+                      ...prev,
+                      roles: next,
+                    }))
+                  }
+                  bucketCount={bucketCount}
+                />
+              </div>
+
+              {/* Clear all filters — pinned at bottom of left rail */}
+              <div className="border-border shrink-0 border-t px-3 py-2">
+                <button
+                  type="button"
+                  onClick={clearAllFilters}
+                  className="bg-muted text-muted-foreground hover:bg-accent hover:text-accent-foreground w-full rounded px-2 py-1.5 text-[11px] font-medium transition-colors"
+                >
+                  Clear all filters
+                </button>
+              </div>
+            </>
+          ) : (
+            <CollapsedSidebarStrip
+              filters={filters}
+              onExpand={() => setSidebarOpen(true)}
+            />
+          )}
         </div>
 
         {/* Right — table (always rendered, filtered by query). When the
@@ -869,7 +1051,7 @@ export function SpeciesPicker({
                 <span className="text-muted-foreground text-center text-[9px] whitespace-nowrap">
                   Types
                 </span>
-                <span className="text-muted-foreground text-[9px] whitespace-nowrap">
+                <span className="text-muted-foreground text-center text-[9px] whitespace-nowrap">
                   Abilities
                 </span>
                 <SortHeaderButton
@@ -927,7 +1109,7 @@ export function SpeciesPicker({
                   sort={sort}
                   onSort={handleSort}
                 />
-                <span className="text-muted-foreground text-[9px] whitespace-nowrap">
+                <span className="text-muted-foreground text-center text-[9px] whitespace-nowrap">
                   Moves
                 </span>
               </div>

--- a/apps/web/src/components/team-builder/pickers/species-picker.tsx
+++ b/apps/web/src/components/team-builder/pickers/species-picker.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { Search } from "lucide-react";
+import { ChevronRight, Search } from "lucide-react";
 
 import {
   ALL_TYPES,
@@ -29,6 +29,7 @@ import {
 } from "./species-filter-state";
 import { SpeciesSidebar } from "./species-sidebar";
 import { SpeciesSmartSearch } from "./species-smart-search";
+import { SpeciesExpandedPanel } from "./species-expanded-panel";
 
 // =============================================================================
 // Constants
@@ -40,6 +41,7 @@ const HIGH_STAT_THRESHOLD = 110;
 /**
  * Shared Tailwind grid template for each data row.
  *
+ *   20px              — expand/collapse chevron
  *   64px              — sprite circle (size-16, sprite rendered at size-14)
  *   minmax(180px,2fr) — name column. 180px floor fits "Kangaskhan-Mega",
  *                       "Aegislash-Blade", "Charizard-Mega-X", etc. without
@@ -61,7 +63,7 @@ const HIGH_STAT_THRESHOLD = 110;
  *                       by base-stat total)
  */
 const ROW_GRID =
-  "grid-cols-[64px_minmax(180px,2fr)_72px_minmax(160px,2fr)_minmax(180px,2fr)_repeat(6,44px)_48px]";
+  "grid-cols-[20px_64px_minmax(180px,2fr)_72px_minmax(160px,2fr)_minmax(180px,2fr)_repeat(6,44px)_48px]";
 
 /** Default format ID used when no format is active. */
 const DEFAULT_FORMAT_ID = "gen9vgc2025regg";
@@ -227,14 +229,22 @@ const STAT_HEADER_COLORS: Record<
 interface SpeciesRowProps {
   entry: SpeciesSearchEntry;
   isCurrent: boolean;
+  isExpanded: boolean;
+  formatId: string;
+  filteredMoves: readonly string[];
   onSelect: () => void;
+  onToggleExpand: () => void;
   onFilterAbility: (ability: string) => void;
 }
 
 function SpeciesRow({
   entry,
   isCurrent,
+  isExpanded,
+  formatId,
+  filteredMoves,
   onSelect,
+  onToggleExpand,
   onFilterAbility,
 }: SpeciesRowProps) {
   const sprite = getPokemonSprite(entry.species);
@@ -250,154 +260,186 @@ function SpeciesRow({
   }
 
   return (
-    // Using `<div role="row" tabIndex={0}>` instead of a wrapping `<button>`
-    // because the row contains nested interactive elements (AbilityCell
-    // `<button>`s) and nested buttons are invalid HTML. The row is itself
-    // keyboard-accessible (tabIndex + onKeyDown handles Enter/Space) and
-    // mouse-accessible (onClick fires onSelect). Nested AbilityCell buttons
-    // stopPropagation so cell clicks don't also select the row.
-    <div
-      role="row"
-      aria-label={`Select ${entry.species}`}
-      tabIndex={0}
-      onClick={onSelect}
-      onKeyDown={handleRowKey}
-      className={cn(
-        "hover:bg-muted/60 focus-visible:bg-muted/80 focus-visible:outline-primary relative grid w-full cursor-pointer items-center gap-2 border-b px-4 py-2 text-left transition-colors outline-none focus-visible:outline-2",
-        ROW_GRID,
-        isCurrent && "bg-primary/5"
-      )}
-    >
-      {/* Sprite — 64px circle, image rendered at 56px */}
-      <div className="bg-primary/10 relative z-10 flex size-16 shrink-0 items-center justify-center rounded-full">
-        <Image
-          src={sprite.url}
-          alt={entry.species}
-          width={56}
-          height={56}
+    <div>
+      {/* Using `<div role="row" tabIndex={0}>` instead of a wrapping `<button>`
+          because the row contains nested interactive elements (AbilityCell
+          `<button>`s) and nested buttons are invalid HTML. The row is itself
+          keyboard-accessible (tabIndex + onKeyDown handles Enter/Space) and
+          mouse-accessible (onClick fires onSelect). Nested AbilityCell buttons
+          stopPropagation so cell clicks don't also select the row. */}
+      <div
+        role="row"
+        aria-label={`Select ${entry.species}`}
+        aria-expanded={isExpanded}
+        tabIndex={0}
+        onClick={onSelect}
+        onKeyDown={handleRowKey}
+        className={cn(
+          "hover:bg-muted/60 focus-visible:bg-muted/80 focus-visible:outline-primary relative grid w-full cursor-pointer items-center gap-2 px-4 py-2 text-left transition-colors outline-none focus-visible:outline-2",
+          ROW_GRID,
+          isCurrent && "bg-primary/5",
+          !isExpanded && "border-b"
+        )}
+      >
+        {/* Expand/collapse chevron */}
+        <button
+          type="button"
+          aria-label={isExpanded ? `Collapse ${entry.species}` : `Expand ${entry.species}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleExpand();
+          }}
+          onKeyDown={(e) => e.stopPropagation()}
           className={cn(
-            "size-14 object-contain",
-            sprite.pixelated && "[image-rendering:pixelated]"
+            "text-muted-foreground hover:text-foreground relative z-10 flex items-center justify-center transition-transform",
+            isExpanded && "rotate-90"
           )}
-          unoptimized
-        />
-      </div>
+        >
+          <ChevronRight className="size-4" />
+        </button>
 
-      {/* Name */}
-      <span className="text-foreground relative z-10 min-w-0 truncate text-sm font-semibold">
-        {entry.species}
-      </span>
-
-      <div className="relative z-10 flex min-w-0 items-center gap-1.5">
-        {entry.types[0] ? (
-          <TypeSymbolIcon
-            type={
-              entry.types[0] as Parameters<typeof TypeSymbolIcon>[0]["type"]
-            }
-            size={28}
+        {/* Sprite — 64px circle */}
+        <div className="bg-primary/10 relative z-10 flex size-16 shrink-0 items-center justify-center rounded-full">
+          <Image
+            src={sprite.url}
+            alt={entry.species}
+            width={56}
+            height={56}
+            className={cn(
+              "size-14 object-contain",
+              sprite.pixelated && "[image-rendering:pixelated]"
+            )}
+            unoptimized
           />
-        ) : (
-          <span className="text-muted-foreground text-xs">—</span>
-        )}
-        {entry.types[1] ? (
-          <TypeSymbolIcon
-            type={
-              entry.types[1] as Parameters<typeof TypeSymbolIcon>[0]["type"]
-            }
-            size={28}
-          />
-        ) : (
-          <span className="text-muted-foreground text-xs">—</span>
-        )}
-      </div>
+        </div>
 
-      {/* Regular abilities — slot 1 stacked above slot 2, left-aligned.
-          If the species has only one regular ability, render just that one. */}
-      <div className="relative z-10 flex min-w-0 flex-col justify-center gap-0.5 overflow-hidden">
-        {entry.abilitySlot1 ? (
+        {/* Name */}
+        <span className="text-foreground relative z-10 min-w-0 truncate text-sm font-semibold">
+          {entry.species}
+        </span>
+
+        <div className="relative z-10 flex min-w-0 items-center gap-1.5">
+          {entry.types[0] ? (
+            <TypeSymbolIcon
+              type={
+                entry.types[0] as Parameters<typeof TypeSymbolIcon>[0]["type"]
+              }
+              size={28}
+            />
+          ) : (
+            <span className="text-muted-foreground text-xs">—</span>
+          )}
+          {entry.types[1] ? (
+            <TypeSymbolIcon
+              type={
+                entry.types[1] as Parameters<typeof TypeSymbolIcon>[0]["type"]
+              }
+              size={28}
+            />
+          ) : (
+            <span className="text-muted-foreground text-xs">—</span>
+          )}
+        </div>
+
+        {/* Regular abilities — slot 1 stacked above slot 2, left-aligned.
+            If the species has only one regular ability, render just that one. */}
+        <div className="relative z-10 flex min-w-0 flex-col justify-center gap-0.5 overflow-hidden">
+          {entry.abilitySlot1 ? (
+            <AbilityCell
+              name={entry.abilitySlot1}
+              slot="slot1"
+              onFilter={onFilterAbility}
+            />
+          ) : null}
+          {entry.abilitySlot2 ? (
+            <AbilityCell
+              name={entry.abilitySlot2}
+              slot="slot2"
+              onFilter={onFilterAbility}
+            />
+          ) : null}
+        </div>
+
+        {/* Hidden ability — italic + muted, left-aligned in its own column */}
+        <div className="relative z-10 flex min-w-0 items-center overflow-hidden">
           <AbilityCell
-            name={entry.abilitySlot1}
-            slot="slot1"
+            name={entry.hiddenAbility ?? null}
+            slot="hidden"
             onFilter={onFilterAbility}
           />
-        ) : null}
-        {entry.abilitySlot2 ? (
-          <AbilityCell
-            name={entry.abilitySlot2}
-            slot="slot2"
-            onFilter={onFilterAbility}
+        </div>
+
+        {/* HP */}
+        <span
+          className={cn(
+            "relative z-10 text-center font-mono text-xs tabular-nums",
+            statValueClass(entry.baseStats.hp)
+          )}
+        >
+          {entry.baseStats.hp}
+        </span>
+        {/* Atk */}
+        <span
+          className={cn(
+            "relative z-10 text-center font-mono text-xs tabular-nums",
+            statValueClass(entry.baseStats.atk)
+          )}
+        >
+          {entry.baseStats.atk}
+        </span>
+        {/* Def */}
+        <span
+          className={cn(
+            "relative z-10 text-center font-mono text-xs tabular-nums",
+            statValueClass(entry.baseStats.def)
+          )}
+        >
+          {entry.baseStats.def}
+        </span>
+        {/* SpA */}
+        <span
+          className={cn(
+            "relative z-10 text-center font-mono text-xs tabular-nums",
+            statValueClass(entry.baseStats.spa)
+          )}
+        >
+          {entry.baseStats.spa}
+        </span>
+        {/* SpD */}
+        <span
+          className={cn(
+            "relative z-10 text-center font-mono text-xs tabular-nums",
+            statValueClass(entry.baseStats.spd)
+          )}
+        >
+          {entry.baseStats.spd}
+        </span>
+        {/* Spe */}
+        <span
+          className={cn(
+            "relative z-10 text-center font-mono text-xs tabular-nums",
+            statValueClass(entry.baseStats.spe)
+          )}
+        >
+          {entry.baseStats.spe}
+        </span>
+
+        {/* BST */}
+        <span className="border-border/60 text-foreground relative z-10 border-l pl-1.5 text-center font-mono text-xs font-semibold tabular-nums">
+          {entry.bst}
+        </span>
+      </div>
+
+      {/* Expanded content — learnset panel */}
+      {isExpanded && (
+        <div className="border-b">
+          <SpeciesExpandedPanel
+            species={entry.species}
+            formatId={formatId}
+            filteredMoves={filteredMoves}
           />
-        ) : null}
-      </div>
-
-      {/* Hidden ability — italic + muted, left-aligned in its own column */}
-      <div className="relative z-10 flex min-w-0 items-center overflow-hidden">
-        <AbilityCell
-          name={entry.hiddenAbility ?? null}
-          slot="hidden"
-          onFilter={onFilterAbility}
-        />
-      </div>
-
-      {/* HP */}
-      <span
-        className={cn(
-          "relative z-10 text-center font-mono text-xs tabular-nums",
-          statValueClass(entry.baseStats.hp)
-        )}
-      >
-        {entry.baseStats.hp}
-      </span>
-      {/* Atk */}
-      <span
-        className={cn(
-          "relative z-10 text-center font-mono text-xs tabular-nums",
-          statValueClass(entry.baseStats.atk)
-        )}
-      >
-        {entry.baseStats.atk}
-      </span>
-      {/* Def */}
-      <span
-        className={cn(
-          "relative z-10 text-center font-mono text-xs tabular-nums",
-          statValueClass(entry.baseStats.def)
-        )}
-      >
-        {entry.baseStats.def}
-      </span>
-      {/* SpA */}
-      <span
-        className={cn(
-          "relative z-10 text-center font-mono text-xs tabular-nums",
-          statValueClass(entry.baseStats.spa)
-        )}
-      >
-        {entry.baseStats.spa}
-      </span>
-      {/* SpD */}
-      <span
-        className={cn(
-          "relative z-10 text-center font-mono text-xs tabular-nums",
-          statValueClass(entry.baseStats.spd)
-        )}
-      >
-        {entry.baseStats.spd}
-      </span>
-      {/* Spe */}
-      <span
-        className={cn(
-          "relative z-10 text-center font-mono text-xs tabular-nums",
-          statValueClass(entry.baseStats.spe)
-        )}
-      >
-        {entry.baseStats.spe}
-      </span>
-
-      {/* BST */}
-      <span className="border-border/60 text-foreground relative z-10 border-l pl-1.5 text-center font-mono text-xs font-semibold tabular-nums">
-        {entry.bst}
-      </span>
+        </div>
+      )}
     </div>
   );
 }
@@ -446,6 +488,9 @@ export function SpeciesPicker({
   // Default sort: BST descending — surfaces the strongest legal Pokémon
   // overall before the user narrows by stat or role.
   const [sort, setSort] = useState<SortState>({ col: "bst", dir: "desc" });
+
+  // Track which species row is expanded (null = none expanded)
+  const [expandedSpecies, setExpandedSpecies] = useState<string | null>(null);
 
   // Scroll container ref for the virtualizer
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -646,14 +691,19 @@ export function SpeciesPicker({
   const rowVirtualizer = useVirtualizer({
     count: matched.length,
     getScrollElement: () => scrollRef.current,
-    // Row height: 64px sprite (size-16) + py-2 top + py-2 bottom ≈ 80px
-    estimateSize: () => 80,
+    // Estimate: collapsed row ~80px, expanded row will be measured dynamically
+    estimateSize: (index) => {
+      const entry = matched[index];
+      return entry?.species === expandedSpecies ? 400 : 80;
+    },
     overscan: 5,
     scrollMargin,
+    measureElement: (el) => el.getBoundingClientRect().height,
   });
 
   function clearAllFilters() {
     setFilters(DEFAULT_SPECIES_FILTERS);
+    setExpandedSpecies(null);
   }
 
   // ---------------------------------------------------------------------------
@@ -785,6 +835,7 @@ export function SpeciesPicker({
                 role="row"
               >
                 <span aria-hidden="true" />
+                <span aria-hidden="true" />
                 <SortHeaderButton
                   col="name"
                   label="Name"
@@ -876,13 +927,23 @@ export function SpeciesPicker({
                     return (
                       <div
                         key={virtualRow.key}
+                        ref={rowVirtualizer.measureElement}
+                        data-index={virtualRow.index}
                         className="absolute right-0 left-0"
                         style={{ top: virtualRow.start - scrollMargin }}
                       >
                         <SpeciesRow
                           entry={entry}
                           isCurrent={entry.species === value}
+                          isExpanded={entry.species === expandedSpecies}
+                          formatId={format?.id ?? DEFAULT_FORMAT_ID}
+                          filteredMoves={filters.moves}
                           onSelect={() => onPick(entry.species)}
+                          onToggleExpand={() =>
+                            setExpandedSpecies((prev) =>
+                              prev === entry.species ? null : entry.species
+                            )
+                          }
                           onFilterAbility={handleAbilityFilter}
                         />
                       </div>

--- a/apps/web/src/components/team-builder/pickers/species-picker.tsx
+++ b/apps/web/src/components/team-builder/pickers/species-picker.tsx
@@ -11,6 +11,8 @@ import {
   buildSpeciesSearchIndex,
   getAllLegalMoves,
   isLegalSpecies,
+  getLegalMoves,
+  getMoveData,
   searchSpecies,
   type GameFormat,
   type SpeciesSearchEntry,
@@ -22,7 +24,7 @@ import { cn } from "@/lib/utils";
 import { TypeSymbolIcon } from "../type-symbol-icon";
 import { AbilityCell } from "./ability-cell";
 import { RolePresetsPanel } from "./role-presets-panel";
-import { getRolesForSpecies } from "./role-registry";
+import { getRolesForMove, getRolesForSpecies, type RoleId } from "./role-registry";
 import {
   DEFAULT_SPECIES_FILTERS,
   type SpeciesFilterState,
@@ -41,29 +43,17 @@ const HIGH_STAT_THRESHOLD = 110;
 /**
  * Shared Tailwind grid template for each data row.
  *
- *   20px              — expand/collapse chevron
- *   64px              — sprite circle (size-16, sprite rendered at size-14)
- *   minmax(180px,2fr) — name column. 180px floor fits "Kangaskhan-Mega",
- *                       "Aegislash-Blade", "Charizard-Mega-X", etc. without
- *                       truncation.
- *   72px              — Types (two wordless icons side-by-side; em-dash
- *                       for monotypes)
- *   minmax(160px,2fr) — Regular abilities — slot 1 stacked above slot 2.
- *                       If the species has only one regular ability, only
- *                       that ability renders (no empty placeholder line).
- *   minmax(180px,2fr) — Hidden ability (italic + muted). 180px floor so
- *                       names like "Magic Guard", "Heavy Metal", "Aroma
- *                       Veil", "Sheer Force" don't truncate.
- *   repeat(6,44px)    — HP/Atk/Def/SpA/SpD/Spe stat cells. 44px so the
- *                       active sort arrow (e.g. "SPA ↓") doesn't push the
- *                       header label into the neighboring cell. Empty
- *                       buffer on each side keeps adjacent labels from
- *                       visually touching.
- *   48px              — BST rollup (large enough for "BST ↓" when sorted
- *                       by base-stat total)
+ *   20px               — expand/collapse chevron
+ *   56px               — sprite circle
+ *   minmax(170px,2fr)  — name
+ *   60px               — types (two icons)
+ *   minmax(120px,1.5fr)— abilities (stacked: ● slot1, ● slot2, ★ hidden)
+ *   repeat(6,38px)     — HP/Atk/Def/SpA/SpD/Spe
+ *   42px               — BST
+ *   minmax(0,2fr)      — matching move chips (collapses when empty)
  */
 const ROW_GRID =
-  "grid-cols-[20px_64px_minmax(180px,2fr)_72px_minmax(160px,2fr)_minmax(180px,2fr)_repeat(6,44px)_48px]";
+  "grid-cols-[20px_56px_minmax(170px,2fr)_60px_minmax(120px,1.5fr)_repeat(6,38px)_42px_minmax(0,2fr)]";
 
 /** Default format ID used when no format is active. */
 const DEFAULT_FORMAT_ID = "gen9vgc2025regg";
@@ -232,6 +222,7 @@ interface SpeciesRowProps {
   isExpanded: boolean;
   formatId: string;
   filteredMoves: readonly string[];
+  filteredRoles: readonly RoleId[];
   onSelect: () => void;
   onToggleExpand: () => void;
   onFilterAbility: (ability: string) => void;
@@ -243,11 +234,27 @@ function SpeciesRow({
   isExpanded,
   formatId,
   filteredMoves,
+  filteredRoles,
   onSelect,
   onToggleExpand,
   onFilterAbility,
 }: SpeciesRowProps) {
   const sprite = getPokemonSprite(entry.species);
+
+  // Compute moves matching active role filters (only when roles are active)
+  const matchingMoveNames: string[] = [];
+  if (filteredRoles.length > 0) {
+    const legalMoves = getLegalMoves(entry.species, formatId);
+    if (legalMoves && typeof legalMoves !== "symbol") {
+      for (const moveName of legalMoves) {
+        const moveRoles = getRolesForMove(moveName);
+        if (filteredRoles.some((role) => moveRoles.includes(role))) {
+          const data = getMoveData(moveName);
+          if (data) matchingMoveNames.push(data.name);
+        }
+      }
+    }
+  }
 
   function handleRowKey(e: React.KeyboardEvent<HTMLDivElement>) {
     // Only respond when focus is on the row itself (not on a nested
@@ -260,7 +267,7 @@ function SpeciesRow({
   }
 
   return (
-    <div>
+    <div className={cn(!isExpanded && "border-b")}>
       {/* Using `<div role="row" tabIndex={0}>` instead of a wrapping `<button>`
           because the row contains nested interactive elements (AbilityCell
           `<button>`s) and nested buttons are invalid HTML. The row is itself
@@ -277,8 +284,7 @@ function SpeciesRow({
         className={cn(
           "hover:bg-muted/60 focus-visible:bg-muted/80 focus-visible:outline-primary relative grid w-full cursor-pointer items-center gap-2 px-4 py-2 text-left transition-colors outline-none focus-visible:outline-2",
           ROW_GRID,
-          isCurrent && "bg-primary/5",
-          !isExpanded && "border-b"
+          isCurrent && "bg-primary/5"
         )}
       >
         {/* Expand/collapse chevron */}
@@ -341,32 +347,36 @@ function SpeciesRow({
           )}
         </div>
 
-        {/* Regular abilities — slot 1 stacked above slot 2, left-aligned.
-            If the species has only one regular ability, render just that one. */}
+        {/* Abilities — all slots stacked: • regular, ★ hidden */}
         <div className="relative z-10 flex min-w-0 flex-col justify-center gap-0.5 overflow-hidden">
-          {entry.abilitySlot1 ? (
+          <div className="flex min-w-0 items-baseline gap-1">
+            <span className="text-muted-foreground/50 inline-block w-2.5 shrink-0 text-center text-[8px]">●</span>
             <AbilityCell
-              name={entry.abilitySlot1}
+              name={entry.abilitySlot1 ?? null}
               slot="slot1"
               onFilter={onFilterAbility}
             />
-          ) : null}
-          {entry.abilitySlot2 ? (
-            <AbilityCell
-              name={entry.abilitySlot2}
-              slot="slot2"
-              onFilter={onFilterAbility}
-            />
-          ) : null}
-        </div>
-
-        {/* Hidden ability — italic + muted, left-aligned in its own column */}
-        <div className="relative z-10 flex min-w-0 items-center overflow-hidden">
-          <AbilityCell
-            name={entry.hiddenAbility ?? null}
-            slot="hidden"
-            onFilter={onFilterAbility}
-          />
+          </div>
+          {(entry.abilitySlot2 || entry.hiddenAbility) && (
+            <div className="flex min-w-0 items-baseline gap-1">
+              <span className="text-muted-foreground/50 inline-block w-2.5 shrink-0 text-center text-[8px]">●</span>
+              <AbilityCell
+                name={entry.abilitySlot2 ?? null}
+                slot="slot2"
+                onFilter={onFilterAbility}
+              />
+            </div>
+          )}
+          {(entry.abilitySlot2 || entry.hiddenAbility) && (
+            <div className="flex min-w-0 items-baseline gap-1">
+              <span className="text-amber-400/70 inline-block w-2.5 shrink-0 text-center text-[8px]">★</span>
+              <AbilityCell
+                name={entry.hiddenAbility ?? null}
+                slot="hidden"
+                onFilter={onFilterAbility}
+              />
+            </div>
+          )}
         </div>
 
         {/* HP */}
@@ -428,6 +438,18 @@ function SpeciesRow({
         <span className="border-border/60 text-foreground relative z-10 border-l pl-1.5 text-center font-mono text-xs font-semibold tabular-nums">
           {entry.bst}
         </span>
+
+        {/* Matching move chips — inline column */}
+        <div className="relative z-10 flex min-w-0 flex-wrap items-center gap-1 overflow-hidden">
+          {matchingMoveNames.map((name) => (
+            <span
+              key={name}
+              className="bg-primary/8 text-primary border-primary/15 shrink-0 rounded-full border px-1.5 py-px text-[10px] font-medium leading-tight"
+            >
+              {name}
+            </span>
+          ))}
+        </div>
       </div>
 
       {/* Expanded content — learnset panel */}
@@ -437,6 +459,7 @@ function SpeciesRow({
             species={entry.species}
             formatId={formatId}
             filteredMoves={filteredMoves}
+            filteredRoles={filteredRoles}
           />
         </div>
       )}
@@ -849,9 +872,6 @@ export function SpeciesPicker({
                 <span className="text-muted-foreground text-[9px] whitespace-nowrap">
                   Abilities
                 </span>
-                <span className="text-muted-foreground text-[9px] whitespace-nowrap">
-                  Hidden
-                </span>
                 <SortHeaderButton
                   col="hp"
                   label="HP"
@@ -907,6 +927,9 @@ export function SpeciesPicker({
                   sort={sort}
                   onSort={handleSort}
                 />
+                <span className="text-muted-foreground text-[9px] whitespace-nowrap">
+                  Moves
+                </span>
               </div>
 
               {matched.length === 0 ? (
@@ -938,6 +961,7 @@ export function SpeciesPicker({
                           isExpanded={entry.species === expandedSpecies}
                           formatId={format?.id ?? DEFAULT_FORMAT_ID}
                           filteredMoves={filters.moves}
+                          filteredRoles={filters.roles}
                           onSelect={() => onPick(entry.species)}
                           onToggleExpand={() =>
                             setExpandedSpecies((prev) =>

--- a/apps/web/src/components/team-builder/pickers/species-sidebar.tsx
+++ b/apps/web/src/components/team-builder/pickers/species-sidebar.tsx
@@ -1,10 +1,10 @@
 /**
  * SpeciesSidebar — left-column panel of the species picker.
  *
- * Renders four filter sections in a fixed-width aside:
- *   1. Type grid (multi-select, 3-col, with team-needs hints)
- *   2. Ability combobox (input + datalist from getAllLegalAbilities)
- *   3. Champions M-A Mega toggle (gated on isChampionsFormat)
+ * Renders filter sections in a fixed-width aside:
+ *   1. Mega toggle (format-gated, Champions only)
+ *   2. Type grid (multi-select, 3-col, with team-needs hints)
+ *   3. Ability combobox (input + datalist from getAllLegalAbilities)
  *   4. Learns Move (search + quick-picks + removable chips)
  *
  * Does NOT own the `roles` filter — that lives in <RolePresetsPanel>.
@@ -25,13 +25,19 @@ import {
 } from "@trainers/pokemon";
 
 import { cn } from "@/lib/utils";
+import { getTypeStyle } from "@/lib/pokemon/type-colors";
 
 import { TypeSymbolIcon } from "../type-symbol-icon";
 import { type SpeciesFilterState } from "./species-filter-state";
 
 // =============================================================================
-// Constants
+// Shared section header style
 // =============================================================================
+
+const SECTION_HEADER =
+  "text-muted-foreground mb-1.5 block text-[9px] font-bold tracking-widest uppercase";
+
+const SECTION_PADDING = "px-3 py-2.5";
 
 // =============================================================================
 // Types
@@ -187,135 +193,12 @@ export function SpeciesSidebar({
   // ---------------------------------------------------------------------------
 
   return (
-    <aside className="bg-muted/50 flex h-full flex-col">
+    <aside className="flex h-full flex-col divide-y divide-border/40">
       {/* ------------------------------------------------------------------ */}
-      {/* 1. Type grid                                                        */}
-      {/* ------------------------------------------------------------------ */}
-      <div className="px-3 pt-3 pb-2">
-        <span className="text-muted-foreground mb-2 block text-[9px] font-bold tracking-widest uppercase">
-          Type
-        </span>
-
-        <div className="grid grid-cols-3 gap-1">
-          {allTypes.map((type) => {
-            const isActive = filters.types.includes(type);
-            const isNeeded = neededTypes.includes(type);
-            return (
-              <button
-                key={type}
-                type="button"
-                aria-label={isNeeded ? `${type} (team needs coverage)` : type}
-                aria-pressed={isActive}
-                title={
-                  isNeeded
-                    ? `${type} — team is weak to this without coverage`
-                    : undefined
-                }
-                onClick={() => toggleType(type)}
-                className={cn(
-                  "relative flex items-center justify-center rounded px-1 py-1 transition-all",
-                  isActive
-                    ? "ring-primary bg-background ring-2 ring-offset-1"
-                    : "bg-muted/40 opacity-70 hover:opacity-100"
-                )}
-              >
-                {isNeeded && (
-                  <span
-                    aria-hidden="true"
-                    className="absolute -top-1 -right-1 text-[9px] leading-none text-amber-500 drop-shadow"
-                  >
-                    ✦
-                  </span>
-                )}
-                <TypeSymbolIcon
-                  type={type as Parameters<typeof TypeSymbolIcon>[0]["type"]}
-                  size={28}
-                />
-              </button>
-            );
-          })}
-        </div>
-      </div>
-
-      {/* ------------------------------------------------------------------ */}
-      {/* 2. Ability combobox                                                 */}
-      {/* ------------------------------------------------------------------ */}
-      <div className="border-border border-t px-3 py-2">
-        <span className="text-muted-foreground mb-1.5 block text-[9px] font-bold tracking-widest uppercase">
-          Ability
-        </span>
-        {filters.ability ? (
-          <button
-            type="button"
-            onClick={() => onFiltersChange({ ...filters, ability: null })}
-            aria-label={`Clear ${filters.ability} filter`}
-            className="bg-primary/10 text-primary border-primary/30 hover:bg-primary/15 inline-flex w-full items-center justify-between gap-2 rounded border px-2 py-1 text-[11px] font-medium transition-colors"
-          >
-            <span className="truncate">{filters.ability}</span>
-            <span aria-hidden="true" className="text-[10px] opacity-70">
-              ×
-            </span>
-          </button>
-        ) : (
-          <div className="relative">
-            <input
-              type="text"
-              placeholder="Type or click an ability…"
-              value={abilityInput}
-              onChange={(e) => setAbilityInput(e.target.value)}
-              onKeyDown={handleAbilityKeyDown}
-              onFocus={() => setAbilityFocused(true)}
-              onBlur={() => {
-                // Defer so a click on a suggestion can fire before the
-                // dropdown disappears.
-                clearTimeout(abilityBlurTimerRef.current);
-                abilityBlurTimerRef.current = setTimeout(
-                  () => setAbilityFocused(false),
-                  120
-                );
-              }}
-              className="border-input bg-background placeholder:text-muted-foreground/60 focus:ring-ring w-full rounded border px-2 py-1 text-[11px] focus:ring-1 focus:outline-none"
-            />
-            {abilityFocused && abilitySuggestions.length > 0 && (
-              // Plain <ul> rather than role="listbox" — items are real <button>s
-              // with their own focus/keyboard handling, not aria-managed
-              // options. Listbox role would imply option semantics + arrow-key
-              // navigation we don't implement here.
-              <ul
-                aria-label="Matching abilities"
-                className="border-border bg-popover absolute top-full right-0 left-0 z-30 mt-1 max-h-60 overflow-y-auto rounded-md border shadow-lg"
-              >
-                {abilitySuggestions.map((ability) => (
-                  <li key={ability}>
-                    <button
-                      type="button"
-                      onMouseDown={(e) => {
-                        // mousedown fires before blur; prevents the input from
-                        // losing focus and hiding the dropdown before our click
-                        // handler runs.
-                        e.preventDefault();
-                      }}
-                      onClick={() => {
-                        onFiltersChange({ ...filters, ability });
-                        setAbilityInput("");
-                      }}
-                      className="hover:bg-accent w-full px-2 py-1 text-left text-[11px]"
-                    >
-                      {ability}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-        )}
-      </div>
-
-      {/* ------------------------------------------------------------------ */}
-      {/* 3. Champions M-A Mega toggle (format-gated)                         */}
+      {/* 1. Mega toggle (Champions only)                                     */}
       {/* ------------------------------------------------------------------ */}
       {showMegaToggle && (
-        <div className="border-border border-t px-3 py-2">
+        <div className={SECTION_PADDING}>
           <button
             type="button"
             aria-pressed={filters.megaOnly}
@@ -366,18 +249,130 @@ export function SpeciesSidebar({
       )}
 
       {/* ------------------------------------------------------------------ */}
+      {/* 2. Type grid                                                        */}
+      {/* ------------------------------------------------------------------ */}
+      <div className={SECTION_PADDING}>
+        <span className={SECTION_HEADER}>Type</span>
+        <div className="grid grid-cols-3 gap-1">
+          {allTypes.map((type) => {
+            const isActive = filters.types.includes(type);
+            const isNeeded = neededTypes.includes(type);
+            const typeStyle = getTypeStyle(type);
+            return (
+              <button
+                key={type}
+                type="button"
+                aria-label={isNeeded ? `${type} (team needs coverage)` : type}
+                aria-pressed={isActive}
+                title={
+                  isNeeded
+                    ? `${type} — team is weak to this without coverage`
+                    : undefined
+                }
+                onClick={() => toggleType(type)}
+                className={cn(
+                  "relative flex items-center justify-center rounded border border-transparent px-1 py-1 transition-all",
+                  typeStyle.bg,
+                  isActive
+                    ? cn(typeStyle.border, "ring-primary ring-2 ring-offset-background ring-offset-1")
+                    : cn(typeStyle.borderHover, "before:absolute before:inset-0 before:rounded before:bg-background/50 before:transition-opacity before:pointer-events-none hover:before:opacity-0")
+                )}
+              >
+                {isNeeded && (
+                  <span
+                    aria-hidden="true"
+                    className="absolute -top-1 -right-1 z-10 text-[9px] leading-none text-amber-500 drop-shadow"
+                  >
+                    ✦
+                  </span>
+                )}
+                <TypeSymbolIcon
+                  type={type as Parameters<typeof TypeSymbolIcon>[0]["type"]}
+                  size={28}
+                  className="relative z-10"
+                />
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* 3. Ability combobox                                                 */}
+      {/* ------------------------------------------------------------------ */}
+      <div className={SECTION_PADDING}>
+        <span className={SECTION_HEADER}>Ability</span>
+        {filters.ability ? (
+          <button
+            type="button"
+            onClick={() => onFiltersChange({ ...filters, ability: null })}
+            aria-label={`Clear ${filters.ability} filter`}
+            className="bg-primary/10 text-primary border-primary hover:bg-primary/15 inline-flex w-full items-center justify-between gap-2 rounded border px-2 py-1 text-[11px] font-medium transition-colors"
+          >
+            <span className="truncate">{filters.ability}</span>
+            <span aria-hidden="true" className="text-[10px] opacity-70">
+              ×
+            </span>
+          </button>
+        ) : (
+          <div className="relative">
+            <input
+              type="text"
+              placeholder="Type or click an ability..."
+              value={abilityInput}
+              onChange={(e) => setAbilityInput(e.target.value)}
+              onKeyDown={handleAbilityKeyDown}
+              onFocus={() => setAbilityFocused(true)}
+              onBlur={() => {
+                // Defer so a click on a suggestion can fire before the
+                // dropdown disappears.
+                clearTimeout(abilityBlurTimerRef.current);
+                abilityBlurTimerRef.current = setTimeout(
+                  () => setAbilityFocused(false),
+                  120
+                );
+              }}
+              className="border-border bg-background placeholder:text-muted-foreground/60 focus:border-primary focus:ring-primary w-full rounded border px-2 py-1.5 text-[11px] focus:ring-1 focus:outline-none"
+            />
+            {abilityFocused && abilitySuggestions.length > 0 && (
+              <ul
+                aria-label="Matching abilities"
+                className="border-border bg-popover absolute top-full right-0 left-0 z-30 mt-1 max-h-60 overflow-y-auto rounded-md border shadow-lg"
+              >
+                {abilitySuggestions.map((ability) => (
+                  <li key={ability}>
+                    <button
+                      type="button"
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                      }}
+                      onClick={() => {
+                        onFiltersChange({ ...filters, ability });
+                        setAbilityInput("");
+                      }}
+                      className="hover:bg-accent w-full px-2 py-1 text-left text-[11px]"
+                    >
+                      {ability}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* ------------------------------------------------------------------ */}
       {/* 4. Learns Move                                                      */}
       {/* ------------------------------------------------------------------ */}
-      <div className="border-border border-t px-3 py-2">
-        <span className="text-muted-foreground mb-1.5 block text-[9px] font-bold tracking-widest uppercase">
-          Learns Move
-        </span>
+      <div className={SECTION_PADDING}>
+        <span className={SECTION_HEADER}>Learns Move</span>
 
         {/* Typeahead input + suggestion dropdown */}
         <div className="relative">
           <input
             type="text"
-            placeholder="Type a move…"
+            placeholder="Type a move..."
             value={moveInput}
             onChange={(e) => setMoveInput(e.target.value)}
             onKeyDown={handleMoveKeyDown}
@@ -391,11 +386,9 @@ export function SpeciesSidebar({
                 120
               );
             }}
-            className="border-input bg-background placeholder:text-muted-foreground/60 focus:ring-ring w-full rounded border px-2 py-1 text-[11px] focus:ring-1 focus:outline-none"
+            className="border-border bg-background placeholder:text-muted-foreground/60 focus:border-primary focus:ring-primary w-full rounded border px-2 py-1.5 text-[11px] focus:ring-1 focus:outline-none"
           />
           {moveFocused && moveSuggestions.length > 0 && (
-            // See ability typeahead above — same rationale for dropping
-            // role="listbox" without option semantics.
             <ul
               aria-label="Matching moves"
               className="border-border bg-popover absolute top-full right-0 left-0 z-30 mt-1 max-h-60 overflow-y-auto rounded-md border shadow-lg"
@@ -427,7 +420,7 @@ export function SpeciesSidebar({
                 key={move}
                 type="button"
                 onClick={() => removeMove(move)}
-                className="bg-primary/15 text-primary hover:bg-primary/25 flex items-center gap-0.5 rounded-full px-2 py-0.5 text-[10px] font-medium transition-colors"
+                className="bg-primary/15 text-primary border-primary hover:bg-primary/25 flex items-center gap-0.5 rounded-full border px-2 py-0.5 text-[10px] font-medium transition-colors"
               >
                 {move}
                 <span aria-hidden="true" className="ml-0.5 text-[9px]">

--- a/apps/web/src/components/team-builder/team-workspace.tsx
+++ b/apps/web/src/components/team-builder/team-workspace.tsx
@@ -47,16 +47,6 @@ import {
   ResizablePanel,
   ResizableHandle,
 } from "@/components/ui/resizable";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { ImportDialog } from "./import-dialog";
 import { useTeamValidation, type ValidationError } from "./validation-hooks";
 import { CalcBottomPanel } from "./calc/calc-bottom-panel";
@@ -429,7 +419,6 @@ export function TeamWorkspaceV2({
   const [importOpen, setImportOpen] = useState(false);
 
   /** Slot index awaiting remove confirmation. null = dialog closed. */
-  const [removeSlotIdx, setRemoveSlotIdx] = useState<number | null>(null);
 
   /** Ref to the worklane element — used by the panel resizer to compute the
    *  pointer's offset within the lane during drag. */
@@ -579,16 +568,9 @@ export function TeamWorkspaceV2({
     });
   }
 
-  /** Opens the remove confirmation dialog for the given slot index. */
+  /** Removes the Pokémon at the given slot index immediately. */
   function handleRequestRemove(idx: number) {
-    setRemoveSlotIdx(idx);
-  }
-
-  /** Called when the user confirms removal in the AlertDialog. */
-  function handleConfirmRemove() {
-    if (removeSlotIdx === null) return;
-    const p = slots[removeSlotIdx];
-    setRemoveSlotIdx(null);
+    const p = slots[idx];
     if (!p) return;
     const pokemonId = p.id;
 
@@ -1129,31 +1111,6 @@ export function TeamWorkspaceV2({
           formatId={format?.id}
         />
 
-        {/* Remove confirmation dialog */}
-        <AlertDialog
-          open={removeSlotIdx !== null}
-          onOpenChange={(open) => {
-            if (!open) setRemoveSlotIdx(null);
-          }}
-        >
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>Remove Pokémon?</AlertDialogTitle>
-              <AlertDialogDescription>
-                This will remove the Pokémon from this slot.
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction
-                onClick={handleConfirmRemove}
-                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              >
-                Remove
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
       </CalcStateProvider>
     </TeamLayoutContext.Provider>
   );

--- a/apps/web/src/components/team-builder/type-symbol-icon.tsx
+++ b/apps/web/src/components/team-builder/type-symbol-icon.tsx
@@ -1,80 +1,18 @@
 "use client";
 
 /**
- * TypeSymbolIcon — round type icon with a lucide-react glyph on a
- * type-colored background. No English text on the icon itself; the full
- * type name surfaces via a shadcn Tooltip and the wrapper's aria-label.
+ * TypeSymbolIcon — official Pokémon type symbol icons
+ * (Scarlet/Violet/Champions/HOME style).
  *
- * Source rationale: Pokémon Showdown's CDN only hosts rectangular badge PNGs
- * (sprites/types/*.png) that contain English text — there are no round/glyph
- * variants available from any CDN. Using lucide-react icons on Tailwind
- * type-color backgrounds produces a crisp, text-free, self-contained icon that
- * renders at any size without a network request.
+ * The PNGs at `/types/{Type}.png` are 60×60 RGBA with their own colored
+ * circular backgrounds baked in, so no additional Tailwind background is needed.
  */
 
-import {
-  Bug,
-  Circle,
-  Droplets,
-  Flame,
-  Ghost,
-  Mountain,
-  Shield,
-  Skull,
-  Snowflake,
-  Sparkles,
-  Star,
-  Sun,
-  Swords,
-  Wind,
-  Zap,
-  type LucideProps,
-} from "lucide-react";
+import Image from "next/image";
 
 import { type PokemonType } from "@trainers/pokemon";
 
 import { cn } from "@/lib/utils";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-
-// =============================================================================
-// Icon + background mapping
-// =============================================================================
-
-/**
- * Each type maps to:
- *   icon      — the lucide-react icon component (glyph only, no text)
- *   bgClass   — Tailwind background + text-color classes from TYPE_PILL_COLORS
- */
-const TYPE_SYMBOL_MAP: Record<
-  PokemonType | "Stellar",
-  { icon: React.ComponentType<LucideProps>; bgClass: string }
-> = {
-  Normal: { icon: Circle, bgClass: "bg-stone-400   text-white" },
-  Bug: { icon: Bug, bgClass: "bg-lime-500    text-white" },
-  Dark: { icon: Skull, bgClass: "bg-stone-700   text-white" },
-  Dragon: { icon: Sparkles, bgClass: "bg-indigo-600  text-white" },
-  Electric: { icon: Zap, bgClass: "bg-yellow-400  text-black" },
-  Fairy: { icon: Star, bgClass: "bg-pink-400    text-white" },
-  Fighting: { icon: Swords, bgClass: "bg-red-700     text-white" },
-  Fire: { icon: Flame, bgClass: "bg-orange-500  text-white" },
-  Flying: { icon: Wind, bgClass: "bg-sky-300     text-black" },
-  Ghost: { icon: Ghost, bgClass: "bg-purple-600  text-white" },
-  Grass: { icon: Sun, bgClass: "bg-green-500   text-white" },
-  Ground: { icon: Mountain, bgClass: "bg-amber-600   text-white" },
-  Ice: { icon: Snowflake, bgClass: "bg-cyan-300    text-black" },
-  Poison: { icon: Skull, bgClass: "bg-purple-500  text-white" },
-  Psychic: { icon: Star, bgClass: "bg-pink-500    text-white" },
-  Rock: { icon: Mountain, bgClass: "bg-amber-700   text-white" },
-  Steel: { icon: Shield, bgClass: "bg-slate-400   text-black" },
-  Water: { icon: Droplets, bgClass: "bg-blue-500    text-white" },
-  // Stellar has a gradient in the pill — use a solid mid-point purple here for
-  // the round icon (gradients on tiny circles don't read well).
-  Stellar: { icon: Sparkles, bgClass: "bg-purple-500  text-white" },
-};
 
 // =============================================================================
 // TypeSymbolIcon
@@ -93,51 +31,34 @@ interface TypeSymbolIconProps {
 }
 
 /**
- * Small round type-symbol icon with a Tooltip showing the full type name.
- * No text is rendered on the icon itself — accessibility via aria-label + Tooltip.
+ * Small round type-symbol icon.
+ * Uses the official Pokémon type symbols (SV/Champions/HOME).
  */
 export function TypeSymbolIcon({
   type,
   size = 18,
   className,
 }: TypeSymbolIconProps) {
-  const mapping = TYPE_SYMBOL_MAP[type];
-
-  // Fallback for unknown/future types — render a neutral circle.
-  const { icon: Icon, bgClass } = mapping ?? {
-    icon: Circle,
-    bgClass: "bg-muted text-foreground",
-  };
-
-  // Icon glyph is ~60% of the container so there's a visible colored ring.
-  const glyphSize = Math.round(size * 0.6);
-
   return (
-    <Tooltip>
-      <TooltipTrigger
-        render={
-          <span
-            role="img"
-            aria-label={type}
-            data-type={type}
-            style={{ width: size, height: size }}
-            className={cn(
-              "inline-flex shrink-0 cursor-default items-center justify-center rounded-full",
-              "outline-ring/40 focus-visible:outline-2",
-              bgClass,
-              className
-            )}
-          >
-            <Icon
-              aria-hidden="true"
-              width={glyphSize}
-              height={glyphSize}
-              strokeWidth={2.5}
-            />
-          </span>
-        }
+    <span
+      role="img"
+      aria-label={type}
+      data-type={type}
+      style={{ width: size, height: size }}
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center",
+        className
+      )}
+    >
+      <Image
+        src={`/types/${type}.png`}
+        alt=""
+        width={size}
+        height={size}
+        className="size-full rounded-full object-contain"
+        aria-hidden="true"
+        unoptimized
       />
-      <TooltipContent>{type}</TooltipContent>
-    </Tooltip>
+    </span>
   );
 }

--- a/apps/web/src/lib/pokemon/type-colors.ts
+++ b/apps/web/src/lib/pokemon/type-colors.ts
@@ -7,6 +7,8 @@ export interface TypeStyle {
   bg: string;
   text: string;
   border: string;
+  /** Hover-prefixed border class for Tailwind static analysis. */
+  borderHover: string;
 }
 
 export const typeColors: Record<string, TypeStyle> = {
@@ -14,96 +16,115 @@ export const typeColors: Record<string, TypeStyle> = {
     bg: "bg-gray-400/20",
     text: "text-gray-600 dark:text-gray-400",
     border: "border-gray-400/30",
+    borderHover: "hover:border-gray-400/30",
   },
   Fire: {
     bg: "bg-red-500/20",
     text: "text-red-600 dark:text-red-400",
     border: "border-red-500/30",
+    borderHover: "hover:border-red-500/30",
   },
   Water: {
     bg: "bg-blue-500/20",
     text: "text-blue-600 dark:text-blue-400",
     border: "border-blue-500/30",
+    borderHover: "hover:border-blue-500/30",
   },
   Electric: {
     bg: "bg-yellow-400/20",
     text: "text-yellow-600 dark:text-yellow-400",
     border: "border-yellow-400/30",
+    borderHover: "hover:border-yellow-400/30",
   },
   Grass: {
     bg: "bg-green-500/20",
     text: "text-green-600 dark:text-green-400",
     border: "border-green-500/30",
+    borderHover: "hover:border-green-500/30",
   },
   Ice: {
     bg: "bg-cyan-400/20",
     text: "text-cyan-600 dark:text-cyan-400",
     border: "border-cyan-400/30",
+    borderHover: "hover:border-cyan-400/30",
   },
   Fighting: {
     bg: "bg-orange-600/20",
     text: "text-orange-700 dark:text-orange-400",
     border: "border-orange-600/30",
+    borderHover: "hover:border-orange-600/30",
   },
   Poison: {
     bg: "bg-purple-500/20",
     text: "text-purple-600 dark:text-purple-400",
     border: "border-purple-500/30",
+    borderHover: "hover:border-purple-500/30",
   },
   Ground: {
     bg: "bg-amber-600/20",
     text: "text-amber-700 dark:text-amber-400",
     border: "border-amber-600/30",
+    borderHover: "hover:border-amber-600/30",
   },
   Flying: {
     bg: "bg-indigo-400/20",
     text: "text-indigo-600 dark:text-indigo-400",
     border: "border-indigo-400/30",
+    borderHover: "hover:border-indigo-400/30",
   },
   Psychic: {
     bg: "bg-pink-500/20",
     text: "text-pink-600 dark:text-pink-400",
     border: "border-pink-500/30",
+    borderHover: "hover:border-pink-500/30",
   },
   Bug: {
     bg: "bg-lime-500/20",
     text: "text-lime-600 dark:text-lime-400",
     border: "border-lime-500/30",
+    borderHover: "hover:border-lime-500/30",
   },
   Rock: {
     bg: "bg-stone-500/20",
     text: "text-stone-600 dark:text-stone-400",
     border: "border-stone-500/30",
+    borderHover: "hover:border-stone-500/30",
   },
   Ghost: {
     bg: "bg-violet-600/20",
     text: "text-violet-600 dark:text-violet-400",
     border: "border-violet-600/30",
+    borderHover: "hover:border-violet-600/30",
   },
   Dragon: {
     bg: "bg-indigo-600/20",
     text: "text-indigo-700 dark:text-indigo-400",
     border: "border-indigo-600/30",
+    borderHover: "hover:border-indigo-600/30",
   },
   Dark: {
     bg: "bg-neutral-700/20",
     text: "text-neutral-700 dark:text-neutral-300",
     border: "border-neutral-700/30",
+    borderHover: "hover:border-neutral-700/30",
   },
   Steel: {
     bg: "bg-slate-400/20",
     text: "text-slate-600 dark:text-slate-400",
     border: "border-slate-400/30",
+    borderHover: "hover:border-slate-400/30",
   },
   Fairy: {
     bg: "bg-pink-400/20",
     text: "text-pink-500 dark:text-pink-400",
     border: "border-pink-400/30",
+    borderHover: "hover:border-pink-400/30",
   },
   Stellar: {
     bg: "bg-sky-400/20",
     text: "text-sky-600 dark:text-sky-400",
     border: "border-sky-400/30",
+    borderHover: "hover:border-sky-400/30",
   },
 };
 

--- a/packages/pokemon/src/species-search.ts
+++ b/packages/pokemon/src/species-search.ts
@@ -12,6 +12,7 @@ import { getFormatById } from "./formats";
 import {
   getLegalMoves,
   getLegalSpecies,
+  getMegaAbilityForSpecies,
   getMegaStoneForSpecies,
   LEGALITY_UNAVAILABLE,
 } from "./format-legality";
@@ -146,17 +147,34 @@ function makeEntry(
   getRoles?: GetRolesFn,
   formatId?: string
 ): SpeciesSearchEntry {
-  // Cast abilities to an indexable record for per-slot access
-  const abilitiesRecord = species.abilities as Record<
-    string,
-    string | undefined
-  >;
-  const abilities = Object.values(abilitiesRecord).filter(
-    (a): a is string => typeof a === "string" && a.length > 0
-  );
-  const abilitySlot1 = abilitiesRecord["0"] ?? null;
-  const abilitySlot2 = abilitiesRecord["1"] ?? null;
-  const hiddenAbility = abilitiesRecord["H"] ?? null;
+  // If the species is a mega with a known post-evolution ability, use only
+  // that ability — the dex entry may carry base-form slots instead.
+  const megaAbility = getMegaAbilityForSpecies(species.name);
+
+  let abilitySlot1: string | null;
+  let abilitySlot2: string | null;
+  let hiddenAbility: string | null;
+  let abilities: string[];
+
+  if (megaAbility) {
+    abilitySlot1 = megaAbility;
+    abilitySlot2 = null;
+    hiddenAbility = null;
+    abilities = [megaAbility];
+  } else {
+    // Cast abilities to an indexable record for per-slot access
+    const abilitiesRecord = species.abilities as Record<
+      string,
+      string | undefined
+    >;
+    abilities = Object.values(abilitiesRecord).filter(
+      (a): a is string => typeof a === "string" && a.length > 0
+    );
+    abilitySlot1 = abilitiesRecord["0"] ?? null;
+    abilitySlot2 = abilitiesRecord["1"] ?? null;
+    hiddenAbility = abilitiesRecord["H"] ?? null;
+  }
+
   const { hp, atk, def, spa, spd, spe } = species.baseStats;
   const roles =
     getRoles && formatId


### PR DESCRIPTION
## Summary

Comprehensive UX improvements to the team builder's speed tiers panel, species picker, and move picker.

### Speed Tiers Panel
- Default SP/EVs to 0 with neutral nature for cleaner baseline
- Rounded borders, renamed labels (SP for Champions, EVs for VGC)
- Fix EV null fallback to 0 baseline (was incorrectly falling back to 252)

### Species Picker
- Expandable rows with inline learnset panel (drag-resizable)
- Consolidated ability display: slot1/slot2 (●) + hidden (★) in single column
- Mega ability fix at data layer using `getMegaAbilityForSpecies`
- Collapsible sidebar with icon strip + filter count badges
- Type grid with official Pokémon type PNG icons
- Type-colored backgrounds/borders with dim overlay for inactive state
- Mega toggle moved above TYPE filters (Champions format only)
- Independent ability row rendering (no blank rows)
- `aria-expanded` moved to chevron button with `aria-controls`

### Move Picker
- Category filter above Type filter
- "Clear all filters" moved below ROLE section
- Type grid with official type icons (matching species picker)
- Sort button accessibility: `aria-pressed` + dynamic `aria-label`
- `onCategoryFilter` properly typed as `MoveCategory`

### Shared Components
- `TypeSymbolIcon`: official Pokémon type PNGs, no tooltip
- `RoleChip`: `shrink-0 whitespace-nowrap` to prevent wrapping
- `MoveListRow`: roles container `overflow-x-auto`
- `RolePresetsPanel`: scrollable when content overflows
- Cohesive sidebar design: consistent padding, headers, dividers

### Other
- Remove Pokémon confirmation dialog — immediate removal
- Teal ring on all picker dialogs (`ring-2 ring-primary/50`)
- Resize handle uses pointer events with proper cleanup on unmount

## Test Plan
- Manual testing of all picker interactions
- Typecheck passes across all packages
- 755 pokemon package tests pass (mega ability fix verified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Species learnset panels now expand inline to display sortable move lists with filtering.
  * Automatic Mega Stone preloading when selecting Mega-eligible species.
  * Improved move list interface with sortable columns and enhanced filtering.

* **Refactor**
  * Type symbols now display as official Pokémon images instead of icons.
  * Pokémon removal now occurs immediately without confirmation dialog.
  * Updated labels: "Choice Scarf" and "SPE Nature" for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->