### PR TITLE
feat: redesign dashboard home and polish community pages

### DIFF
--- a/apps/web/e2e/tests/navigation/community-dashboard.spec.ts
+++ b/apps/web/e2e/tests/navigation/community-dashboard.spec.ts
@@ -78,7 +78,7 @@ test.describe("Community dashboard", () => {
         page.getByText("Overview", { exact: true }).first()
       ).toBeVisible({ timeout: 10000 });
 
-      await expect(page.getByText("📅 Upcoming Tournaments")).toBeVisible({
+      await expect(page.getByText("Upcoming Tournaments")).toBeVisible({
         timeout: 10000,
       });
     });

--- a/apps/web/e2e/tests/navigation/dashboard-alts.spec.ts
+++ b/apps/web/e2e/tests/navigation/dashboard-alts.spec.ts
@@ -10,8 +10,11 @@ test.describe("Dashboard alts section", () => {
       { timeout: 10000 }
     );
 
-    // "New Alt" button should be present
-    await expect(main.getByRole("button", { name: /new alt/i })).toBeVisible();
+    // "New Alt" button in the alts section (the actual <button>, not the
+    // welcome header's <a role="button"> quick-action link)
+    await expect(
+      main.locator("button", { hasText: /new alt/i })
+    ).toBeVisible();
   });
 
   test("renders alt list or empty state", async ({ page }) => {

--- a/apps/web/src/app/(dashboard)/dashboard/alts/[username]/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/alts/[username]/page.tsx
@@ -1,3 +1,4 @@
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 import { PageHeader } from "@/components/dashboard/page-header";
 
 interface AltDetailPageProps {
@@ -10,12 +11,14 @@ export default async function AltDetailPage({ params }: AltDetailPageProps) {
   return (
     <>
       <PageHeader title={username} />
-      <div className="flex flex-1 flex-col gap-4 p-4 md:p-6">
-        <h1 className="text-xl font-bold tracking-tight">{username}</h1>
-        <p className="text-muted-foreground text-sm">
-          Alt detail page coming soon.
-        </p>
-      </div>
+      <DashboardContent>
+        <div className="flex flex-1 flex-col gap-4">
+          <h1 className="text-xl font-bold tracking-tight">{username}</h1>
+          <p className="text-muted-foreground text-sm">
+            Alt detail page coming soon.
+          </p>
+        </div>
+      </DashboardContent>
     </>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/alts/[username]/teams/[teamId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/alts/[username]/teams/[teamId]/page.tsx
@@ -3,7 +3,6 @@ import { notFound } from "next/navigation";
 import { getFormatById } from "@trainers/pokemon";
 import { getCurrentUserAlts, getTeamWithPokemon } from "@trainers/supabase";
 
-import { DashboardContent } from "@/components/dashboard/dashboard-content";
 import { createClientReadOnly } from "@/lib/supabase/server";
 import { DashboardBuilderWrapper } from "@/components/team-builder/dashboard-builder-wrapper";
 
@@ -49,13 +48,11 @@ export default async function TeamWorkspacePage({
   const format = team.format ? getFormatById(team.format) : undefined;
 
   return (
-    <DashboardContent>
-      <DashboardBuilderWrapper
-        team={team}
-        format={format}
-        username={username}
-        alts={alts}
-      />
-    </DashboardContent>
+    <DashboardBuilderWrapper
+      team={team}
+      format={format}
+      username={username}
+      alts={alts}
+    />
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/alts/[username]/teams/[teamId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/alts/[username]/teams/[teamId]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { getFormatById } from "@trainers/pokemon";
 import { getCurrentUserAlts, getTeamWithPokemon } from "@trainers/supabase";
 
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 import { createClientReadOnly } from "@/lib/supabase/server";
 import { DashboardBuilderWrapper } from "@/components/team-builder/dashboard-builder-wrapper";
 
@@ -48,11 +49,13 @@ export default async function TeamWorkspacePage({
   const format = team.format ? getFormatById(team.format) : undefined;
 
   return (
-    <DashboardBuilderWrapper
-      team={team}
-      format={format}
-      username={username}
-      alts={alts}
-    />
+    <DashboardContent>
+      <DashboardBuilderWrapper
+        team={team}
+        format={format}
+        username={username}
+        alts={alts}
+      />
+    </DashboardContent>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/alts/[username]/teams/new/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/alts/[username]/teams/new/page.tsx
@@ -4,6 +4,7 @@ import { getActiveFormats } from "@trainers/pokemon";
 import { getAltByUsername, hasTeamBuilderAccess } from "@trainers/supabase";
 
 import { getUser, createClientReadOnly } from "@/lib/supabase/server";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 import { PageHeader } from "@/components/dashboard/page-header";
 
 import { NewTeamForm } from "./new-team-form";
@@ -66,7 +67,7 @@ export default async function NewTeamPage({
   return (
     <>
       <PageHeader title="New Team" />
-      <div className="flex flex-1 flex-col p-4 md:p-6">
+      <DashboardContent>
         <div className="mx-auto w-full max-w-xl">
           <div className="mb-6">
             <h1 className="text-xl font-semibold tracking-tight">
@@ -85,7 +86,7 @@ export default async function NewTeamPage({
             initialMode={initialMode}
           />
         </div>
-      </div>
+      </DashboardContent>
     </>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/alts/[username]/teams/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/alts/[username]/teams/page.tsx
@@ -8,6 +8,7 @@ import {
 } from "@trainers/supabase";
 
 import { getUser, createClientReadOnly } from "@/lib/supabase/server";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 import { PageHeader } from "@/components/dashboard/page-header";
 import { TeamsListClient } from "@/components/team-builder/teams-list-client";
 
@@ -61,12 +62,14 @@ export default async function TeamsPage({ params }: TeamsPageProps) {
   return (
     <>
       <PageHeader title="Teams" />
-      <TeamsListClient
-        initialTeams={teams}
-        altId={alt.id}
-        handle={username}
-        activeFormats={activeFormats}
-      />
+      <DashboardContent>
+        <TeamsListClient
+          initialTeams={teams}
+          altId={alt.id}
+          handle={username}
+          activeFormats={activeFormats}
+        />
+      </DashboardContent>
     </>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/__tests__/overview-client.test.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/__tests__/overview-client.test.tsx
@@ -156,7 +156,7 @@ describe("OverviewClient — StatCards", () => {
           stats={makeStats({ totalTournaments: 5, activeTournaments: 2 })}
         />
       );
-      expect(screen.getByText("↑ 2 active")).toBeInTheDocument();
+      expect(screen.getByText("2 active")).toBeInTheDocument();
     });
 
     it("shows total entries in Unique Players subtitle", () => {
@@ -205,48 +205,6 @@ describe("OverviewClient — StatCards", () => {
         />
       );
       expect(screen.getByText("2 admins, 3 judges")).toBeInTheDocument();
-    });
-  });
-
-  describe("staff avatar badges", () => {
-    it("shows Admin badge when adminCount > 0", () => {
-      render(
-        <OverviewClient
-          {...defaultProps}
-          stats={makeStats({ adminCount: 1, judgeCount: 0 })}
-        />
-      );
-      expect(screen.getByText("A")).toBeInTheDocument();
-    });
-
-    it("shows Judge badge when judgeCount > 0", () => {
-      render(
-        <OverviewClient
-          {...defaultProps}
-          stats={makeStats({ adminCount: 0, judgeCount: 1 })}
-        />
-      );
-      expect(screen.getByText("J")).toBeInTheDocument();
-    });
-
-    it("hides Admin badge when adminCount is 0", () => {
-      render(
-        <OverviewClient
-          {...defaultProps}
-          stats={makeStats({ adminCount: 0, judgeCount: 1 })}
-        />
-      );
-      expect(screen.queryByText("A")).not.toBeInTheDocument();
-    });
-
-    it("hides Judge badge when judgeCount is 0", () => {
-      render(
-        <OverviewClient
-          {...defaultProps}
-          stats={makeStats({ adminCount: 1, judgeCount: 0 })}
-        />
-      );
-      expect(screen.queryByText("J")).not.toBeInTheDocument();
     });
   });
 });
@@ -382,9 +340,10 @@ describe("OverviewClient — Upcoming Tournaments", () => {
 describe("OverviewClient — Activity Feed", () => {
   it("shows empty state message when activity is empty", () => {
     render(<OverviewClient {...defaultProps} activity={[]} />);
+    expect(screen.getByText("No activity yet")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "No activity yet — things will show up here as your community grows"
+        "Things will show up here as your community grows"
       )
     ).toBeInTheDocument();
   });
@@ -475,6 +434,7 @@ describe("OverviewClient — Activity Feed", () => {
 describe("OverviewClient — Top Regulars", () => {
   it("shows empty state when topPlayers is empty", () => {
     render(<OverviewClient {...defaultProps} topPlayers={[]} />);
+    expect(screen.getByText("No regulars yet")).toBeInTheDocument();
     expect(
       screen.getByText("Players will appear here after your first tournament")
     ).toBeInTheDocument();

--- a/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/overview-client.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/overview-client.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Plus } from "lucide-react";
+import {
+  Calendar,
+  Plus,
+  Swords,
+  Trophy,
+  UserCheck,
+  Users,
+  Zap,
+} from "lucide-react";
 import Link from "next/link";
 
 import type {
@@ -63,34 +71,22 @@ interface StatCardProps {
   label: string;
   value: number | string;
   subtitle: string;
-  extra?: React.ReactNode;
+  icon: React.ReactNode;
 }
 
-function StatCard({ label, value, subtitle, extra }: StatCardProps) {
+function StatCard({ label, value, subtitle, icon }: StatCardProps) {
   return (
-    <div className="bg-card text-card-foreground rounded-lg p-3 shadow-sm">
-      <p className="text-muted-foreground text-[10px] font-semibold tracking-wide uppercase">
-        {label}
-      </p>
-      <div className="mt-1.5 flex items-end justify-between">
-        <p className="text-xl font-bold">{value}</p>
-        {extra ?? (
-          <svg
-            width="52"
-            height="22"
-            viewBox="0 0 52 22"
-            className="text-primary opacity-60"
-          >
-            <polyline
-              points="0,20 9,15 17,17 26,11 35,13 43,7 52,4"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-            />
-          </svg>
-        )}
+    <div className="rounded-xl bg-card p-4 shadow-sm">
+      <div className="flex items-center gap-2">
+        {icon}
+        <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+          {label}
+        </p>
       </div>
-      <p className="mt-1 text-[10px] text-emerald-600">{subtitle}</p>
+      <p className="mt-2.5 text-2xl font-bold leading-none tabular-nums">
+        {value}
+      </p>
+      <p className="text-muted-foreground mt-1.5 text-[11px]">{subtitle}</p>
     </div>
   );
 }
@@ -111,37 +107,32 @@ export function OverviewClient({
       ? Math.round(stats.totalEntries / stats.totalTournaments)
       : 0;
 
-  const staffExtra = (
-    <div className="flex">
-      {stats.adminCount > 0 && (
-        <div className="flex h-5 w-5 items-center justify-center rounded-full bg-violet-500 text-[8px] font-semibold text-white">
-          A
-        </div>
-      )}
-      {stats.judgeCount > 0 && (
-        <div className="-ml-1 flex h-5 w-5 items-center justify-center rounded-full bg-sky-500 text-[8px] font-semibold text-white">
-          J
-        </div>
-      )}
-    </div>
-  );
-
   return (
-    <>
+    <div className="space-y-4">
       {/* Stats row */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <div className="grid grid-cols-2 gap-3 rounded-2xl bg-muted/30 p-3 lg:grid-cols-4">
         <StatCard
           label="Tournaments"
           value={stats.totalTournaments}
+          icon={
+            <div className="flex size-7 items-center justify-center rounded-lg bg-primary/10">
+              <Trophy className="size-3.5 text-primary" />
+            </div>
+          }
           subtitle={
             stats.totalTournaments === 0
               ? "Host your first tournament to start tracking"
-              : `↑ ${stats.activeTournaments} active`
+              : `${stats.activeTournaments} active`
           }
         />
         <StatCard
           label="Unique Players"
           value={stats.uniquePlayers}
+          icon={
+            <div className="flex size-7 items-center justify-center rounded-lg bg-violet-500/10">
+              <Users className="size-3.5 text-violet-600 dark:text-violet-400" />
+            </div>
+          }
           subtitle={
             stats.totalTournaments === 0
               ? "Host your first tournament to start tracking"
@@ -151,6 +142,11 @@ export function OverviewClient({
         <StatCard
           label="Total Entries"
           value={stats.totalEntries}
+          icon={
+            <div className="flex size-7 items-center justify-center rounded-lg bg-amber-500/10">
+              <Swords className="size-3.5 text-amber-600 dark:text-amber-400" />
+            </div>
+          }
           subtitle={
             stats.totalTournaments === 0
               ? "Host your first tournament to start tracking"
@@ -160,19 +156,26 @@ export function OverviewClient({
         <StatCard
           label="Staff"
           value={stats.staffCount}
+          icon={
+            <div className="flex size-7 items-center justify-center rounded-lg bg-sky-500/10">
+              <UserCheck className="size-3.5 text-sky-600 dark:text-sky-400" />
+            </div>
+          }
           subtitle={
             stats.totalTournaments === 0
               ? "Host your first tournament to start tracking"
               : `${stats.adminCount} admins, ${stats.judgeCount} judges`
           }
-          extra={staffExtra}
         />
       </div>
 
       {/* Upcoming Tournaments */}
       <DashboardCard>
         <div className="mb-3 flex items-center justify-between">
-          <p className="text-sm font-semibold">📅 Upcoming Tournaments</p>
+          <div className="flex items-center gap-2">
+            <Calendar className="size-4 text-primary" />
+            <p className="text-sm font-semibold">Upcoming Tournaments</p>
+          </div>
           <div className="flex items-center gap-3">
             <Link
               href={`/dashboard/community/${communitySlug}/tournaments/create`}
@@ -190,9 +193,13 @@ export function OverviewClient({
           </div>
         </div>
         {upcomingTournaments.length === 0 ? (
-          <div className="py-6 text-center">
+          <div className="py-8 text-center">
+            <Calendar className="text-muted-foreground/50 mx-auto mb-2 size-8" />
             <p className="text-muted-foreground text-sm">
               No upcoming tournaments
+            </p>
+            <p className="text-muted-foreground/70 mt-1 text-xs">
+              Create one to get started
             </p>
           </div>
         ) : (
@@ -201,14 +208,14 @@ export function OverviewClient({
               <Link
                 key={t.id}
                 href={`/dashboard/community/${communitySlug}/tournaments/${t.slug}/manage`}
-                className="bg-muted border-primary hover:bg-muted/70 focus-visible:ring-ring flex-1 rounded-lg border-l-[3px] p-3 transition-colors focus-visible:ring-2 focus-visible:outline-none"
+                className="flex-1 rounded-xl bg-muted/50 p-3 transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 <p className="text-sm font-semibold">{t.name}</p>
                 <p className="text-muted-foreground mt-1 text-xs">
                   {formatShortDate(t.start_date)} · {t.registrationCount}/
                   {t.max_participants ?? "∞"} registered
                 </p>
-                <div className="bg-border mt-2 h-1 overflow-hidden rounded-full">
+                <div className="mt-2 h-1 overflow-hidden rounded-full bg-border">
                   <div
                     className="bg-primary h-full rounded-full"
                     style={{
@@ -223,21 +230,28 @@ export function OverviewClient({
       </DashboardCard>
 
       {/* Activity Feed + Top Regulars */}
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         {/* Activity Feed */}
         <DashboardCard>
-          <p className="mb-3 text-sm font-semibold">⚡ Recent Activity</p>
+          <div className="mb-3 flex items-center gap-2">
+            <Zap className="size-4 text-amber-500" />
+            <p className="text-sm font-semibold">Recent Activity</p>
+          </div>
           {activity.length === 0 ? (
-            <p className="text-muted-foreground text-xs">
-              No activity yet — things will show up here as your community grows
-            </p>
+            <div className="py-6 text-center">
+              <Zap className="text-muted-foreground/50 mx-auto mb-2 size-8" />
+              <p className="text-muted-foreground text-sm">No activity yet</p>
+              <p className="text-muted-foreground/70 mt-1 text-xs">
+                Things will show up here as your community grows
+              </p>
+            </div>
           ) : (
             activity.map((item, i) => (
               <div
                 key={i}
                 className={cn(
                   "py-2",
-                  i < activity.length - 1 && "border-border/50 border-b"
+                  i < activity.length - 1 && "border-b border-border/50"
                 )}
               >
                 <p className="text-xs">
@@ -259,11 +273,18 @@ export function OverviewClient({
 
         {/* Top Regulars */}
         <DashboardCard>
-          <p className="mb-3 text-sm font-semibold">🏆 Top Regulars</p>
+          <div className="mb-3 flex items-center gap-2">
+            <Trophy className="size-4 text-amber-500" />
+            <p className="text-sm font-semibold">Top Regulars</p>
+          </div>
           {topPlayers.length === 0 ? (
-            <p className="text-muted-foreground text-xs">
-              Players will appear here after your first tournament
-            </p>
+            <div className="py-6 text-center">
+              <Trophy className="text-muted-foreground/50 mx-auto mb-2 size-8" />
+              <p className="text-muted-foreground text-sm">No regulars yet</p>
+              <p className="text-muted-foreground/70 mt-1 text-xs">
+                Players will appear here after your first tournament
+              </p>
+            </div>
           ) : (
             topPlayers.map((player, i) => (
               <div
@@ -275,9 +296,9 @@ export function OverviewClient({
                 </span>
                 <div
                   className={cn(
-                    "flex h-6 w-6 items-center justify-center rounded-full text-[9px] font-bold",
-                    i === 0 && "bg-amber-400",
-                    i === 1 && "bg-zinc-300",
+                    "flex size-6 items-center justify-center rounded-full text-[9px] font-bold",
+                    i === 0 && "bg-amber-400 text-amber-950",
+                    i === 1 && "bg-zinc-300 text-zinc-700",
                     i === 2 && "bg-amber-700 text-white",
                     i > 2 && "bg-muted text-muted-foreground"
                   )}
@@ -295,6 +316,6 @@ export function OverviewClient({
           )}
         </DashboardCard>
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/page.tsx
@@ -9,6 +9,7 @@ import {
 
 import { createClient } from "@/lib/supabase/server";
 import { PageHeader } from "@/components/dashboard/page-header";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 
 import { OverviewClient } from "./overview-client";
 
@@ -67,7 +68,7 @@ export default async function DashboardCommunityOverviewPage({
   return (
     <>
       <PageHeader title="Overview" />
-      <div className="flex flex-1 flex-col gap-3 p-4 md:p-6">
+      <DashboardContent>
         <OverviewClient
           communitySlug={communitySlug}
           stats={stats}
@@ -75,7 +76,7 @@ export default async function DashboardCommunityOverviewPage({
           activity={activity}
           upcomingTournaments={upcomingTournaments}
         />
-      </div>
+      </DashboardContent>
     </>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/settings/integrations/discord/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/settings/integrations/discord/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/discord/guild-cache";
 
 import { DiscordClient } from "./discord-client";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 
 interface PageProps {
   params: Promise<{ communitySlug: string }>;
@@ -44,12 +45,14 @@ export default async function DiscordIntegrationPage({ params }: PageProps) {
   }
 
   return (
-    <DiscordClient
-      community={community}
-      communitySlug={communitySlug}
-      overview={overview}
-      guildChannels={guildChannels}
-      guildRoles={guildRoles}
-    />
+    <DashboardContent>
+      <DiscordClient
+        community={community}
+        communitySlug={communitySlug}
+        overview={overview}
+        guildChannels={guildChannels}
+        guildRoles={guildRoles}
+      />
+    </DashboardContent>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/settings/integrations/discord/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/settings/integrations/discord/page.tsx
@@ -5,7 +5,6 @@ import {
   getDiscordIntegrationOverview,
 } from "@trainers/supabase";
 
-import { rejectBots } from "@/actions/utils";
 import { createClient } from "@/lib/supabase/server";
 import {
   getCachedGuildChannels,
@@ -20,7 +19,6 @@ interface PageProps {
 }
 
 export default async function DiscordIntegrationPage({ params }: PageProps) {
-  await rejectBots();
   const { communitySlug } = await params;
   const supabase = await createClient();
 

--- a/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/settings/page.tsx
@@ -29,6 +29,7 @@ import {
   removeCommunityLogo,
 } from "@/actions/community-logo";
 import { PageHeader } from "@/components/dashboard/page-header";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -100,23 +101,21 @@ export default function DashboardSettingsPage({ params }: PageProps) {
   return (
     <>
       <PageHeader title="Settings" />
-      <div className="flex flex-1 flex-col gap-3 p-4 md:p-6">
-        <div className="mx-auto w-full max-w-6xl">
-          {isLoading ? (
-            <SettingsSkeleton />
-          ) : !org ? (
-            <p className="text-muted-foreground text-sm">
-              Community not found.
-            </p>
-          ) : (
-            <SettingsForm
-              org={org}
-              communitySlug={communitySlug}
-              onSaved={refetch}
-            />
-          )}
-        </div>
-      </div>
+      <DashboardContent>
+        {isLoading ? (
+          <SettingsSkeleton />
+        ) : !org ? (
+          <p className="text-muted-foreground text-sm">
+            Community not found.
+          </p>
+        ) : (
+          <SettingsForm
+            org={org}
+            communitySlug={communitySlug}
+            onSaved={refetch}
+          />
+        )}
+      </DashboardContent>
     </>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/staff/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/staff/page.tsx
@@ -6,6 +6,7 @@ import {
 
 import { createClient, getUser } from "@/lib/supabase/server";
 import { PageHeader } from "@/components/dashboard/page-header";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 import { RolePermissionsCard } from "@/components/dashboard/role-permissions-card";
 
 import { StaffClient } from "./staff-client";
@@ -45,7 +46,7 @@ export default async function DashboardStaffPage({ params }: PageProps) {
   return (
     <>
       <PageHeader title="Staff" />
-      <div className="flex flex-1 flex-col gap-3 p-4 md:p-6">
+      <DashboardContent>
         <StaffClient
           communityId={organization.id}
           communitySlug={communitySlug}
@@ -56,7 +57,7 @@ export default async function DashboardStaffPage({ params }: PageProps) {
           currentUserRole={currentUserRole}
         />
         <RolePermissionsCard />
-      </div>
+      </DashboardContent>
     </>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/staff/staff-client.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/staff/staff-client.tsx
@@ -27,6 +27,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -543,42 +544,44 @@ function StaffMobileRow({
             <MoreHorizontal className="size-5" />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-52">
-            <DropdownMenuLabel>Move to</DropdownMenuLabel>
-            {groups.map((group) => {
-              const targetRole = group.role?.name ?? null;
-              const canMoveHere = canManageGroup(
-                currentUserRole,
-                isOwner,
-                targetRole
-              );
-              const isCurrent = currentGroupId === group.id;
-              return (
+            <DropdownMenuGroup>
+              <DropdownMenuLabel>Move to</DropdownMenuLabel>
+              {groups.map((group) => {
+                const targetRole = group.role?.name ?? null;
+                const canMoveHere = canManageGroup(
+                  currentUserRole,
+                  isOwner,
+                  targetRole
+                );
+                const isCurrent = currentGroupId === group.id;
+                return (
+                  <DropdownMenuItem
+                    key={group.id}
+                    disabled={!canMoveHere || isCurrent}
+                    onClick={() => {
+                      if (!canMoveHere || isCurrent) return;
+                      void onMoveTo(member, { type: "group", group });
+                    }}
+                  >
+                    {group.name}
+                    {isCurrent && (
+                      <span className="text-muted-foreground ml-auto text-xs">
+                        Current
+                      </span>
+                    )}
+                  </DropdownMenuItem>
+                );
+              })}
+              {currentGroupId !== null && canManageMember && (
                 <DropdownMenuItem
-                  key={group.id}
-                  disabled={!canMoveHere || isCurrent}
                   onClick={() => {
-                    if (!canMoveHere || isCurrent) return;
-                    void onMoveTo(member, { type: "group", group });
+                    void onMoveTo(member, { type: "unassigned" });
                   }}
                 >
-                  {group.name}
-                  {isCurrent && (
-                    <span className="text-muted-foreground ml-auto text-xs">
-                      Current
-                    </span>
-                  )}
+                  Unassign
                 </DropdownMenuItem>
-              );
-            })}
-            {currentGroupId !== null && canManageMember && (
-              <DropdownMenuItem
-                onClick={() => {
-                  void onMoveTo(member, { type: "unassigned" });
-                }}
-              >
-                Unassign
-              </DropdownMenuItem>
-            )}
+              )}
+            </DropdownMenuGroup>
             {isOwner && (
               <>
                 <DropdownMenuSeparator />

--- a/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/tournaments/[tournamentSlug]/manage/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/tournaments/[tournamentSlug]/manage/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 
 import { PageHeader } from "@/components/dashboard/page-header";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 import { TournamentManageClient } from "./tournament-manage-client";
 
 interface PageProps {
@@ -27,12 +28,12 @@ export default async function DashboardTournamentManagePage({
           Tournaments
         </Link>
       </PageHeader>
-      <div className="flex flex-1 flex-col gap-3 p-4 md:p-6">
+      <DashboardContent>
         <TournamentManageClient
           communitySlug={communitySlug}
           tournamentSlug={tournamentSlug}
         />
-      </div>
+      </DashboardContent>
     </>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/tournaments/[tournamentSlug]/manage/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/tournaments/[tournamentSlug]/manage/settings/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 
 import { PageHeader } from "@/components/dashboard/page-header";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 import { TournamentSettingsPageClient } from "./tournament-settings-page-client";
 
 interface PageProps {
@@ -25,12 +26,12 @@ export default async function TournamentSettingsPage({ params }: PageProps) {
           Manage
         </Link>
       </PageHeader>
-      <div className="flex flex-1 flex-col gap-3 p-4 md:p-6">
+      <DashboardContent>
         <TournamentSettingsPageClient
           communitySlug={communitySlug}
           tournamentSlug={tournamentSlug}
         />
-      </div>
+      </DashboardContent>
     </>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/tournaments/create/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/tournaments/create/page.tsx
@@ -8,6 +8,7 @@ import {
 
 import { createClientReadOnly } from "@/lib/supabase/server";
 import { PageHeader } from "@/components/dashboard/page-header";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 import { CreateTournamentClient } from "./create-tournament-client";
 
 interface PageProps {
@@ -38,12 +39,12 @@ export default async function DashboardCreateTournamentPage({
           Tournaments
         </Link>
       </PageHeader>
-      <div className="flex flex-1 flex-col gap-3 p-4 md:p-6">
+      <DashboardContent>
         <CreateTournamentClient
           communitySlug={communitySlug}
           discordInstalled={discordInstalled}
         />
-      </div>
+      </DashboardContent>
     </>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/tournaments/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/tournaments/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { createClient } from "@/lib/supabase/server";
 import { TournamentsListClient } from "./tournaments-list-client";
 import { PageHeader } from "@/components/dashboard/page-header";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 
 interface PageProps {
   params: Promise<{
@@ -41,13 +42,13 @@ export default async function DashboardTournamentsPage({
           </Button>
         </Link>
       </PageHeader>
-      <div className="flex flex-1 flex-col gap-3 p-4 md:p-6">
+      <DashboardContent>
         <TournamentsListClient
           communityId={organization.id}
           communitySlug={communitySlug}
           initialStatus={status}
         />
-      </div>
+      </DashboardContent>
     </>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/community/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/page.tsx
@@ -3,6 +3,7 @@ import { createClient, getUser } from "@/lib/supabase/server";
 import { listMyCommunities } from "@trainers/supabase";
 import { CommunitySelectorClient } from "./community-selector-client";
 import { PageHeader } from "@/components/dashboard/page-header";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 
 export default async function DashboardCommunityPage() {
   const user = await getUser();
@@ -21,9 +22,9 @@ export default async function DashboardCommunityPage() {
     return (
       <>
         <PageHeader title="Communities" />
-        <div className="flex flex-1 flex-col gap-4 p-4 md:p-6">
+        <DashboardContent>
           <CommunitySelectorClient organizations={[]} />
-        </div>
+        </DashboardContent>
       </>
     );
   }
@@ -37,9 +38,9 @@ export default async function DashboardCommunityPage() {
   return (
     <>
       <PageHeader title="Communities" />
-      <div className="flex flex-1 flex-col gap-4 p-4 md:p-6">
+      <DashboardContent>
         <CommunitySelectorClient organizations={organizations} />
-      </div>
+      </DashboardContent>
     </>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/community/request/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/request/page.tsx
@@ -25,6 +25,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { PageHeader } from "@/components/dashboard/page-header";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 import { PlatformIcon } from "@/components/communities/social-link-icons";
 import { submitCommunityRequestAction } from "@/actions/community-requests";
 import { cn } from "@/lib/utils";
@@ -120,7 +121,7 @@ export default function DashboardCommunityRequestPage() {
   return (
     <>
       <PageHeader title="Request a Community" />
-      <div className="flex flex-1 flex-col p-4 md:p-6">
+      <DashboardContent>
         <div className="w-full max-w-[520px]">
           {isLoading ? (
             <RequestPageSkeleton />
@@ -134,7 +135,7 @@ export default function DashboardCommunityRequestPage() {
             />
           )}
         </div>
-      </div>
+      </DashboardContent>
     </>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/components/__tests__/community-highlights.test.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/__tests__/community-highlights.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from "@testing-library/react";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => <img {...props} />,
+}));
+jest.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    render,
+  }: {
+    children: React.ReactNode;
+    render?: React.ReactElement;
+    nativeButton?: boolean;
+    size?: string;
+    variant?: string;
+    className?: string;
+  }) => {
+    if (render && render.props?.href) {
+      return <a href={render.props.href}>{children}</a>;
+    }
+    return <button>{children}</button>;
+  },
+}));
+
+import { CommunityHighlights } from "../community-highlights";
+
+describe("CommunityHighlights", () => {
+  it("shows empty state when no communities", () => {
+    render(<CommunityHighlights communities={[]} />);
+    expect(
+      screen.getByText("Not part of any communities yet")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Browse Communities")).toBeInTheDocument();
+  });
+
+  it("renders community names as links", () => {
+    const communities = [
+      {
+        id: 1,
+        name: "VGC League",
+        slug: "vgc-league",
+        logoUrl: null,
+        hasLiveTournament: false,
+      },
+    ];
+    render(<CommunityHighlights communities={communities} />);
+    const link = screen.getByText("VGC League").closest("a");
+    expect(link).toHaveAttribute("href", "/dashboard/community/vgc-league");
+  });
+
+  it("shows Live tournament indicator when hasLiveTournament is true", () => {
+    const communities = [
+      {
+        id: 1,
+        name: "Active League",
+        slug: "active-league",
+        logoUrl: null,
+        hasLiveTournament: true,
+      },
+    ];
+    render(<CommunityHighlights communities={communities} />);
+    expect(screen.getByText("Live tournament")).toBeInTheDocument();
+  });
+
+  it("does not show Live tournament when hasLiveTournament is false", () => {
+    const communities = [
+      {
+        id: 1,
+        name: "Quiet League",
+        slug: "quiet-league",
+        logoUrl: null,
+        hasLiveTournament: false,
+      },
+    ];
+    render(<CommunityHighlights communities={communities} />);
+    expect(screen.queryByText("Live tournament")).not.toBeInTheDocument();
+  });
+
+  it("shows community logo when logoUrl is present", () => {
+    const communities = [
+      {
+        id: 1,
+        name: "Logo League",
+        slug: "logo-league",
+        logoUrl: "https://example.com/logo.png",
+        hasLiveTournament: false,
+      },
+    ];
+    render(<CommunityHighlights communities={communities} />);
+    const img = screen.getByAltText("Logo League");
+    expect(img).toHaveAttribute("src", "https://example.com/logo.png");
+  });
+});

--- a/apps/web/src/app/(dashboard)/dashboard/components/__tests__/dashboard-activity.test.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/__tests__/dashboard-activity.test.tsx
@@ -1,0 +1,368 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(() => ({ push: jest.fn(), refresh: jest.fn() })),
+}));
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+jest.mock("@/actions/tournaments", () => ({
+  checkIn: jest.fn(),
+}));
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+// Mock Button to render simply (avoids Base UI render prop complexity)
+jest.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    render,
+    onClick,
+    disabled,
+    ...props
+  }: {
+    children: React.ReactNode;
+    render?: React.ReactElement;
+    onClick?: () => void;
+    disabled?: boolean;
+    nativeButton?: boolean;
+    size?: string;
+    variant?: string;
+    className?: string;
+  }) => {
+    if (render && render.props?.href) {
+      return <a href={render.props.href}>{children}</a>;
+    }
+    return (
+      <button onClick={onClick} disabled={disabled} {...props}>
+        {children}
+      </button>
+    );
+  },
+}));
+
+import { checkIn } from "@/actions/tournaments";
+import { toast } from "sonner";
+import { DashboardActivity } from "../dashboard-activity";
+
+const mockedCheckIn = checkIn as jest.MockedFunction<typeof checkIn>;
+
+describe("DashboardActivity", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Fix Date.now to a known value
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-03-25T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("renders both panels", () => {
+    render(<DashboardActivity myTournaments={[]} recentActivity={[]} />);
+    expect(screen.getByText("Upcoming Tournaments")).toBeInTheDocument();
+    expect(screen.getByText("Recent Activity")).toBeInTheDocument();
+  });
+
+  describe("UpcomingTournamentsList", () => {
+    it("shows empty state with Find Tournaments button", () => {
+      render(<DashboardActivity myTournaments={[]} recentActivity={[]} />);
+      expect(screen.getByText("No upcoming tournaments")).toBeInTheDocument();
+      expect(screen.getByText("Find Tournaments")).toBeInTheDocument();
+    });
+
+    it("renders tournament names and dates", () => {
+      const tournaments = [
+        {
+          id: 1,
+          name: "VGC Cup",
+          slug: "vgc-cup",
+          startDate: new Date("2026-03-25T18:00:00.000Z").getTime(),
+          status: "upcoming",
+          hasTeam: true,
+          registrationStatus: "checked_in",
+          registrationId: 1,
+          lateCheckInMaxRound: null,
+        },
+      ];
+      render(
+        <DashboardActivity myTournaments={tournaments} recentActivity={[]} />
+      );
+      expect(screen.getByText("VGC Cup")).toBeInTheDocument();
+      expect(screen.getByText("Today")).toBeInTheDocument();
+      expect(screen.getByText("Checked In")).toBeInTheDocument();
+    });
+
+    it("shows Tomorrow for 24-48h away", () => {
+      const tournaments = [
+        {
+          id: 1,
+          name: "Tomorrow Cup",
+          slug: "tomorrow-cup",
+          startDate: new Date("2026-03-26T18:00:00.000Z").getTime(),
+          status: "upcoming",
+          hasTeam: true,
+          registrationStatus: "checked_in",
+          registrationId: 1,
+          lateCheckInMaxRound: null,
+        },
+      ];
+      render(
+        <DashboardActivity myTournaments={tournaments} recentActivity={[]} />
+      );
+      expect(screen.getByText("Tomorrow")).toBeInTheDocument();
+    });
+
+    it("shows In X days for 2-7 days away", () => {
+      const tournaments = [
+        {
+          id: 1,
+          name: "Future Cup",
+          slug: "future-cup",
+          startDate: new Date("2026-03-28T12:00:00.000Z").getTime(),
+          status: "upcoming",
+          hasTeam: true,
+          registrationStatus: "checked_in",
+          registrationId: 1,
+          lateCheckInMaxRound: null,
+        },
+      ];
+      render(
+        <DashboardActivity myTournaments={tournaments} recentActivity={[]} />
+      );
+      expect(screen.getByText("In 3 days")).toBeInTheDocument();
+    });
+
+    it("shows formatted date for > 7 days away", () => {
+      const tournaments = [
+        {
+          id: 1,
+          name: "Far Cup",
+          slug: "far-cup",
+          startDate: new Date("2026-04-15T12:00:00.000Z").getTime(),
+          status: "upcoming",
+          hasTeam: true,
+          registrationStatus: "checked_in",
+          registrationId: 1,
+          lateCheckInMaxRound: null,
+        },
+      ];
+      render(
+        <DashboardActivity myTournaments={tournaments} recentActivity={[]} />
+      );
+      expect(screen.getByText("Apr 15")).toBeInTheDocument();
+    });
+
+    it("shows In Progress for past start dates", () => {
+      const tournaments = [
+        {
+          id: 1,
+          name: "Active Cup",
+          slug: "active-cup",
+          startDate: new Date("2026-03-25T10:00:00.000Z").getTime(),
+          status: "active",
+          hasTeam: true,
+          registrationStatus: "checked_in",
+          registrationId: 1,
+          lateCheckInMaxRound: null,
+        },
+      ];
+      render(
+        <DashboardActivity myTournaments={tournaments} recentActivity={[]} />
+      );
+      expect(screen.getByText("In Progress")).toBeInTheDocument();
+    });
+
+    it("shows Date TBD for null startDate", () => {
+      const tournaments = [
+        {
+          id: 1,
+          name: "TBD Cup",
+          slug: "tbd-cup",
+          startDate: null,
+          status: "upcoming",
+          hasTeam: true,
+          registrationStatus: "checked_in",
+          registrationId: 1,
+          lateCheckInMaxRound: null,
+        },
+      ];
+      render(
+        <DashboardActivity myTournaments={tournaments} recentActivity={[]} />
+      );
+      expect(screen.getByText("Date TBD")).toBeInTheDocument();
+    });
+
+    it("shows Team Required when !hasTeam", () => {
+      const tournaments = [
+        {
+          id: 1,
+          name: "No Team",
+          slug: "no-team",
+          startDate: new Date("2026-03-26T12:00:00.000Z").getTime(),
+          status: "upcoming",
+          hasTeam: false,
+          registrationStatus: "registered",
+          registrationId: 1,
+          lateCheckInMaxRound: null,
+        },
+      ];
+      render(
+        <DashboardActivity myTournaments={tournaments} recentActivity={[]} />
+      );
+      expect(screen.getByText("Team Required")).toBeInTheDocument();
+    });
+
+    it("shows Check in now! when active and not checked in", () => {
+      const tournaments = [
+        {
+          id: 1,
+          name: "Urgent",
+          slug: "urgent",
+          startDate: new Date("2026-03-25T10:00:00.000Z").getTime(),
+          status: "active",
+          hasTeam: true,
+          registrationStatus: "registered",
+          registrationId: 1,
+          lateCheckInMaxRound: null,
+        },
+      ];
+      render(
+        <DashboardActivity myTournaments={tournaments} recentActivity={[]} />
+      );
+      expect(screen.getByText("Check in now!")).toBeInTheDocument();
+    });
+
+    it("shows Ready for Check-in when hasTeam and not checked in", () => {
+      const tournaments = [
+        {
+          id: 1,
+          name: "Ready",
+          slug: "ready",
+          startDate: new Date("2026-03-26T12:00:00.000Z").getTime(),
+          status: "upcoming",
+          hasTeam: true,
+          registrationStatus: "registered",
+          registrationId: 1,
+          lateCheckInMaxRound: null,
+        },
+      ];
+      render(
+        <DashboardActivity myTournaments={tournaments} recentActivity={[]} />
+      );
+      expect(screen.getByText("Ready for Check-in")).toBeInTheDocument();
+    });
+
+    it("check-in button calls action and shows toast on success", async () => {
+      mockedCheckIn.mockResolvedValue({ success: true });
+      const tournaments = [
+        {
+          id: 42,
+          name: "Check In Test",
+          slug: "check-in-test",
+          startDate: new Date("2026-03-26T12:00:00.000Z").getTime(),
+          status: "upcoming",
+          hasTeam: true,
+          registrationStatus: "registered",
+          registrationId: 1,
+          lateCheckInMaxRound: null,
+        },
+      ];
+      render(
+        <DashboardActivity myTournaments={tournaments} recentActivity={[]} />
+      );
+      fireEvent.click(screen.getByText("Check In"));
+      await waitFor(() => {
+        expect(mockedCheckIn).toHaveBeenCalledWith(42);
+      });
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith("Successfully checked in!");
+      });
+    });
+
+    it("check-in shows error toast on failure", async () => {
+      mockedCheckIn.mockResolvedValue({
+        success: false,
+        error: "Already checked in",
+      });
+      const tournaments = [
+        {
+          id: 42,
+          name: "Fail Test",
+          slug: "fail-test",
+          startDate: new Date("2026-03-26T12:00:00.000Z").getTime(),
+          status: "upcoming",
+          hasTeam: true,
+          registrationStatus: "registered",
+          registrationId: 1,
+          lateCheckInMaxRound: null,
+        },
+      ];
+      render(
+        <DashboardActivity myTournaments={tournaments} recentActivity={[]} />
+      );
+      fireEvent.click(screen.getByText("Check In"));
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith("Already checked in");
+      });
+    });
+  });
+
+  describe("RecentActivityList", () => {
+    it("shows empty state", () => {
+      render(<DashboardActivity myTournaments={[]} recentActivity={[]} />);
+      expect(screen.getByText("No recent battles")).toBeInTheDocument();
+    });
+
+    it("renders win/loss indicators", () => {
+      const activities = [
+        {
+          id: 1,
+          tournamentName: "VGC Cup",
+          opponentName: "Ash",
+          result: "won",
+          date: new Date("2026-03-25T11:00:00.000Z").getTime(),
+        },
+        {
+          id: 2,
+          tournamentName: "VGC Cup",
+          opponentName: "Gary",
+          result: "lost",
+          date: new Date("2026-03-25T10:00:00.000Z").getTime(),
+        },
+      ];
+      render(
+        <DashboardActivity myTournaments={[]} recentActivity={activities} />
+      );
+      expect(screen.getByText("W")).toBeInTheDocument();
+      expect(screen.getByText("L")).toBeInTheDocument();
+      expect(screen.getByText("Ash")).toBeInTheDocument();
+      expect(screen.getByText("Gary")).toBeInTheDocument();
+    });
+
+    it("shows relative time for recent activities", () => {
+      const activities = [
+        {
+          id: 1,
+          tournamentName: "VGC Cup",
+          opponentName: "Ash",
+          result: "won",
+          date: new Date("2026-03-25T11:30:00.000Z").getTime(),
+        },
+      ];
+      render(
+        <DashboardActivity myTournaments={[]} recentActivity={activities} />
+      );
+      expect(screen.getByText("30m ago")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/app/(dashboard)/dashboard/components/__tests__/enhanced-stats.test.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/__tests__/enhanced-stats.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from "@testing-library/react";
+import { EnhancedStats } from "../enhanced-stats";
+
+const defaultProps = {
+  winRate: "55.0%",
+  winRateSub: "11W - 9L",
+  rating: "1250",
+  ratingSub: "Peak: 1300",
+  record: "11-9",
+  recordSub: "20 games played",
+  tournaments: "3",
+  tournamentsSub: "1 active",
+};
+
+describe("EnhancedStats", () => {
+  it("renders all 4 stat cards", () => {
+    render(<EnhancedStats {...defaultProps} />);
+    expect(screen.getByText("Win Rate")).toBeInTheDocument();
+    expect(screen.getByText("Rating")).toBeInTheDocument();
+    expect(screen.getByText("Record")).toBeInTheDocument();
+    expect(screen.getByText("Tournaments")).toBeInTheDocument();
+  });
+
+  it("displays passed values", () => {
+    render(<EnhancedStats {...defaultProps} />);
+    expect(screen.getByText("55.0%")).toBeInTheDocument();
+    expect(screen.getByText("1250")).toBeInTheDocument();
+    expect(screen.getByText("11-9")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("applies high tier color for win rate >= 60%", () => {
+    const { container } = render(
+      <EnhancedStats {...defaultProps} winRate="65.0%" />
+    );
+    // The value element should have emerald color class
+    const valueEl = screen.getByText("65.0%");
+    expect(valueEl.className).toContain("emerald");
+  });
+
+  it("applies good tier color for win rate 50-60%", () => {
+    render(<EnhancedStats {...defaultProps} winRate="55.0%" />);
+    const valueEl = screen.getByText("55.0%");
+    expect(valueEl.className).toContain("teal");
+  });
+
+  it("applies low tier color for win rate < 40%", () => {
+    render(<EnhancedStats {...defaultProps} winRate="35.0%" />);
+    const valueEl = screen.getByText("35.0%");
+    expect(valueEl.className).toContain("red");
+  });
+
+  it("applies neutral (no special color) for 40-50% win rate", () => {
+    render(<EnhancedStats {...defaultProps} winRate="45.0%" />);
+    const valueEl = screen.getByText("45.0%");
+    expect(valueEl.className).not.toContain("emerald");
+    expect(valueEl.className).not.toContain("teal");
+    expect(valueEl.className).not.toContain("red");
+  });
+
+  it("applies neutral when no games (0.0%)", () => {
+    render(<EnhancedStats {...defaultProps} winRate="0.0%" />);
+    const valueEl = screen.getByText("0.0%");
+    expect(valueEl.className).not.toContain("emerald");
+    expect(valueEl.className).not.toContain("red");
+  });
+
+  it("shows muted style for rating '—'", () => {
+    render(<EnhancedStats {...defaultProps} rating="—" />);
+    const valueEl = screen.getByText("—");
+    expect(valueEl.className).toContain("muted");
+  });
+
+  it("shows muted style for rating '0'", () => {
+    render(<EnhancedStats {...defaultProps} rating="0" />);
+    const valueEl = screen.getByText("0");
+    expect(valueEl.className).toContain("muted");
+  });
+
+  it("shows accent color for tournaments sub when tournamentsSubAccent is true", () => {
+    render(
+      <EnhancedStats
+        {...defaultProps}
+        tournamentsSub="1 active"
+        tournamentsSubAccent={true}
+      />
+    );
+    const subEl = screen.getByText("1 active");
+    expect(subEl.className).toContain("emerald");
+  });
+
+  it("shows muted color for tournaments sub when tournamentsSubAccent is false", () => {
+    render(
+      <EnhancedStats
+        {...defaultProps}
+        tournamentsSub="None active"
+        tournamentsSubAccent={false}
+      />
+    );
+    const subEl = screen.getByText("None active");
+    expect(subEl.className).toContain("muted");
+  });
+});

--- a/apps/web/src/app/(dashboard)/dashboard/components/__tests__/enhanced-stats.test.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/__tests__/enhanced-stats.test.tsx
@@ -30,7 +30,7 @@ describe("EnhancedStats", () => {
   });
 
   it("applies high tier color for win rate >= 60%", () => {
-    const { container } = render(
+    render(
       <EnhancedStats {...defaultProps} winRate="65.0%" />
     );
     // The value element should have emerald color class

--- a/apps/web/src/app/(dashboard)/dashboard/components/__tests__/teams-sub-table.test.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/__tests__/teams-sub-table.test.tsx
@@ -67,9 +67,11 @@ jest.mock("@/lib/utils", () => ({
 // --- lucide-react ---
 jest.mock("lucide-react", () => ({
   Loader2: () => <svg data-testid="icon-loader" />,
-  Hammer: () => <svg data-testid="icon-hammer" />,
-  ArrowUpRight: () => <svg data-testid="icon-arrow-up" />,
-  Copy: () => <svg data-testid="icon-copy" />,
+  ExternalLink: () => <svg data-testid="icon-external-link" />,
+  Trophy: () => <svg data-testid="icon-trophy" />,
+  Swords: () => <svg data-testid="icon-swords" />,
+  ChevronRight: () => <svg data-testid="icon-chevron-right" />,
+  History: () => <svg data-testid="icon-history" />,
 }));
 
 // --- @/components/ui/button ---
@@ -93,23 +95,6 @@ jest.mock("@/components/ui/button", () => ({
     }
     return <button {...props}>{children}</button>;
   },
-}));
-
-// --- @/components/ui/tooltip ---
-jest.mock("@/components/ui/tooltip", () => ({
-  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  TooltipTrigger: ({
-    children,
-    render: _render,
-    ...props
-  }: {
-    children?: React.ReactNode;
-    render?: React.ReactElement;
-    [key: string]: unknown;
-  }) => <span {...props}>{children}</span>,
-  TooltipContent: ({ children }: { children: React.ReactNode }) => (
-    <span>{children}</span>
-  ),
 }));
 
 import { render, screen, fireEvent } from "@testing-library/react";
@@ -180,7 +165,7 @@ describe("TeamsSubTable", () => {
     setupQueryMocks({ data: [], isLoading: false });
   });
 
-  // ── Loading state ──────────────────────────────────────────────────────
+  // -- Loading state --
 
   it("renders loading spinner when teams are loading", () => {
     setupQueryMocks({ data: null, isLoading: true });
@@ -190,7 +175,7 @@ describe("TeamsSubTable", () => {
     expect(loaders.length).toBeGreaterThanOrEqual(1);
   });
 
-  // ── Empty state ────────────────────────────────────────────────────────
+  // -- Empty state --
 
   it("renders 'No teams yet' when there are no teams", () => {
     setupQueryMocks({ data: [], isLoading: false });
@@ -207,7 +192,7 @@ describe("TeamsSubTable", () => {
     expect(screen.getByText("No results yet")).toBeInTheDocument();
   });
 
-  // ── Teams display ──────────────────────────────────────────────────────
+  // -- Teams display --
 
   it("renders team names and pokemon sprites", () => {
     const teams: Team[] = [
@@ -226,7 +211,7 @@ describe("TeamsSubTable", () => {
     expect(images.length).toBe(4);
   });
 
-  // ── Recent results display ─────────────────────────────────────────────
+  // -- Recent results display --
 
   it("renders tournament results with placement", () => {
     const results: TournamentResult[] = [
@@ -255,57 +240,57 @@ describe("TeamsSubTable", () => {
 
     expect(screen.getByText("Pallet Open")).toBeInTheDocument();
     expect(screen.getByText("Viridian Cup")).toBeInTheDocument();
-    // First place gets trophy emoji
-    expect(screen.getByText(/^#1/)).toBeInTheDocument();
+    // First place shows trophy icon instead of #1 text
+    expect(screen.getByTestId("icon-trophy")).toBeInTheDocument();
     expect(screen.getByText("#4")).toBeInTheDocument();
   });
 
-  // ── Footer buttons ─────────────────────────────────────────────────────
+  // -- Footer buttons --
 
-  it("renders 'View as this alt' and 'View history' links", () => {
+  it("renders 'View alt' and 'History' links", () => {
     setupQueryMocks({ data: [], isLoading: false });
     render(<TeamsSubTable {...getDefaultProps()} />);
 
-    const viewAltLink = screen.getByText("View as this alt");
+    const viewAltLink = screen.getByText("View alt");
     expect(viewAltLink.closest("a")).toHaveAttribute(
       "href",
       "/dashboard/alts/ash_main"
     );
 
-    const viewHistoryLink = screen.getByText("View history");
-    expect(viewHistoryLink.closest("a")).toHaveAttribute(
+    const historyLink = screen.getByText("History");
+    expect(historyLink.closest("a")).toHaveAttribute(
       "href",
       "/dashboard/alts/ash_main/tournaments"
     );
   });
 
-  it("renders Delete alt button for non-main alts", () => {
+  it("renders Delete button for non-main alts", () => {
     setupQueryMocks({ data: [], isLoading: false });
     render(<TeamsSubTable {...getDefaultProps({ isMain: false })} />);
     expect(
-      screen.getByRole("button", { name: /Delete alt/ })
+      screen.getByRole("button", { name: /Delete/ })
     ).toBeInTheDocument();
   });
 
-  it("does not render Delete alt button for main alt", () => {
+  it("does not render Delete button for main alt", () => {
     render(<TeamsSubTable {...getDefaultProps({ isMain: true })} />);
-    expect(screen.queryByText("Delete alt")).not.toBeInTheDocument();
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
   });
 
   it("calls onDeleteAlt when delete button is clicked", () => {
     const props = getDefaultProps();
     render(<TeamsSubTable {...props} />);
-    fireEvent.click(screen.getByText("Delete alt"));
+    fireEvent.click(screen.getByText("Delete"));
     expect(props.onDeleteAlt).toHaveBeenCalled();
   });
 
   it("disables delete button when isDeletePending is true", () => {
     render(<TeamsSubTable {...getDefaultProps({ isDeletePending: true })} />);
-    const deleteBtn = screen.getByText("Delete alt");
+    const deleteBtn = screen.getByText("Delete");
     expect(deleteBtn).toBeDisabled();
   });
 
-  // ── Section headings ──────────────────────────────────────────────────
+  // -- Section headings --
 
   it("renders Teams and Recent Results section headings", () => {
     setupQueryMocks({ data: [], isLoading: false });

--- a/apps/web/src/app/(dashboard)/dashboard/components/__tests__/welcome-header.test.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/__tests__/welcome-header.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from "@testing-library/react";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+jest.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    render,
+  }: {
+    children: React.ReactNode;
+    render?: React.ReactElement;
+    nativeButton?: boolean;
+    size?: string;
+    variant?: string;
+  }) => {
+    if (render && render.props?.href) {
+      return <a href={render.props.href}>{children}</a>;
+    }
+    return <button>{children}</button>;
+  },
+}));
+
+import { WelcomeHeader } from "../welcome-header";
+
+describe("WelcomeHeader", () => {
+  it("shows username in heading", () => {
+    render(
+      <WelcomeHeader
+        username="ash_ketchum"
+        hasAlts={true}
+        hasTeamBuilderAccess={false}
+      />
+    );
+    expect(
+      screen.getByText("Welcome back, ash_ketchum")
+    ).toBeInTheDocument();
+  });
+
+  it("shows 'Trainer' for temp_ usernames", () => {
+    render(
+      <WelcomeHeader
+        username="temp_abc123"
+        hasAlts={false}
+        hasTeamBuilderAccess={false}
+      />
+    );
+    expect(screen.getByText("Welcome back, Trainer")).toBeInTheDocument();
+  });
+
+  it("shows 'Trainer' for user_ usernames", () => {
+    render(
+      <WelcomeHeader
+        username="user_xyz"
+        hasAlts={false}
+        hasTeamBuilderAccess={false}
+      />
+    );
+    expect(screen.getByText("Welcome back, Trainer")).toBeInTheDocument();
+  });
+
+  it("always shows Browse Tournaments button", () => {
+    render(
+      <WelcomeHeader
+        username="ash"
+        hasAlts={false}
+        hasTeamBuilderAccess={false}
+      />
+    );
+    expect(screen.getByText("Browse Tournaments")).toBeInTheDocument();
+  });
+
+  it("shows Team Builder when hasTeamBuilderAccess=true", () => {
+    render(
+      <WelcomeHeader
+        username="ash"
+        hasAlts={false}
+        hasTeamBuilderAccess={true}
+      />
+    );
+    expect(screen.getByText("Team Builder")).toBeInTheDocument();
+  });
+
+  it("hides Team Builder when hasTeamBuilderAccess=false", () => {
+    render(
+      <WelcomeHeader
+        username="ash"
+        hasAlts={false}
+        hasTeamBuilderAccess={false}
+      />
+    );
+    expect(screen.queryByText("Team Builder")).not.toBeInTheDocument();
+  });
+
+  it("shows 'New Alt' when hasAlts=true", () => {
+    render(
+      <WelcomeHeader
+        username="ash"
+        hasAlts={true}
+        hasTeamBuilderAccess={false}
+      />
+    );
+    expect(screen.getByText("New Alt")).toBeInTheDocument();
+  });
+
+  it("shows 'Create Alt' when hasAlts=false", () => {
+    render(
+      <WelcomeHeader
+        username="ash"
+        hasAlts={false}
+        hasTeamBuilderAccess={false}
+      />
+    );
+    expect(screen.getByText("Create Alt")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(dashboard)/dashboard/components/alts-table.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/alts-table.tsx
@@ -288,7 +288,7 @@ export function AltsTable({
         <table className="w-full text-sm">
           <thead>
             <tr>
-              <th className="h-8 w-8" />
+              <th className="h-8 w-8" aria-label="Expand" />
               <th className="text-muted-foreground h-8 w-[200px] px-3 text-left text-xs font-medium tracking-wide uppercase">
                 Handle
               </th>

--- a/apps/web/src/app/(dashboard)/dashboard/components/alts-table.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/alts-table.tsx
@@ -100,6 +100,15 @@ function AltTableRow({
           !isExpanded && "last:border-0"
         )}
       >
+        {/* Chevron */}
+        <td className="w-8 px-2 py-2.5 text-center">
+          {isExpanded ? (
+            <ChevronDown className="text-muted-foreground mx-auto size-3.5" />
+          ) : (
+            <ChevronRight className="text-muted-foreground mx-auto size-3.5" />
+          )}
+        </td>
+
         {/* Handle */}
         <td className="w-[200px] px-3 py-2.5">
           <div className="flex items-center gap-2">
@@ -202,15 +211,6 @@ function AltTableRow({
             layout="cell"
           />
         </td>
-
-        {/* Chevron */}
-        <td className="w-8 px-2 py-2.5 text-center">
-          {isExpanded ? (
-            <ChevronDown className="text-muted-foreground mx-auto size-3.5" />
-          ) : (
-            <ChevronRight className="text-muted-foreground mx-auto size-3.5" />
-          )}
-        </td>
       </tr>
 
       {/* Expanded panel */}
@@ -288,6 +288,7 @@ export function AltsTable({
         <table className="w-full text-sm">
           <thead>
             <tr>
+              <th className="h-8 w-8" />
               <th className="text-muted-foreground h-8 w-[200px] px-3 text-left text-xs font-medium tracking-wide uppercase">
                 Handle
               </th>
@@ -309,7 +310,6 @@ export function AltsTable({
               <th className="text-muted-foreground h-8 px-3 text-center text-xs font-medium tracking-wide uppercase">
                 Public
               </th>
-              <th className="h-8 w-8" />
             </tr>
           </thead>
           <tbody>

--- a/apps/web/src/app/(dashboard)/dashboard/components/community-highlights.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/community-highlights.tsx
@@ -1,0 +1,126 @@
+import Link from "next/link";
+import Image from "next/image";
+import { Users, ChevronRight, Plus, Trophy } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+interface CommunityInfo {
+  id: number;
+  name: string;
+  slug: string;
+  logoUrl: string | null;
+  hasLiveTournament: boolean;
+}
+
+interface CommunityHighlightsProps {
+  communities: CommunityInfo[];
+}
+
+/**
+ * Server-rendered community highlights section.
+ * Shows the user's communities with quick links.
+ */
+export function CommunityHighlights({
+  communities,
+}: CommunityHighlightsProps) {
+  if (communities.length === 0) {
+    return (
+      <div className="rounded-xl bg-card p-4 shadow-sm">
+        <div className="mb-3 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Users className="text-muted-foreground size-4" />
+            <h3 className="text-sm font-semibold">Your Communities</h3>
+          </div>
+        </div>
+        <div className="flex flex-col items-center justify-center py-8">
+          <Users className="text-muted-foreground size-8" />
+          <p className="text-muted-foreground mt-3 text-sm font-medium">
+            Not part of any communities yet
+          </p>
+          <p className="text-muted-foreground mt-1 text-xs">
+            Join a community to participate in tournaments
+          </p>
+          <Button
+            size="sm"
+            variant="outline"
+            className="mt-4"
+            render={<Link href="/communities" />}
+            nativeButton={false}
+          >
+            <Plus className="mr-1.5 size-3.5" />
+            Browse Communities
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl bg-card p-4 shadow-sm">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Users className="text-muted-foreground size-4" />
+          <h3 className="text-sm font-semibold">Your Communities</h3>
+        </div>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-7 text-xs"
+          render={<Link href="/communities" />}
+          nativeButton={false}
+        >
+          Browse
+          <ChevronRight className="ml-0.5 size-3" />
+        </Button>
+      </div>
+
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {communities.map((community) => (
+          <Link
+            key={community.id}
+            href={`/dashboard/community/${community.slug}`}
+            className="group flex items-center gap-3 rounded-lg p-2.5 transition-colors hover:bg-muted/50"
+          >
+            {/* Community logo */}
+            <div className="relative flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-muted">
+              {community.logoUrl ? (
+                <Image
+                  src={community.logoUrl}
+                  alt={community.name}
+                  width={36}
+                  height={36}
+                  className="size-full object-cover"
+                  unoptimized
+                />
+              ) : (
+                <Users className="text-muted-foreground size-4" />
+              )}
+              {/* Live tournament indicator */}
+              {community.hasLiveTournament && (
+                <span className="absolute -top-0.5 -right-0.5 flex size-2.5">
+                  <span className="absolute inline-flex size-full animate-ping rounded-full bg-emerald-500 opacity-75" />
+                  <span className="relative inline-flex size-2.5 rounded-full bg-emerald-500" />
+                </span>
+              )}
+            </div>
+
+            {/* Community name */}
+            <div className="min-w-0 flex-1">
+              <p className="group-hover:text-primary truncate text-sm font-medium transition-colors">
+                {community.name}
+              </p>
+              {community.hasLiveTournament && (
+                <div className="flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
+                  <Trophy className="size-3" />
+                  <span>Live tournament</span>
+                </div>
+              )}
+            </div>
+
+            <ChevronRight className="text-muted-foreground size-3.5 shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/dashboard/components/dashboard-activity.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/dashboard-activity.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 import {
   Trophy,
@@ -57,6 +58,7 @@ function UpcomingTournamentsList({
 }: {
   tournaments: Tournament[];
 }) {
+  const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [checkingInId, setCheckingInId] = useState<number | null>(null);
   const [now] = useState(() => Date.now());
@@ -64,12 +66,12 @@ function UpcomingTournamentsList({
   const formatDate = (timestamp: number | null) => {
     if (!timestamp) return "Date TBD";
     const date = new Date(timestamp);
-    const diffDays = Math.ceil(
-      (date.getTime() - now) / (1000 * 60 * 60 * 24)
-    );
-    if (diffDays < 0) return "In Progress";
-    if (diffDays === 0) return "Today";
-    if (diffDays === 1) return "Tomorrow";
+    const diffMs = date.getTime() - now;
+    if (diffMs < 0) return "In Progress";
+    const hoursUntil = diffMs / (1000 * 60 * 60);
+    if (hoursUntil < 24) return "Today";
+    if (hoursUntil < 48) return "Tomorrow";
+    const diffDays = Math.ceil(hoursUntil / 24);
     if (diffDays <= 7) return `In ${diffDays} days`;
     return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
   };
@@ -130,6 +132,7 @@ function UpcomingTournamentsList({
         const result = await checkIn(tournamentId);
         if (result.success) {
           toast.success("Successfully checked in!");
+          router.refresh();
         } else {
           toast.error(result.error || "Failed to check in");
         }
@@ -295,8 +298,8 @@ function UpcomingTournamentsList({
 // =============================================================================
 
 /** Format a timestamp as a relative age string (e.g. "5m ago", "2d ago") */
-function formatAge(timestamp: number) {
-  const diffMs = Date.now() - timestamp;
+function formatAge(timestamp: number, now: number) {
+  const diffMs = now - timestamp;
   const diffMins = Math.floor(diffMs / 60000);
   const diffHours = Math.floor(diffMs / 3600000);
   const diffDays = Math.floor(diffMs / 86400000);
@@ -316,6 +319,8 @@ function formatAge(timestamp: number) {
 // =============================================================================
 
 function RecentActivityList({ activities }: { activities: Activity[] }) {
+  const [now] = useState(() => Date.now());
+
   if (activities.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-10">
@@ -365,7 +370,7 @@ function RecentActivityList({ activities }: { activities: Activity[] }) {
 
             {/* Time */}
             <span className="text-muted-foreground shrink-0 text-xs">
-              {formatAge(activity.date)}
+              {formatAge(activity.date, now)}
             </span>
           </div>
         );

--- a/apps/web/src/app/(dashboard)/dashboard/components/dashboard-activity.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/dashboard-activity.tsx
@@ -26,6 +26,7 @@ import { checkIn } from "@/actions/tournaments";
 interface Tournament {
   id: number;
   name: string;
+  slug: string;
   startDate: number | null;
   status: string;
   hasTeam: boolean;
@@ -200,12 +201,12 @@ function UpcomingTournamentsList({
                 statusInfo.bgColor
               )}
             >
-              <Trophy className={cn("size-4", statusInfo.color)} />
+              <StatusIcon className={cn("size-4", statusInfo.color)} />
             </div>
 
             {/* Content */}
             <Link
-              href={`/tournaments/${tournament.id}`}
+              href={`/tournaments/${tournament.slug}`}
               className="min-w-0 flex-1"
             >
               <p className="group-hover:text-primary truncate text-sm font-medium transition-colors">
@@ -235,7 +236,7 @@ function UpcomingTournamentsList({
                   size="sm"
                   variant="outline"
                   className="h-7 text-xs"
-                  render={<Link href={`/tournaments/${tournament.id}`} />}
+                  render={<Link href={`/tournaments/${tournament.slug}`} />}
                   nativeButton={false}
                 >
                   <Upload className="mr-1 size-3" />
@@ -261,7 +262,7 @@ function UpcomingTournamentsList({
                   size="sm"
                   variant="ghost"
                   className="h-7 text-xs"
-                  render={<Link href={`/tournaments/${tournament.id}`} />}
+                  render={<Link href={`/tournaments/${tournament.slug}`} />}
                   nativeButton={false}
                 >
                   View

--- a/apps/web/src/app/(dashboard)/dashboard/components/dashboard-activity.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/dashboard-activity.tsx
@@ -1,0 +1,429 @@
+"use client";
+
+import Link from "next/link";
+import { useState, useTransition } from "react";
+import {
+  Trophy,
+  Clock,
+  ChevronRight,
+  Calendar,
+  CheckCircle2,
+  AlertCircle,
+  Upload,
+  Swords,
+  Plus,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { checkIn } from "@/actions/tournaments";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface Tournament {
+  id: number;
+  name: string;
+  startDate: number | null;
+  status: string;
+  hasTeam: boolean;
+  registrationStatus: string | null;
+  registrationId: number | null;
+  lateCheckInMaxRound: number | null;
+}
+
+interface Activity {
+  id: number;
+  tournamentName: string;
+  opponentName: string;
+  result: string;
+  date: number;
+}
+
+interface DashboardActivityProps {
+  myTournaments: Tournament[];
+  recentActivity: Activity[];
+}
+
+// =============================================================================
+// Upcoming Tournaments
+// =============================================================================
+
+function UpcomingTournamentsList({
+  tournaments,
+}: {
+  tournaments: Tournament[];
+}) {
+  const [isPending, startTransition] = useTransition();
+  const [checkingInId, setCheckingInId] = useState<number | null>(null);
+  const [now] = useState(() => Date.now());
+
+  const formatDate = (timestamp: number | null) => {
+    if (!timestamp) return "Date TBD";
+    const date = new Date(timestamp);
+    const diffDays = Math.ceil(
+      (date.getTime() - now) / (1000 * 60 * 60 * 24)
+    );
+    if (diffDays < 0) return "In Progress";
+    if (diffDays === 0) return "Today";
+    if (diffDays === 1) return "Tomorrow";
+    if (diffDays <= 7) return `In ${diffDays} days`;
+    return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  };
+
+  const getStatusInfo = (tournament: Tournament) => {
+    const startDate = tournament.startDate ?? null;
+    const hoursUntilStart = startDate
+      ? (startDate - now) / (1000 * 60 * 60)
+      : null;
+    const isUrgent =
+      hoursUntilStart !== null && hoursUntilStart > 0 && hoursUntilStart < 24;
+    const isCheckedIn = tournament.registrationStatus === "checked_in";
+    const isActive = tournament.status === "active";
+
+    if (!tournament.hasTeam) {
+      return {
+        icon: AlertCircle,
+        label: "Team Required",
+        color: "text-amber-600 dark:text-amber-400",
+        bgColor: "bg-amber-500/10",
+        isUrgent,
+      };
+    }
+
+    if (isActive && !isCheckedIn) {
+      return {
+        icon: AlertCircle,
+        label: "Check in now!",
+        color: "text-red-600 dark:text-red-400",
+        bgColor: "bg-red-500/10",
+        isUrgent: true,
+      };
+    }
+
+    if (tournament.hasTeam && !isCheckedIn) {
+      return {
+        icon: Clock,
+        label: "Ready for Check-in",
+        color: "text-blue-600 dark:text-blue-400",
+        bgColor: "bg-blue-500/10",
+        isUrgent: false,
+      };
+    }
+
+    return {
+      icon: CheckCircle2,
+      label: "Checked In",
+      color: "text-emerald-600 dark:text-emerald-400",
+      bgColor: "bg-emerald-500/10",
+      isUrgent: false,
+    };
+  };
+
+  const handleCheckIn = (tournamentId: number) => {
+    setCheckingInId(tournamentId);
+    startTransition(async () => {
+      try {
+        const result = await checkIn(tournamentId);
+        if (result.success) {
+          toast.success("Successfully checked in!");
+        } else {
+          toast.error(result.error || "Failed to check in");
+        }
+      } catch {
+        toast.error("Failed to check in");
+      } finally {
+        setCheckingInId(null);
+      }
+    });
+  };
+
+  // Sort: urgent first, then by start date
+  const sorted = [...tournaments].sort((a, b) => {
+    const aStatus = getStatusInfo(a);
+    const bStatus = getStatusInfo(b);
+    if (aStatus.isUrgent && !bStatus.isUrgent) return -1;
+    if (!aStatus.isUrgent && bStatus.isUrgent) return 1;
+    return (a.startDate ?? Infinity) - (b.startDate ?? Infinity);
+  });
+
+  if (tournaments.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-10">
+        <Trophy className="text-muted-foreground size-8" />
+        <p className="text-muted-foreground mt-3 text-sm font-medium">
+          No upcoming tournaments
+        </p>
+        <p className="text-muted-foreground mt-1 text-xs">
+          Browse available tournaments to join
+        </p>
+        <Button
+          size="sm"
+          variant="outline"
+          className="mt-4"
+          render={<Link href="/tournaments" />}
+          nativeButton={false}
+        >
+          <Plus className="mr-1.5 size-3.5" />
+          Find Tournaments
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {sorted.slice(0, 4).map((tournament) => {
+        const statusInfo = getStatusInfo(tournament);
+        const StatusIcon = statusInfo.icon;
+        const canCheckIn =
+          tournament.hasTeam &&
+          tournament.registrationStatus !== "checked_in";
+        const isCheckedIn = tournament.registrationStatus === "checked_in";
+
+        return (
+          <div
+            key={tournament.id}
+            className={cn(
+              "group flex items-center gap-3 rounded-lg p-3 transition-colors",
+              statusInfo.isUrgent
+                ? "bg-amber-500/5 hover:bg-amber-500/10"
+                : "hover:bg-muted/50"
+            )}
+          >
+            {/* Status icon */}
+            <div
+              className={cn(
+                "flex size-9 shrink-0 items-center justify-center rounded-lg",
+                statusInfo.bgColor
+              )}
+            >
+              <Trophy className={cn("size-4", statusInfo.color)} />
+            </div>
+
+            {/* Content */}
+            <Link
+              href={`/tournaments/${tournament.id}`}
+              className="min-w-0 flex-1"
+            >
+              <p className="group-hover:text-primary truncate text-sm font-medium transition-colors">
+                {tournament.name}
+              </p>
+              <div className="mt-0.5 flex items-center gap-2">
+                <div className="text-muted-foreground flex items-center gap-1 text-xs">
+                  <Calendar className="size-3" />
+                  <span>{formatDate(tournament.startDate)}</span>
+                </div>
+                <div
+                  className={cn(
+                    "flex items-center gap-1 text-xs font-medium",
+                    statusInfo.color
+                  )}
+                >
+                  <StatusIcon className="size-3" />
+                  <span>{statusInfo.label}</span>
+                </div>
+              </div>
+            </Link>
+
+            {/* Actions */}
+            <div className="shrink-0">
+              {!tournament.hasTeam && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-7 text-xs"
+                  render={<Link href={`/tournaments/${tournament.id}`} />}
+                  nativeButton={false}
+                >
+                  <Upload className="mr-1 size-3" />
+                  Submit Team
+                </Button>
+              )}
+              {canCheckIn && (
+                <Button
+                  size="sm"
+                  variant={statusInfo.isUrgent ? "default" : "outline"}
+                  className="h-7 text-xs"
+                  onClick={() => handleCheckIn(tournament.id)}
+                  disabled={isPending && checkingInId === tournament.id}
+                >
+                  <CheckCircle2 className="mr-1 size-3" />
+                  {isPending && checkingInId === tournament.id
+                    ? "..."
+                    : "Check In"}
+                </Button>
+              )}
+              {isCheckedIn && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 text-xs"
+                  render={<Link href={`/tournaments/${tournament.id}`} />}
+                  nativeButton={false}
+                >
+                  View
+                  <ChevronRight className="ml-0.5 size-3" />
+                </Button>
+              )}
+            </div>
+          </div>
+        );
+      })}
+
+      {tournaments.length > 4 && (
+        <Button
+          size="sm"
+          variant="ghost"
+          className="w-full text-xs"
+          render={<Link href="/dashboard/tournaments" />}
+          nativeButton={false}
+        >
+          View all {tournaments.length} tournaments
+          <ChevronRight className="ml-1 size-3" />
+        </Button>
+      )}
+    </div>
+  );
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Format a timestamp as a relative age string (e.g. "5m ago", "2d ago") */
+function formatAge(timestamp: number) {
+  const diffMs = Date.now() - timestamp;
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+
+  return new Date(timestamp).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+// =============================================================================
+// Recent Activity List
+// =============================================================================
+
+function RecentActivityList({ activities }: { activities: Activity[] }) {
+  if (activities.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-10">
+        <Swords className="text-muted-foreground size-8" />
+        <p className="text-muted-foreground mt-3 text-sm font-medium">
+          No recent battles
+        </p>
+        <p className="text-muted-foreground mt-1 text-xs">
+          Play in a tournament to see your results here
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      {activities.map((activity) => {
+        const isWin = activity.result === "won";
+
+        return (
+          <div
+            key={activity.id}
+            className="flex items-center gap-3 rounded-lg p-2.5"
+          >
+            {/* Win/Loss indicator */}
+            <div
+              className={cn(
+                "flex size-7 shrink-0 items-center justify-center rounded-md font-mono text-xs font-bold",
+                isWin
+                  ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+                  : "bg-red-500/10 text-red-600 dark:text-red-400"
+              )}
+            >
+              {isWin ? "W" : "L"}
+            </div>
+
+            {/* Match info */}
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium">
+                {activity.tournamentName}
+              </p>
+              <p className="text-muted-foreground text-xs">
+                vs{" "}
+                <span className="font-medium">{activity.opponentName}</span>
+              </p>
+            </div>
+
+            {/* Time */}
+            <span className="text-muted-foreground shrink-0 text-xs">
+              {formatAge(activity.date)}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// =============================================================================
+// Main Component
+// =============================================================================
+
+export function DashboardActivity({
+  myTournaments,
+  recentActivity,
+}: DashboardActivityProps) {
+  return (
+    <div className="grid gap-6 lg:grid-cols-2">
+      {/* Upcoming Tournaments */}
+      <div className="rounded-xl bg-card p-4 shadow-sm">
+        <div className="mb-3 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Trophy className="text-primary size-4" />
+            <h3 className="text-sm font-semibold">Upcoming Tournaments</h3>
+          </div>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 text-xs"
+            render={<Link href="/tournaments" />}
+            nativeButton={false}
+          >
+            Browse
+            <ChevronRight className="ml-0.5 size-3" />
+          </Button>
+        </div>
+        <UpcomingTournamentsList tournaments={myTournaments} />
+      </div>
+
+      {/* Recent Activity */}
+      <div className="rounded-xl bg-card p-4 shadow-sm">
+        <div className="mb-3 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Clock className="text-muted-foreground size-4" />
+            <h3 className="text-sm font-semibold">Recent Activity</h3>
+          </div>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 text-xs"
+            render={<Link href="/dashboard/tournaments" />}
+            nativeButton={false}
+          >
+            History
+            <ChevronRight className="ml-0.5 size-3" />
+          </Button>
+        </div>
+        <RecentActivityList activities={recentActivity} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/dashboard/components/enhanced-stats.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/enhanced-stats.tsx
@@ -1,0 +1,152 @@
+import { cn } from "@/lib/utils";
+import { Zap, Target, Trophy, Award } from "lucide-react";
+
+interface EnhancedStatsProps {
+  winRate: string;
+  winRateSub: string;
+  rating: string;
+  ratingSub: string;
+  record: string;
+  recordSub: string;
+  tournaments: string;
+  tournamentsSub: string;
+  tournamentsSubAccent?: boolean;
+}
+
+/**
+ * Enhanced stat cards with icons and contextual coloring.
+ * Server component — no client-side interactivity needed.
+ */
+export function EnhancedStats({
+  winRate,
+  winRateSub,
+  rating,
+  ratingSub,
+  record,
+  recordSub,
+  tournaments,
+  tournamentsSub,
+  tournamentsSubAccent = false,
+}: EnhancedStatsProps) {
+  // Parse win rate for 4-tier conditional coloring
+  const winRateNum = parseFloat(winRate);
+  const hasGames = !isNaN(winRateNum) && winRate !== "0.0%";
+  // Green >= 60%, teal 50-60%, neutral 40-50%, red < 40%
+  const winRateTier = !hasGames
+    ? "neutral"
+    : winRateNum >= 60
+      ? "high"
+      : winRateNum >= 50
+        ? "good"
+        : winRateNum >= 40
+          ? "neutral"
+          : "low";
+
+  // Parse rating
+  const hasRating = rating !== "—" && rating !== "0";
+
+  return (
+    <div className="grid grid-cols-2 gap-3 rounded-2xl bg-muted/30 p-3 lg:grid-cols-4">
+      {/* Win Rate */}
+      <div className="rounded-xl bg-card p-4 shadow-sm">
+        <div className="flex items-center gap-2">
+          <div
+            className={cn(
+              "flex size-7 items-center justify-center rounded-lg",
+              winRateTier === "high" && "bg-emerald-500/10",
+              winRateTier === "good" && "bg-teal-500/10",
+              winRateTier === "low" && "bg-red-500/10",
+              (winRateTier === "neutral") && "bg-primary/10"
+            )}
+          >
+            <Zap
+              className={cn(
+                "size-3.5",
+                winRateTier === "high" && "text-emerald-600 dark:text-emerald-400",
+                winRateTier === "good" && "text-teal-600 dark:text-teal-400",
+                winRateTier === "low" && "text-red-600 dark:text-red-400",
+                (winRateTier === "neutral") && "text-primary"
+              )}
+            />
+          </div>
+          <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+            Win Rate
+          </p>
+        </div>
+        <p
+          className={cn(
+            "mt-2.5 font-mono text-2xl font-bold leading-none tabular-nums",
+            winRateTier === "high" && "text-emerald-600 dark:text-emerald-400",
+            winRateTier === "good" && "text-teal-600 dark:text-teal-400",
+            winRateTier === "low" && "text-red-600 dark:text-red-400"
+          )}
+        >
+          {winRate}
+        </p>
+        <p className="text-muted-foreground mt-1.5 text-[11px]">{winRateSub}</p>
+      </div>
+
+      {/* Rating */}
+      <div className="rounded-xl bg-card p-4 shadow-sm">
+        <div className="flex items-center gap-2">
+          <div className="flex size-7 items-center justify-center rounded-lg bg-blue-500/10">
+            <Target className="size-3.5 text-blue-500" />
+          </div>
+          <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+            Rating
+          </p>
+        </div>
+        <p
+          className={cn(
+            "mt-2.5 font-mono text-2xl font-bold leading-none tabular-nums",
+            !hasRating && "text-muted-foreground/50"
+          )}
+        >
+          {rating}
+        </p>
+        <p className="text-muted-foreground mt-1.5 text-[11px]">{ratingSub}</p>
+      </div>
+
+      {/* Record */}
+      <div className="rounded-xl bg-card p-4 shadow-sm">
+        <div className="flex items-center gap-2">
+          <div className="flex size-7 items-center justify-center rounded-lg bg-purple-500/10">
+            <Trophy className="size-3.5 text-purple-500" />
+          </div>
+          <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+            Record
+          </p>
+        </div>
+        <p className="mt-2.5 font-mono text-2xl font-bold leading-none tabular-nums">
+          {record}
+        </p>
+        <p className="text-muted-foreground mt-1.5 text-[11px]">{recordSub}</p>
+      </div>
+
+      {/* Tournaments */}
+      <div className="rounded-xl bg-card p-4 shadow-sm">
+        <div className="flex items-center gap-2">
+          <div className="flex size-7 items-center justify-center rounded-lg bg-amber-500/10">
+            <Award className="size-3.5 text-amber-500" />
+          </div>
+          <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+            Tournaments
+          </p>
+        </div>
+        <p className="mt-2.5 font-mono text-2xl font-bold leading-none tabular-nums">
+          {tournaments}
+        </p>
+        <p
+          className={cn(
+            "mt-1.5 text-[11px]",
+            tournamentsSubAccent
+              ? "text-emerald-600 dark:text-emerald-400"
+              : "text-muted-foreground"
+          )}
+        >
+          {tournamentsSub}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/dashboard/components/teams-sub-table.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/teams-sub-table.tsx
@@ -44,11 +44,11 @@ function TeamCard({
 }) {
   return (
     <Link
-      href={`/dashboard/alts/${altUsername}`}
+      href={`/dashboard/alts/${altUsername}/teams/${team.id}`}
       className="group flex items-center gap-3 rounded-lg bg-background/60 px-3 py-2 transition-colors hover:bg-background"
     >
       {/* Team name */}
-      <span className="min-w-0 shrink-0 truncate text-xs font-medium">
+      <span className="min-w-0 flex-1 truncate text-xs font-medium">
         {team.name}
       </span>
 

--- a/apps/web/src/app/(dashboard)/dashboard/components/teams-sub-table.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/teams-sub-table.tsx
@@ -14,22 +14,11 @@ import {
 import { getPokemonSprite } from "@trainers/pokemon/sprites";
 import { getTeamsForAlt, getPlayerTournamentHistory } from "@trainers/supabase";
 import type { TypedSupabaseClient } from "@trainers/supabase";
+import { formatShortDate } from "@trainers/utils";
 
 import { Button } from "@/components/ui/button";
 import { useSupabaseQuery } from "@/lib/supabase";
 import { cn } from "@/lib/utils";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Format a date as "Mar 28" */
-function formatShortDate(dateStr: string) {
-  return new Date(dateStr).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-  });
-}
 
 // ---------------------------------------------------------------------------
 // Team Card (replaces nested table row)
@@ -278,7 +267,7 @@ export function TeamsSubTable({
       </div>
 
       {/* Footer — softened buttons */}
-      <div className="flex items-center justify-between border-t px-3 py-2.5">
+      <div className="flex items-center justify-between bg-muted/50 px-3 py-2.5">
         <div className="flex gap-2">
           <Button
             nativeButton={false}

--- a/apps/web/src/app/(dashboard)/dashboard/components/teams-sub-table.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/teams-sub-table.tsx
@@ -2,66 +2,80 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { Loader2, Hammer, ArrowUpRight, Copy } from "lucide-react";
+import {
+  Loader2,
+  ExternalLink,
+  Trophy,
+  Swords,
+  ChevronRight,
+  History,
+} from "lucide-react";
 
 import { getPokemonSprite } from "@trainers/pokemon/sprites";
 import { getTeamsForAlt, getPlayerTournamentHistory } from "@trainers/supabase";
 import type { TypedSupabaseClient } from "@trainers/supabase";
 
 import { Button } from "@/components/ui/button";
-import {
-  Tooltip,
-  TooltipTrigger,
-  TooltipContent,
-} from "@/components/ui/tooltip";
 import { useSupabaseQuery } from "@/lib/supabase";
 import { cn } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
-// TeamActions
+// Helpers
 // ---------------------------------------------------------------------------
 
-function TeamActions({ altUsername }: { altUsername: string }) {
+/** Format a date as "Mar 28" */
+function formatShortDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Team Card (replaces nested table row)
+// ---------------------------------------------------------------------------
+
+function TeamCard({
+  team,
+  altUsername,
+}: {
+  team: { id: number; name: string; pokemonSpecies: string[] };
+  altUsername: string;
+}) {
   return (
-    <div className="flex justify-end gap-1">
-      {/* TODO: replace with team builder link when builder feature ships */}
-      <Tooltip>
-        <TooltipTrigger render={<span />}>
-          <Link
-            href={`/dashboard/alts/${altUsername}`}
-            className="bg-muted hover:bg-muted/80 inline-flex size-6 items-center justify-center rounded transition-colors"
-            aria-label="Open alt details"
-          >
-            <Hammer className="text-muted-foreground size-3" />
-          </Link>
-        </TooltipTrigger>
-        <TooltipContent>Open alt details</TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger render={<span />}>
-          <button
-            className="bg-muted hover:bg-muted/80 inline-flex size-6 cursor-not-allowed items-center justify-center rounded transition-colors"
-            aria-label="Share (coming soon)"
-            disabled
-          >
-            <ArrowUpRight className="text-muted-foreground size-3" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent>Share (coming soon)</TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger render={<span />}>
-          <button
-            className="bg-muted hover:bg-muted/80 inline-flex size-6 cursor-not-allowed items-center justify-center rounded transition-colors"
-            aria-label="Clone (coming soon)"
-            disabled
-          >
-            <Copy className="text-muted-foreground size-3" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent>Clone (coming soon)</TooltipContent>
-      </Tooltip>
-    </div>
+    <Link
+      href={`/dashboard/alts/${altUsername}`}
+      className="group flex items-center gap-3 rounded-lg bg-background/60 px-3 py-2 transition-colors hover:bg-background"
+    >
+      {/* Team name */}
+      <span className="min-w-0 shrink-0 truncate text-xs font-medium">
+        {team.name}
+      </span>
+
+      {/* Pokemon sprites — pushed right */}
+      <div className="ml-auto flex shrink-0 items-center">
+        {team.pokemonSpecies.map((species, i) => {
+          const sprite = getPokemonSprite(species);
+          return (
+            <Image
+              key={i}
+              src={sprite.url}
+              alt={species}
+              width={36}
+              height={36}
+              className="object-contain"
+              style={
+                sprite.pixelated ? { imageRendering: "pixelated" } : undefined
+              }
+              unoptimized
+            />
+          );
+        })}
+      </div>
+
+      {/* Arrow */}
+      <ChevronRight className="text-muted-foreground size-3.5 shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
+    </Link>
   );
 }
 
@@ -105,45 +119,57 @@ function RecentResults({
 
   if (recentResults.length === 0) {
     return (
-      <p className="text-muted-foreground py-6 text-center text-xs">
-        No results yet
-      </p>
+      <div className="flex flex-col items-center justify-center py-6">
+        <Swords className="text-muted-foreground size-5" />
+        <p className="text-muted-foreground mt-2 text-xs">No results yet</p>
+      </div>
     );
   }
 
   return (
-    <div className="space-y-0">
+    <div className="space-y-1">
       {recentResults.map((item) => {
         const isFirst = item.placement === 1;
         const placementText =
-          item.placement != null
-            ? `#${item.placement}${isFirst ? " 🏆" : ""}`
-            : "—";
+          item.placement != null ? `#${item.placement}` : "—";
 
-        // Format date as "Mar 28"
-        const dateText = item.startDate
-          ? new Date(item.startDate).toLocaleDateString("en-US", {
-              month: "short",
-              day: "numeric",
-            })
-          : "";
+        const dateText = item.startDate ? formatShortDate(item.startDate) : "";
 
         return (
-          <div
+          <Link
             key={item.id}
-            className="border-border/50 flex items-center gap-2 border-b py-1.5 text-xs last:border-0"
+            href={`/tournaments/${item.tournamentSlug}`}
+            className="group flex items-center gap-2.5 rounded-lg bg-background/60 px-3 py-2 transition-colors hover:bg-background"
           >
-            {/* Tournament name */}
-            <Link
-              href={`/tournaments/${item.tournamentSlug}`}
-              className="min-w-0 shrink-0 font-medium hover:underline"
+            {/* Placement badge */}
+            <span
+              className={cn(
+                "flex size-7 shrink-0 items-center justify-center rounded-md text-[11px] font-bold",
+                isFirst
+                  ? "bg-amber-500/10 text-amber-600 dark:text-amber-400"
+                  : "bg-muted text-muted-foreground"
+              )}
             >
-              {item.tournamentName}
-            </Link>
+              {isFirst ? (
+                <Trophy className="size-3.5" />
+              ) : (
+                placementText
+              )}
+            </span>
+
+            {/* Tournament name + date */}
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-xs font-medium group-hover:underline">
+                {item.tournamentName}
+              </p>
+              {dateText && (
+                <p className="text-muted-foreground text-[11px]">{dateText}</p>
+              )}
+            </div>
 
             {/* Pokemon sprites */}
             {item.teamPokemon.length > 0 && (
-              <div className="ml-auto flex shrink-0 items-center">
+              <div className="hidden shrink-0 items-center sm:flex">
                 {item.teamPokemon.slice(0, 6).map((species, i) => {
                   const sprite = getPokemonSprite(species);
                   return (
@@ -165,26 +191,7 @@ function RecentResults({
                 })}
               </div>
             )}
-
-            {/* Placement */}
-            <span
-              className={cn(
-                "shrink-0 font-mono text-[11px]",
-                isFirst
-                  ? "font-semibold text-teal-600"
-                  : "text-muted-foreground"
-              )}
-            >
-              {placementText}
-            </span>
-
-            {/* Date */}
-            {dateText && (
-              <span className="text-muted-foreground shrink-0 text-[10px]">
-                {dateText}
-              </span>
-            )}
-          </div>
+          </Link>
         );
       })}
     </div>
@@ -205,7 +212,7 @@ interface TeamsSubTableProps {
 }
 
 // ---------------------------------------------------------------------------
-// TeamsSubTable
+// TeamsSubTable (redesigned expanded panel)
 // ---------------------------------------------------------------------------
 
 export function TeamsSubTable({
@@ -227,131 +234,83 @@ export function TeamsSubTable({
   return (
     <div className="rounded-lg">
       {/* Two-column layout: Teams + Recent Results */}
-      <div className="grid grid-cols-1 gap-6 p-3 sm:grid-cols-2">
+      <div className="grid grid-cols-1 gap-4 p-3 sm:grid-cols-2">
         {/* Left: Teams */}
         <div>
-          <p className="text-muted-foreground mb-2 text-xs font-medium tracking-wide uppercase">
+          <p className="text-muted-foreground mb-2 text-[11px] font-medium tracking-wide uppercase">
             Teams
           </p>
-          <div className="overflow-x-auto">
-            <table className="w-full text-xs">
-              <thead>
-                <tr className="border-b">
-                  <th className="text-muted-foreground px-2 py-1 text-left text-[10px] font-medium tracking-wider uppercase">
-                    Team
-                  </th>
-                  <th className="text-muted-foreground px-2 py-1 text-left text-[10px] font-medium tracking-wider uppercase">
-                    Pokemon
-                  </th>
-                  <th className="w-24 px-2 py-1" />
-                </tr>
-              </thead>
-              <tbody>
-                {teamsError ? (
-                  <tr>
-                    <td
-                      colSpan={3}
-                      className="text-destructive px-2 py-4 text-center text-xs"
-                    >
-                      Failed to load teams
-                    </td>
-                  </tr>
-                ) : isLoading ? (
-                  <tr>
-                    <td colSpan={3} className="px-2 py-4 text-center">
-                      <Loader2 className="text-muted-foreground mx-auto size-4 animate-spin" />
-                    </td>
-                  </tr>
-                ) : !teams || teams.length === 0 ? (
-                  <tr>
-                    <td
-                      colSpan={3}
-                      className="text-muted-foreground px-2 py-6 text-center text-xs"
-                    >
-                      No teams yet
-                    </td>
-                  </tr>
-                ) : (
-                  teams.map((team) => (
-                    <tr
-                      key={team.id}
-                      className="hover:bg-muted/30 border-b transition-colors last:border-0"
-                    >
-                      <td className="px-2 py-1.5 font-medium">{team.name}</td>
-                      <td className="px-2 py-1">
-                        <div className="flex">
-                          {team.pokemonSpecies.map((species, i) => {
-                            const sprite = getPokemonSprite(species);
-                            return (
-                              <Image
-                                key={i}
-                                src={sprite.url}
-                                alt={species}
-                                width={28}
-                                height={28}
-                                className="object-contain"
-                                style={
-                                  sprite.pixelated
-                                    ? { imageRendering: "pixelated" }
-                                    : undefined
-                                }
-                                unoptimized
-                              />
-                            );
-                          })}
-                        </div>
-                      </td>
-                      <td className="px-2 py-1.5">
-                        <TeamActions altUsername={altUsername} />
-                      </td>
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
+          {teamsError ? (
+            <p className="text-destructive py-4 text-center text-xs">
+              Failed to load teams
+            </p>
+          ) : isLoading ? (
+            <div className="flex items-center justify-center py-4">
+              <Loader2 className="text-muted-foreground size-4 animate-spin" />
+            </div>
+          ) : !teams || teams.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-6">
+              <Swords className="text-muted-foreground size-5" />
+              <p className="text-muted-foreground mt-2 text-xs">
+                No teams yet
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-1">
+              {teams.map((team) => (
+                <TeamCard
+                  key={team.id}
+                  team={team}
+                  altUsername={altUsername}
+                />
+              ))}
+            </div>
+          )}
         </div>
 
         {/* Right: Recent Results */}
         <div>
-          <p className="text-muted-foreground mb-2 text-xs font-medium tracking-wide uppercase">
+          <p className="text-muted-foreground mb-2 text-[11px] font-medium tracking-wide uppercase">
             Recent Results
           </p>
           <RecentResults altId={altId} refreshKey={refreshKey} />
         </div>
       </div>
 
-      {/* Footer */}
-      <div className="flex items-center justify-between border-t px-3 py-2">
-        <div className="flex gap-1.5">
-          <Button
-            nativeButton={false}
-            size="sm"
-            className="h-7 text-xs"
-            render={<Link href={`/dashboard/alts/${altUsername}`} />}
-          >
-            View as this alt
-          </Button>
+      {/* Footer — softened buttons */}
+      <div className="flex items-center justify-between border-t px-3 py-2.5">
+        <div className="flex gap-2">
           <Button
             nativeButton={false}
             variant="outline"
             size="sm"
-            className="h-7 text-xs"
+            className="h-7 gap-1.5 text-xs"
+            render={<Link href={`/dashboard/alts/${altUsername}`} />}
+          >
+            <ExternalLink className="size-3" />
+            View alt
+          </Button>
+          <Button
+            nativeButton={false}
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1.5 text-xs"
             render={
               <Link href={`/dashboard/alts/${altUsername}/tournaments`} />
             }
           >
-            View history
+            <History className="size-3" />
+            History
           </Button>
         </div>
         {/* TODO: Replace deleteAltAction with archiveAltAction when archive system is built */}
         {!isMain && (
           <button
-            className="text-muted-foreground cursor-pointer text-xs hover:underline disabled:cursor-not-allowed disabled:opacity-50"
+            className="text-muted-foreground cursor-pointer text-[11px] hover:text-destructive hover:underline disabled:cursor-not-allowed disabled:opacity-50"
             onClick={onDeleteAlt}
             disabled={isDeletePending}
           >
-            Delete alt
+            Delete
           </button>
         )}
       </div>

--- a/apps/web/src/app/(dashboard)/dashboard/components/welcome-header.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/welcome-header.tsx
@@ -1,0 +1,81 @@
+import Link from "next/link";
+import { UserPlus, Plus, Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface WelcomeHeaderProps {
+  username: string;
+  hasAlts: boolean;
+  hasTeamBuilderAccess: boolean;
+}
+
+/**
+ * Server-rendered welcome header for the dashboard home.
+ * Shows a personalized greeting and contextual quick action buttons.
+ */
+export function WelcomeHeader({
+  username,
+  hasAlts,
+  hasTeamBuilderAccess,
+}: WelcomeHeaderProps) {
+  // Determine display name — strip temp/user prefixes
+  const isTemp = username.startsWith("temp_") || username.startsWith("user_");
+  const displayName = isTemp ? "Trainer" : username;
+
+  return (
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+          Welcome back, {displayName}
+        </h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Here&apos;s what&apos;s happening on trainers.gg
+        </p>
+      </div>
+
+      {/* Quick action buttons */}
+      <div className="flex flex-wrap gap-2">
+        <Button
+          size="sm"
+          variant="outline"
+          render={<Link href="/tournaments" />}
+          nativeButton={false}
+        >
+          <Search className="mr-1.5 size-3.5" />
+          Browse Tournaments
+        </Button>
+        {hasTeamBuilderAccess && (
+          <Button
+            size="sm"
+            variant="outline"
+            render={<Link href="/dashboard/builder" />}
+            nativeButton={false}
+          >
+            <Plus className="mr-1.5 size-3.5" />
+            Team Builder
+          </Button>
+        )}
+        {hasAlts && (
+          <Button
+            size="sm"
+            variant="outline"
+            render={<Link href="/dashboard/alts" />}
+            nativeButton={false}
+          >
+            <UserPlus className="mr-1.5 size-3.5" />
+            New Alt
+          </Button>
+        )}
+        {!hasAlts && (
+          <Button
+            size="sm"
+            render={<Link href="/dashboard/alts" />}
+            nativeButton={false}
+          >
+            <UserPlus className="mr-1.5 size-3.5" />
+            Create Alt
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/dashboard/components/welcome-header.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/components/welcome-header.tsx
@@ -54,27 +54,15 @@ export function WelcomeHeader({
             Team Builder
           </Button>
         )}
-        {hasAlts && (
-          <Button
-            size="sm"
-            variant="outline"
-            render={<Link href="/dashboard/alts" />}
-            nativeButton={false}
-          >
-            <UserPlus className="mr-1.5 size-3.5" />
-            New Alt
-          </Button>
-        )}
-        {!hasAlts && (
-          <Button
-            size="sm"
-            render={<Link href="/dashboard/alts" />}
-            nativeButton={false}
-          >
-            <UserPlus className="mr-1.5 size-3.5" />
-            Create Alt
-          </Button>
-        )}
+        <Button
+          size="sm"
+          variant={hasAlts ? "outline" : undefined}
+          render={<Link href="/dashboard/alts" />}
+          nativeButton={false}
+        >
+          <UserPlus className="mr-1.5 size-3.5" />
+          {hasAlts ? "New Alt" : "Create Alt"}
+        </Button>
       </div>
     </div>
   );

--- a/apps/web/src/app/(dashboard)/dashboard/home-loading.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/home-loading.tsx
@@ -1,48 +1,90 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
+import { PageHeader } from "@/components/dashboard/page-header";
 
 export default function HomeLoading() {
   return (
-    <div className="space-y-4">
-      {/* Stats row skeleton */}
-      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="bg-muted/50 rounded-md px-2.5 py-2">
-            <Skeleton className="mb-1 h-2.5 w-14" />
-            <Skeleton className="mb-1 h-5 w-16" />
-            <Skeleton className="h-2 w-20" />
-          </div>
-        ))}
-      </div>
-
-      {/* Alts section header skeleton */}
-      <div className="flex items-center justify-between">
-        <Skeleton className="h-4 w-16" />
-        <Skeleton className="h-8 w-20 rounded-md" />
-      </div>
-
-      {/* Alts table skeleton */}
-      <div className="overflow-hidden rounded-lg border">
-        {/* Header */}
-        <div className="bg-muted/30 border-b px-3 py-2.5">
-          <Skeleton className="h-3 w-full" />
-        </div>
-        {/* Rows */}
-        {Array.from({ length: 3 }).map((_, i) => (
-          <div
-            key={i}
-            className="flex items-center gap-3 border-b px-3 py-3 last:border-0"
-          >
-            <Skeleton className="size-7 rounded-full" />
-            <Skeleton className="h-4 w-24" />
-            <div className="ml-auto flex gap-6">
-              <Skeleton className="h-3.5 w-8" />
-              <Skeleton className="h-3.5 w-8" />
-              <Skeleton className="h-3.5 w-8" />
-              <Skeleton className="h-3.5 w-8" />
+    <>
+      <PageHeader title="Dashboard" />
+      <DashboardContent>
+        <div className="space-y-6">
+          {/* Welcome header skeleton */}
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <Skeleton className="h-8 w-64" />
+              <Skeleton className="mt-2 h-4 w-48" />
+            </div>
+            <div className="flex gap-2">
+              <Skeleton className="h-8 w-36 rounded-md" />
+              <Skeleton className="h-8 w-28 rounded-md" />
             </div>
           </div>
-        ))}
-      </div>
-    </div>
+
+          {/* Stats row skeleton */}
+          <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="rounded-xl bg-card p-4 shadow-sm">
+                <div className="flex items-center gap-2">
+                  <Skeleton className="size-7 rounded-lg" />
+                  <Skeleton className="h-3 w-16" />
+                </div>
+                <Skeleton className="mt-3 h-7 w-20" />
+                <Skeleton className="mt-2 h-3 w-24" />
+              </div>
+            ))}
+          </div>
+
+          {/* Two-column skeleton */}
+          <div className="grid gap-6 lg:grid-cols-2">
+            {Array.from({ length: 2 }).map((_, i) => (
+              <div key={i} className="rounded-xl bg-card p-4 shadow-sm">
+                <div className="mb-3 flex items-center gap-2">
+                  <Skeleton className="size-4 rounded" />
+                  <Skeleton className="h-4 w-32" />
+                </div>
+                <div className="space-y-3">
+                  {Array.from({ length: 3 }).map((_, j) => (
+                    <div key={j} className="flex items-center gap-3 rounded-lg p-2.5">
+                      <Skeleton className="size-9 rounded-lg" />
+                      <div className="flex-1 space-y-1.5">
+                        <Skeleton className="h-4 w-3/4" />
+                        <Skeleton className="h-3 w-1/2" />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Alts section skeleton */}
+          <div>
+            <div className="mb-2 flex items-center justify-between">
+              <Skeleton className="h-5 w-20" />
+              <Skeleton className="h-8 w-24 rounded-md" />
+            </div>
+            <div className="rounded-lg bg-muted/30">
+              <div className="px-3 py-2">
+                <Skeleton className="h-3 w-full" />
+              </div>
+              {Array.from({ length: 2 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="flex items-center gap-3 border-t px-3 py-3"
+                >
+                  <Skeleton className="size-7 rounded-full" />
+                  <Skeleton className="h-4 w-28" />
+                  <div className="ml-auto flex gap-6">
+                    <Skeleton className="h-3.5 w-10" />
+                    <Skeleton className="h-3.5 w-10" />
+                    <Skeleton className="h-3.5 w-10" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </DashboardContent>
+    </>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/onboarding/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/onboarding/page.tsx
@@ -5,6 +5,7 @@ import { needsOnboarding } from "@/lib/proxy-routes";
 import { getUser } from "@/lib/supabase/server";
 
 import { OnboardingForm } from "./onboarding-form";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 
 export const metadata: Metadata = {
   title: "Complete Your Profile | trainers.gg",
@@ -24,48 +25,52 @@ export default async function DashboardOnboardingPage() {
   }
 
   return (
-    <div className="flex flex-1 items-center justify-center px-4 py-12">
-      <div className="w-full max-w-md">
-        {/* Welcome header */}
-        <div className="mb-6 text-center">
-          <div className="mb-3 text-3xl">👋</div>
-          <h1 className="text-xl font-bold">Welcome, Trainer!</h1>
-          <p className="text-muted-foreground mt-1 text-sm">
-            Set up your profile to unlock the full experience
-          </p>
-        </div>
+    <DashboardContent>
+      <div className="flex flex-1 items-center justify-center px-4 py-12">
+        <div className="w-full max-w-md">
+          {/* Welcome header */}
+          <div className="mb-6 text-center">
+            <div className="mb-3 text-3xl">👋</div>
+            <h1 className="text-xl font-bold">Welcome, Trainer!</h1>
+            <p className="text-muted-foreground mt-1 text-sm">
+              Set up your profile to unlock the full experience
+            </p>
+          </div>
 
-        {/* Benefit cards */}
-        <div className="mb-6 grid grid-cols-3 gap-3">
-          <div className="rounded-lg border p-3 text-center">
-            <div className="mb-1 text-lg">🏆</div>
-            <div className="text-muted-foreground text-[11px]">
-              Join tournaments
+          {/* Benefit cards */}
+          <div className="mb-6 grid grid-cols-3 gap-3">
+            <div className="rounded-lg border p-3 text-center">
+              <div className="mb-1 text-lg">🏆</div>
+              <div className="text-muted-foreground text-[11px]">
+                Join tournaments
+              </div>
+            </div>
+            <div className="rounded-lg border p-3 text-center">
+              <div className="mb-1 text-lg">🌐</div>
+              <div className="text-muted-foreground text-[11px]">
+                @you.trainers.gg
+              </div>
+            </div>
+            <div className="rounded-lg border p-3 text-center">
+              <div className="mb-1 text-lg">📊</div>
+              <div className="text-muted-foreground text-[11px]">
+                Track stats &amp; ELO
+              </div>
             </div>
           </div>
-          <div className="rounded-lg border p-3 text-center">
-            <div className="mb-1 text-lg">🌐</div>
-            <div className="text-muted-foreground text-[11px]">
-              @you.trainers.gg
-            </div>
-          </div>
-          <div className="rounded-lg border p-3 text-center">
-            <div className="mb-1 text-lg">📊</div>
-            <div className="text-muted-foreground text-[11px]">
-              Track stats &amp; ELO
-            </div>
-          </div>
-        </div>
 
-        {/* Form card */}
-        <div className="rounded-xl border p-6">
-          <h2 className="mb-1 text-base font-semibold">Set up your profile</h2>
-          <p className="text-muted-foreground mb-5 text-sm">
-            Choose your username and tell us about yourself
-          </p>
-          <OnboardingForm />
+          {/* Form card */}
+          <div className="rounded-xl border p-6">
+            <h2 className="mb-1 text-base font-semibold">
+              Set up your profile
+            </h2>
+            <p className="text-muted-foreground mb-5 text-sm">
+              Choose your username and tell us about yourself
+            </p>
+            <OnboardingForm />
+          </div>
         </div>
       </div>
-    </div>
+    </DashboardContent>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/page.tsx
@@ -7,6 +7,8 @@ import {
   getAltsBulkStats,
   getPlayerRatingsBulk,
   getActiveMatch,
+  getMyDashboardData,
+  listMyCommunities,
   type AltStats,
   type PlayerRating,
 } from "@trainers/supabase";
@@ -19,10 +21,14 @@ import {
 import { CacheTags } from "@/lib/cache";
 import { DASHBOARD_ALT_COOKIE } from "@/components/dashboard/sidebar-helpers";
 import { PageHeader } from "@/components/dashboard/page-header";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 
 import { HomeClient } from "./home-client";
 import { LiveMatchBar, type ActiveMatch } from "./components/live-match-bar";
-import { DashboardStats } from "./components/dashboard-stats";
+import { EnhancedStats } from "./components/enhanced-stats";
+import { WelcomeHeader } from "./components/welcome-header";
+import { DashboardActivity } from "./components/dashboard-activity";
+import { CommunityHighlights } from "./components/community-highlights";
 import { computeStats } from "./compute-stats";
 
 // On-demand revalidation only — no time-based revalidation
@@ -32,10 +38,6 @@ export const revalidate = false;
 // Cached Fetchers (public data — anonymous client, no cookies)
 // =============================================================================
 
-/**
- * Fetch bulk match stats for a list of alt IDs.
- * Cache key includes sorted alt IDs for stable deduplication.
- */
 function getCachedBulkStats(altIds: number[]) {
   return unstable_cache(
     async () => {
@@ -47,10 +49,6 @@ function getCachedBulkStats(altIds: number[]) {
   )();
 }
 
-/**
- * Fetch bulk ratings for a list of alt IDs.
- * Cache key includes sorted alt IDs for stable deduplication.
- */
 function getCachedBulkRatings(altIds: number[]) {
   return unstable_cache(
     async () => {
@@ -67,13 +65,13 @@ function getCachedBulkRatings(altIds: number[]) {
 // =============================================================================
 
 export default async function DashboardHomePage() {
-  // Auth check — layout already redirects, but guard just in case
+  // Auth check
   const user = await getUser();
   if (!user) {
     redirect("/sign-in?redirect=/dashboard");
   }
 
-  // Read selected alt cookie (decode to match encodeURIComponent in writers)
+  // Read selected alt cookie
   const cookieStore = await cookies();
   const rawCookieValue = cookieStore.get(DASHBOARD_ALT_COOKIE)?.value ?? null;
   let selectedAltUsername: string | null = null;
@@ -81,7 +79,6 @@ export default async function DashboardHomePage() {
     try {
       selectedAltUsername = decodeURIComponent(rawCookieValue);
     } catch {
-      // Malformed encoding — treat as no selection
       selectedAltUsername = null;
     }
   }
@@ -96,7 +93,15 @@ export default async function DashboardHomePage() {
     alts = [];
   }
 
-  // Fetch main_alt_id from users table (auth-required — not cached)
+  // Fetch user's communities (auth-required — not cached)
+  let myCommunities: Awaited<ReturnType<typeof listMyCommunities>> = [];
+  try {
+    myCommunities = await listMyCommunities(supabase, user.id);
+  } catch (err) {
+    console.error("[DashboardHomePage] Failed to load communities:", err);
+  }
+
+  // Fetch main_alt_id from users table
   const { data: userRow, error: userRowError } = await supabase
     .from("users")
     .select("main_alt_id")
@@ -114,22 +119,31 @@ export default async function DashboardHomePage() {
   // Extract alt IDs for bulk queries
   const altIds = alts.map((a) => a.id);
 
-  // Parallel fetch: cached bulk stats/ratings + uncached active match (all public data)
+  // Parallel fetch: cached bulk stats/ratings + uncached active match + dashboard data
   let bulkStats: Record<number, AltStats> | undefined;
   let bulkRatings: Record<number, PlayerRating> | undefined;
   let activeMatch: ActiveMatch | null = null;
+  let dashboardData: Awaited<ReturnType<typeof getMyDashboardData>> | null =
+    null;
 
   if (altIds.length > 0) {
-    const [statsResult, ratingsResult, matchResult] = await Promise.allSettled([
-      getCachedBulkStats(altIds),
-      getCachedBulkRatings(altIds),
-      mainAltId
-        ? (() => {
-            const staticClient = createStaticClient();
-            return getActiveMatch(staticClient, mainAltId);
-          })()
-        : Promise.resolve(null),
-    ]);
+    const [statsResult, ratingsResult, matchResult, dashboardResult] =
+      await Promise.allSettled([
+        getCachedBulkStats(altIds),
+        getCachedBulkRatings(altIds),
+        mainAltId
+          ? (() => {
+              const staticClient = createStaticClient();
+              return getActiveMatch(staticClient, mainAltId);
+            })()
+          : Promise.resolve(null),
+        mainAltId
+          ? (() => {
+              const staticClient = createStaticClient();
+              return getMyDashboardData(staticClient, mainAltId);
+            })()
+          : Promise.resolve(null),
+      ]);
 
     bulkStats =
       statsResult.status === "fulfilled" ? statsResult.value : undefined;
@@ -156,9 +170,18 @@ export default async function DashboardHomePage() {
         matchResult.reason
       );
     }
+
+    dashboardData =
+      dashboardResult.status === "fulfilled" ? dashboardResult.value : null;
+    if (dashboardResult.status === "rejected") {
+      console.error(
+        "[DashboardHomePage] Failed to load dashboard data:",
+        dashboardResult.reason
+      );
+    }
   }
 
-  // Compute stats for server-rendered DashboardStats
+  // Compute stats for server-rendered stat cards
   const altCount = alts.length;
   const stats =
     altCount > 0
@@ -175,19 +198,75 @@ export default async function DashboardHomePage() {
           tournamentsSubAccent: false,
         };
 
-  // Extract username for welcome toast detection in client component
+  // Prepare tournament data for UpcomingTournaments component
+  const myTournaments = (dashboardData?.myTournaments ?? [])
+    .filter((t) => t.status === "upcoming" || t.status === "active")
+    .map((t) => ({
+      id: t.id,
+      name: t.name,
+      startDate: t.startDate ? new Date(t.startDate).getTime() : null,
+      status: t.status,
+      hasTeam: t.hasTeam,
+      registrationStatus: t.registrationStatus ?? null,
+      registrationId: t.registrationId ?? null,
+      lateCheckInMaxRound: t.lateCheckInMaxRound ?? null,
+    }));
+
+  // Prepare activity data
+  const recentActivity = dashboardData?.recentActivity ?? [];
+
+  // Username for welcome header
   const username = (user.user_metadata?.username as string) ?? "";
+
+  // Prepare community highlights data
+  const communityIds = myCommunities.map((c) => c.id);
+  let liveTournamentCommunityIds = new Set<number>();
+
+  if (communityIds.length > 0) {
+    try {
+      const staticClient = createStaticClient();
+      const { data: liveTournaments } = await staticClient
+        .from("tournaments")
+        .select("community_id")
+        .in("community_id", communityIds)
+        .eq("status", "active");
+
+      liveTournamentCommunityIds = new Set(
+        (liveTournaments ?? []).map((t) => t.community_id).filter(Boolean)
+      );
+    } catch (err) {
+      console.error(
+        "[DashboardHomePage] Failed to check live tournaments:",
+        err
+      );
+    }
+  }
+
+  const communityHighlights = myCommunities.map((c) => ({
+    id: c.id,
+    name: c.name,
+    slug: c.slug,
+    logoUrl: c.logo_url,
+    hasLiveTournament: liveTournamentCommunityIds.has(c.id),
+  }));
 
   return (
     <>
       <PageHeader title="Dashboard" />
-      <div className="flex flex-1 flex-col gap-4 p-4">
+      <DashboardContent>
         <div className="space-y-6">
+          {/* Welcome header with greeting + quick actions */}
+          <WelcomeHeader
+            username={username}
+            hasAlts={alts.length > 0}
+            hasTeamBuilderAccess
+          />
+
           {/* Live match bar — server-rendered */}
           {activeMatch && <LiveMatchBar match={activeMatch} />}
 
-          {/* Stats row — server-rendered */}
-          <DashboardStats
+          {/* Stats row — server-rendered with icons and contextual color */}
+          <EnhancedStats
             winRate={stats.winRate}
             winRateSub={stats.winRateSub}
             rating={stats.rating}
@@ -199,7 +278,16 @@ export default async function DashboardHomePage() {
             tournamentsSubAccent={stats.tournamentsSubAccent}
           />
 
-          {/* Client component — handles interactivity only */}
+          {/* Tournaments + Activity — two-column on desktop */}
+          <DashboardActivity
+            myTournaments={myTournaments}
+            recentActivity={recentActivity}
+          />
+
+          {/* Community highlights — shows user's communities with live indicators */}
+          <CommunityHighlights communities={communityHighlights} />
+
+          {/* Alt management — kept prominent */}
           <HomeClient
             alts={alts.map((a) => ({
               id: a.id,
@@ -214,7 +302,7 @@ export default async function DashboardHomePage() {
             username={username}
           />
         </div>
-      </div>
+      </DashboardContent>
     </>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/page.tsx
@@ -204,6 +204,7 @@ export default async function DashboardHomePage() {
     .map((t) => ({
       id: t.id,
       name: t.name,
+      slug: t.slug,
       startDate: t.startDate ? new Date(t.startDate).getTime() : null,
       status: t.status,
       hasTeam: t.hasTeam,

--- a/apps/web/src/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/page.tsx
@@ -132,16 +132,10 @@ export default async function DashboardHomePage() {
         getCachedBulkStats(altIds),
         getCachedBulkRatings(altIds),
         mainAltId
-          ? (() => {
-              const staticClient = createStaticClient();
-              return getActiveMatch(staticClient, mainAltId);
-            })()
+          ? getActiveMatch(supabase, mainAltId)
           : Promise.resolve(null),
         mainAltId
-          ? (() => {
-              const staticClient = createStaticClient();
-              return getMyDashboardData(staticClient, mainAltId);
-            })()
+          ? getMyDashboardData(supabase, mainAltId)
           : Promise.resolve(null),
       ]);
 
@@ -225,8 +219,7 @@ export default async function DashboardHomePage() {
 
   if (communityIds.length > 0) {
     try {
-      const staticClient = createStaticClient();
-      const { data: liveTournaments } = await staticClient
+      const { data: liveTournaments } = await supabase
         .from("tournaments")
         .select("community_id")
         .in("community_id", communityIds)

--- a/apps/web/src/app/(dashboard)/dashboard/settings/account/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/account/page.tsx
@@ -11,13 +11,15 @@ import {
 } from "@/components/ui/card";
 import { Mail, Lock } from "lucide-react";
 import { LinkedIdentitiesSection } from "@/components/settings/linked-identities-section";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 
 export default function AccountSettingsPage() {
   const { user } = useAuth();
   const email = user?.email ?? "";
 
   return (
-    <div className="space-y-4">
+    <DashboardContent>
+      <div className="space-y-4">
       <Card>
         <CardHeader>
           <CardTitle>Email</CardTitle>
@@ -65,6 +67,7 @@ export default function AccountSettingsPage() {
           <LinkedIdentitiesSection />
         </CardContent>
       </Card>
-    </div>
+      </div>
+    </DashboardContent>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/settings/display/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/display/page.tsx
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { getUserSpritePreference } from "@trainers/supabase";
 import { DisplayPreferencesForm } from "@/components/settings/display-preferences-form";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 
 export default async function DisplaySettingsPage() {
   const supabase = await createClient();
@@ -8,5 +9,9 @@ export default async function DisplaySettingsPage() {
   // Fetch current sprite preference from database
   const spritePreference = await getUserSpritePreference(supabase);
 
-  return <DisplayPreferencesForm initialPreference={spritePreference} />;
+  return (
+    <DashboardContent>
+      <DisplayPreferencesForm initialPreference={spritePreference} />
+    </DashboardContent>
+  );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/settings/notifications/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/notifications/page.tsx
@@ -11,6 +11,7 @@ import {
 import { createClient, getUser } from "@/lib/supabase/server";
 import { DiscordDmPreferencesSection } from "@/components/settings/discord-dm-preferences-section";
 import { NotificationPreferencesForm } from "./notification-preferences-form";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 
 /**
  * Check if a user has any staff roles by looking at organization_staff membership.
@@ -89,7 +90,8 @@ export default async function NotificationSettingsPage() {
   ) as Record<DiscordDmEventType, boolean>;
 
   return (
-    <div className="space-y-10">
+    <DashboardContent>
+      <div className="space-y-10">
       <NotificationPreferencesForm
         initialPreferences={preferences}
         isStaff={isStaff}
@@ -102,6 +104,7 @@ export default async function NotificationSettingsPage() {
           discordDmWarnUntil={userRow?.discord_dm_warn_until ?? null}
         />
       </div>
-    </div>
+      </div>
+    </DashboardContent>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/settings/profile/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/settings/profile/page.tsx
@@ -24,6 +24,7 @@ import { Loader2, Save, Check, X } from "lucide-react";
 import { SpritePicker } from "@/components/profile/sprite-picker";
 import { DiscordProfilePrivacyRow } from "@/components/settings/discord-profile-privacy-row";
 import { toast } from "sonner";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 import { COUNTRIES } from "@trainers/utils";
 import {
   checkUsernameAvailability,
@@ -204,16 +205,19 @@ export default function ProfileSettingsPage() {
 
   if (isLoading) {
     return (
-      <Card>
+      <DashboardContent>
+        <Card>
         <CardContent className="flex min-h-[200px] items-center justify-center">
           <Loader2 className="text-muted-foreground h-8 w-8 animate-spin" />
         </CardContent>
-      </Card>
+        </Card>
+      </DashboardContent>
     );
   }
 
   return (
-    <Card>
+    <DashboardContent>
+      <Card>
       <CardHeader>
         <CardTitle>Profile</CardTitle>
         <CardDescription>
@@ -344,5 +348,6 @@ export default function ProfileSettingsPage() {
         </Button>
       </CardContent>
     </Card>
+    </DashboardContent>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/teams/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/teams/page.tsx
@@ -9,6 +9,7 @@ import {
 
 import { getUser, createClientReadOnly } from "@/lib/supabase/server";
 import { PageHeader } from "@/components/dashboard/page-header";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 import { AllTeamsClient } from "@/components/team-builder/all-teams-client";
 
 // ---------------------------------------------------------------------------
@@ -50,11 +51,13 @@ export default async function AllTeamsPage() {
   return (
     <>
       <PageHeader title="Team Builder" />
-      <AllTeamsClient
-        initialTeams={teams}
-        alts={alts}
-        activeFormats={activeFormats}
-      />
+      <DashboardContent>
+        <AllTeamsClient
+          initialTeams={teams}
+          alts={alts}
+          activeFormats={activeFormats}
+        />
+      </DashboardContent>
     </>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/tournaments/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/tournaments/page.tsx
@@ -4,6 +4,7 @@ import { getUser } from "@/lib/supabase/server";
 import { TournamentsClient } from "./tournaments-client";
 import { PageHeader } from "@/components/dashboard/page-header";
 import { DASHBOARD_ALT_COOKIE } from "@/components/dashboard/sidebar-helpers";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
 
 export const metadata = {
   title: "Tournaments — trainers.gg",
@@ -25,9 +26,11 @@ export default async function TournamentsPage() {
   return (
     <>
       <PageHeader title="Tournaments" />
-      <div className="flex flex-1 flex-col gap-4 p-4 md:p-6">
-        <TournamentsClient selectedAltUsername={selectedAltUsername} />
-      </div>
+      <DashboardContent>
+        <div className="flex flex-1 flex-col gap-4">
+          <TournamentsClient selectedAltUsername={selectedAltUsername} />
+        </div>
+      </DashboardContent>
     </>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/tournaments/tournaments-client.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/tournaments/tournaments-client.tsx
@@ -227,7 +227,7 @@ function FilterChips({
             className={cn(
               "cursor-pointer rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors",
               active === chip
-                ? "border-foreground bg-foreground text-background"
+                ? "border-primary bg-primary text-primary-foreground"
                 : "text-muted-foreground hover:border-border border-border bg-background hover:text-foreground"
             )}
           >
@@ -235,7 +235,7 @@ function FilterChips({
             <span
               className={cn(
                 "ml-1 text-[10px]",
-                active === chip ? "text-background/70" : "text-muted-foreground"
+                active === chip ? "text-primary-foreground/70" : "text-muted-foreground"
               )}
             >
               {counts[chip]}

--- a/apps/web/src/components/dashboard/__tests__/dashboard-card.test.tsx
+++ b/apps/web/src/components/dashboard/__tests__/dashboard-card.test.tsx
@@ -57,14 +57,14 @@ describe("DashboardCard", () => {
         <DashboardCard className="extra-class">content</DashboardCard>
       );
       const wrapper = container.firstChild as HTMLElement;
-      expect(wrapper).toHaveClass("rounded-lg");
+      expect(wrapper).toHaveClass("rounded-xl");
       expect(wrapper).toHaveClass("extra-class");
     });
 
     it("renders correctly without a className prop", () => {
       const { container } = render(<DashboardCard>content</DashboardCard>);
       const wrapper = container.firstChild as HTMLElement;
-      expect(wrapper).toHaveClass("rounded-lg");
+      expect(wrapper).toHaveClass("rounded-xl");
     });
   });
 

--- a/apps/web/src/components/dashboard/dashboard-card.tsx
+++ b/apps/web/src/components/dashboard/dashboard-card.tsx
@@ -16,7 +16,7 @@ export function DashboardCard({
   return (
     <div
       className={cn(
-        "bg-card text-card-foreground rounded-lg p-4 shadow-sm",
+        "bg-card text-card-foreground rounded-xl p-4 shadow-sm",
         className
       )}
     >

--- a/apps/web/src/components/dashboard/dashboard-content.tsx
+++ b/apps/web/src/components/dashboard/dashboard-content.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+
+interface DashboardContentProps {
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * Content wrapper for dashboard pages.
+ * Constrains width to max-w-6xl (1152px) and centers horizontally
+ * so content doesn't stretch edge-to-edge on wide screens.
+ * The PageHeader remains full-width (it's a toolbar bar).
+ */
+export function DashboardContent({
+  children,
+  className,
+}: DashboardContentProps) {
+  return (
+    <div
+      className={cn(
+        "mx-auto w-full max-w-6xl flex-1 p-4 md:p-6",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/discord/__tests__/install-card.test.tsx
+++ b/apps/web/src/components/discord/__tests__/install-card.test.tsx
@@ -15,6 +15,15 @@ jest.mock("@/actions/discord-integration", () => ({
     mockGetDiscordInstallUrlAction(...args),
 }));
 
+// Mock next/image to render a plain img
+jest.mock("next/image", () => {
+  const MockImage = (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    <img {...props} />
+  );
+  MockImage.displayName = "MockImage";
+  return { __esModule: true, default: MockImage };
+});
+
 // Mock window.location so tests can assert on href assignments
 Object.defineProperty(window, "location", {
   writable: true,

--- a/apps/web/src/components/discord/install-card.tsx
+++ b/apps/web/src/components/discord/install-card.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 
+import Image from "next/image";
 import { toast } from "sonner";
 
 import { cn } from "@/lib/utils";
@@ -84,17 +85,23 @@ export function InstallCard({ communityId }: InstallCardProps) {
   return (
     <div className="space-y-4">
       {/* Hero card */}
-      <div className="rounded-xl border bg-white p-12 text-center">
+      <div className="rounded-xl border border-border bg-card p-12 text-center">
         {/* Bot icon */}
-        <div className="mx-auto mb-5 flex h-20 w-20 items-center justify-center rounded-2xl bg-gradient-to-br from-[#e6f4f1] to-[#cfe9e4] text-4xl">
-          🤖
+        <div className="mx-auto mb-5 flex size-40 items-center justify-center rounded-3xl bg-primary/10">
+          <Image
+            src="/icons/beanie_logo.png"
+            alt="Beanie Bot"
+            width={128}
+            height={128}
+            className="size-32"
+          />
         </div>
 
-        <h2 className="mb-2 text-2xl font-bold tracking-tight text-gray-900">
+        <h2 className="mb-2 text-2xl font-bold tracking-tight">
           Add Beanie Bot to your Discord
         </h2>
 
-        <p className="mx-auto mb-6 max-w-md leading-relaxed text-gray-500">
+        <p className="text-muted-foreground mx-auto mb-6 max-w-md leading-relaxed">
           Install the bot in a Discord server you manage. You&apos;ll be able to
           map tournament events to channels, sync roles, and control DM
           notifications — all from this page.
@@ -113,7 +120,7 @@ export function InstallCard({ communityId }: InstallCardProps) {
           {isLoading ? "Redirecting…" : "Add to your server"}
         </Button>
 
-        <p className="mt-4 text-xs text-gray-400">
+        <p className="text-muted-foreground/70 mt-4 text-xs">
           Requires a Discord server where you have Manage Server permission.
         </p>
       </div>
@@ -121,12 +128,12 @@ export function InstallCard({ communityId }: InstallCardProps) {
       {/* Feature grid */}
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
         {FEATURES.map((feature) => (
-          <div key={feature.title} className="rounded-lg border bg-white p-5">
+          <div key={feature.title} className="rounded-xl border border-border bg-card p-5">
             <div className="mb-2 text-2xl">{feature.icon}</div>
-            <div className="mb-1 font-semibold text-gray-900">
+            <div className="mb-1 font-semibold">
               {feature.title}
             </div>
-            <div className="text-xs leading-relaxed text-gray-500">
+            <div className="text-muted-foreground text-xs leading-relaxed">
               {feature.description}
             </div>
           </div>
@@ -134,15 +141,15 @@ export function InstallCard({ communityId }: InstallCardProps) {
       </div>
 
       {/* Slash commands strip */}
-      <div className="rounded-lg border bg-white px-5 py-4">
-        <div className="mb-3 font-semibold text-gray-900">
+      <div className="rounded-xl border border-border bg-card px-5 py-4">
+        <div className="mb-3 font-semibold">
           Plus 13 slash commands for your members
         </div>
         <div className="flex flex-wrap gap-1.5">
           {SLASH_COMMANDS.map((cmd) => (
             <code
               key={cmd}
-              className="rounded bg-gray-100 px-2 py-0.5 text-xs text-teal-700"
+              className="rounded bg-muted px-2 py-0.5 text-xs text-primary"
             >
               {cmd}
             </code>

--- a/apps/web/src/components/team-builder/__tests__/use-calc-state.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/use-calc-state.test.tsx
@@ -46,7 +46,11 @@ jest.mock("@smogon/calc", () => {
     Move: MockMove,
     Side: MockSide,
     Field: MockField,
-    Generations: { get: jest.fn(() => ({ species: { get: jest.fn() } })) },
+    Generations: { get: jest.fn(() => ({
+      species: { get: jest.fn(() => ({
+        baseStats: { hp: 78, atk: 84, def: 78, spa: 109, spd: 85, spe: 100 },
+      })) },
+    })) },
   };
 });
 

--- a/apps/web/src/components/team-builder/use-calc-state.ts
+++ b/apps/web/src/components/team-builder/use-calc-state.ts
@@ -149,6 +149,28 @@ function getGen(format: GameFormat | undefined) {
   return getCachedGen(safeGen);
 }
 
+/**
+ * Check whether @smogon/calc's gen data can resolve a species name.
+ * `getBaseStats` (from @pkmn/dex) may know about species that @smogon/calc's
+ * internal Generations data doesn't — particularly for gen 0 (Champions) or
+ * species with `exists: false` in certain gens.  This guard prevents the
+ * Pokemon constructor from constructing with `undefined` baseStats.
+ */
+function calcGenKnowsSpecies(
+  gen: ReturnType<typeof Generations.get>,
+  species: string
+): boolean {
+  try {
+    // The gen species lookup expects a branded ID type; cast to satisfy TS
+    // while using the same toID normalization the Pokemon constructor applies.
+    const id = species.toLowerCase().replace(/[^a-z0-9]+/g, "");
+    const entry = gen.species.get(id as Parameters<typeof gen.species.get>[0]);
+    return entry?.baseStats != null;
+  } catch {
+    return false;
+  }
+}
+
 /** Status display label → Smogon status code mapping. */
 export const STATUS_MAP = {
   Healthy: "",
@@ -428,6 +450,9 @@ function buildAttackerFromDb(
     // Verify the effective species (which may differ from db.species after mega
     // resolution) also has known base stats before constructing.
     if (!getBaseStats(effectiveSpecies)) return null;
+    // Also verify the species exists in @smogon/calc's gen data — @pkmn/dex
+    // and @smogon/calc have different species coverage per gen.
+    if (!calcGenKnowsSpecies(gen, effectiveSpecies)) return null;
     const calcAbility =
       canMega && megaActive && megaSpecies
         ? (getMegaAbilityForSpecies(megaSpecies) ?? db.ability ?? null)
@@ -490,6 +515,8 @@ function buildDefenderPokemon(
       canMega && megaActive && megaSpecies
         ? (getMegaAbilityForSpecies(megaSpecies) ?? ability)
         : ability;
+    // Bail if the species is unknown to @smogon/calc's gen data.
+    if (!calcGenKnowsSpecies(gen, effectiveSpecies)) return null;
     // Build without curHP first so we can call maxHP() to compute the real value.
     const mon = new Pokemon(gen, effectiveSpecies, {
       level: 50,

--- a/apps/web/src/components/team-builder/use-calc-state.ts
+++ b/apps/web/src/components/team-builder/use-calc-state.ts
@@ -515,6 +515,8 @@ function buildDefenderPokemon(
       canMega && megaActive && megaSpecies
         ? (getMegaAbilityForSpecies(megaSpecies) ?? ability)
         : ability;
+    // Bail if the species has no base stats in @pkmn/dex.
+    if (!getBaseStats(effectiveSpecies)) return null;
     // Bail if the species is unknown to @smogon/calc's gen data.
     if (!calcGenKnowsSpecies(gen, effectiveSpecies)) return null;
     // Build without curHP first so we can call maxHP() to compute the real value.

--- a/packages/supabase/src/queries/tournaments.ts
+++ b/packages/supabase/src/queries/tournaments.ts
@@ -1386,6 +1386,7 @@ export async function getMyDashboardData(supabase: TypedClient, altId: number) {
   const myTournaments: {
     id: number;
     name: string;
+    slug: string;
     startDate: string | null;
     status: string;
     hasTeam: boolean;
@@ -1399,6 +1400,7 @@ export async function getMyDashboardData(supabase: TypedClient, altId: number) {
     const tournament = reg.tournament as {
       id: number;
       name: string;
+      slug: string;
       start_date: string | null;
       status: string;
       archived_at: string | null;
@@ -1409,6 +1411,7 @@ export async function getMyDashboardData(supabase: TypedClient, altId: number) {
       myTournaments.push({
         id: tournament.id,
         name: tournament.name,
+        slug: tournament.slug,
         startDate: tournament.start_date,
         status: tournament.status,
         hasTeam: reg.team_id != null,

--- a/packages/utils/src/__tests__/format.test.ts
+++ b/packages/utils/src/__tests__/format.test.ts
@@ -2,6 +2,7 @@ import {
   type PlayerRef,
   getPlayerName,
   formatDate,
+  formatShortDate,
   formatDateTime,
   formatTimeAgo,
   isTempUsername,
@@ -81,6 +82,29 @@ describe("formatDate", () => {
     ["2025-12-01T12:00:00.000Z", "Dec 1, 2025"],
   ])("formats %s as %s", (input, expected) => {
     expect(formatDate(input)).toBe(expected);
+  });
+});
+
+describe("formatShortDate", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-03-25T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('formats "2026-03-28" as "Mar 28"', () => {
+    expect(formatShortDate("2026-03-28")).toBe("Mar 28");
+  });
+
+  it('formats "2026-01-01" as "Jan 1"', () => {
+    expect(formatShortDate("2026-01-01")).toBe("Jan 1");
+  });
+
+  it("handles full ISO datetime strings", () => {
+    expect(formatShortDate("2026-06-15T14:30:00.000Z")).toBe("Jun 15");
   });
 });
 

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -18,6 +18,14 @@ export function formatDate(dateStr: string): string {
   });
 }
 
+/** Format a date string as "Mar 1" (without year). */
+export function formatShortDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
 /** Format a date string as "Mar 1, 2026, 3:45 PM". */
 export function formatDateTime(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString("en-US", {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -11,6 +11,7 @@ export {
   getPlayerName,
   formatDate,
   formatDateTime,
+  formatShortDate,
   formatTimeAgo,
   isTempUsername,
   formatDisplayUsername,


### PR DESCRIPTION
## Summary

Full redesign of the dashboard home page and polish pass across community dashboard pages.

### Dashboard Home (`/dashboard`)
- **Welcome header** with time-based greeting and quick action buttons (Browse Tournaments, Team Builder, New Alt)
- **Enhanced stats** with icon backgrounds and 4-tier win rate coloring (green/teal/neutral/red)
- **Dashboard activity** panel with upcoming tournaments (check-in actions) and recent match results (W/L indicators)
- **Community highlights** showing user's communities with live tournament indicators (pinging dot)
- Updated loading skeleton to match new layout

### Dashboard-wide
- New `DashboardContent` wrapper (`max-w-6xl`, centered) applied to all 22 non-builder dashboard pages
- Builder pages (standalone `/builder` and team editor) excluded from width constraint
- `DashboardCard` upgraded from `rounded-lg` to `rounded-xl`

### Community Overview
- Stat cards polished: icon backgrounds (Trophy, Users, Swords, UserCheck), removed fake sparkline SVGs, softer subtitles
- Stats wrapped in `bg-muted/30` container matching main dashboard style
- Upcoming Tournaments: removed harsh left border, improved empty state with icon
- Recent Activity & Top Regulars: emoji headers replaced with Lucide icons, two-line empty states

### Community Staff
- Fixed `DropdownMenuLabel` missing `MenuGroup` context (Base UI runtime error)

### Discord Integration
- All hardcoded colors (`bg-white`, `text-gray-*`) replaced with theme tokens (`bg-card`, `text-muted-foreground`, `bg-muted`)
- Robot emoji replaced with Beanie logo PNG via `next/image`

### Alts Table
- Expand/collapse chevron moved from far right to far left of each row
- Redesigned expanded alt row: card-based teams + results layout

### Other Fixes
- Fixed `rejectBots()` misuse in discord settings page (Server Action called in GET context)
- Fixed tournament filter chips to use `bg-primary`/`text-primary-foreground` theme tokens
- Updated all affected tests (overview-client, dashboard-card, install-card, teams-sub-table)

## Testing
- Lint: 11/11 passed
- Typecheck: 11/11 passed
- Tests: 306 suites, 5565 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added community highlights section to dashboard home page.
  * Added personalized welcome header with quick action buttons.
  * Added enhanced dashboard statistics with icons and improved formatting.
  * Added upcoming tournaments and recent activity sections to dashboard.

* **Improvements**
  * Redesigned community overview page with icon-driven statistics cards.
  * Redesigned teams sub-table with card-based layout.
  * Improved Discord bot installation experience with updated branding.
  * Enhanced staff management mobile UI with better dropdown organization.
  * Updated dashboard card styling for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->