### PR TITLE
fix: use linkIdentity instead of signInWithOAuth for account linking

### DIFF
--- a/apps/web/src/components/settings/__tests__/linked-identities-section.test.tsx
+++ b/apps/web/src/components/settings/__tests__/linked-identities-section.test.tsx
@@ -42,7 +42,7 @@ jest.mock("@tanstack/react-query", () => ({
 }));
 
 // Mock dependencies
-const mockSignInWithOAuth = jest.fn().mockResolvedValue({ error: null });
+const mockLinkIdentity = jest.fn().mockResolvedValue({ data: { url: "" }, error: null });
 const mockUnlinkIdentity = jest.fn();
 
 jest.mock("@/hooks/use-auth", () => ({
@@ -51,13 +51,13 @@ jest.mock("@/hooks/use-auth", () => ({
       id: "user-123",
       identities: mockUserIdentities,
     },
-    signInWithOAuth: mockSignInWithOAuth,
   }),
 }));
 
 jest.mock("@/lib/supabase/client", () => ({
   createClient: jest.fn(() => ({
     auth: {
+      linkIdentity: mockLinkIdentity,
       unlinkIdentity: mockUnlinkIdentity,
     },
   })),
@@ -224,7 +224,7 @@ describe("LinkedIdentitiesSection", () => {
   });
 
   describe("connect functionality", () => {
-    it("calls signInWithOAuth when clicking Connect for OAuth provider", async () => {
+    it("calls linkIdentity when clicking Connect for OAuth provider", async () => {
       const user = userEvent.setup();
       render(<LinkedIdentitiesSection />);
 
@@ -241,10 +241,12 @@ describe("LinkedIdentitiesSection", () => {
       });
       await user.click(connectButton);
 
-      expect(mockSignInWithOAuth).toHaveBeenCalledWith(
-        "discord",
-        "/dashboard/settings/account"
-      );
+      expect(mockLinkIdentity).toHaveBeenCalledWith({
+        provider: "discord",
+        options: {
+          redirectTo: expect.stringContaining("/auth/callback?next=%2Fdashboard%2Fsettings%2Faccount"),
+        },
+      });
     });
 
     it("redirects to Bluesky OAuth when clicking Connect for Bluesky", async () => {

--- a/apps/web/src/components/settings/__tests__/linked-identities-section.test.tsx
+++ b/apps/web/src/components/settings/__tests__/linked-identities-section.test.tsx
@@ -99,7 +99,7 @@ jest.mock("sonner", () => ({
 
 // Mock window.location
 delete (window as Partial<Window>).location;
-window.location = { href: "" } as Location;
+window.location = { href: "", origin: "http://localhost:3000" } as Location;
 
 // Test data
 let mockUserIdentities: Array<{
@@ -244,7 +244,7 @@ describe("LinkedIdentitiesSection", () => {
       expect(mockLinkIdentity).toHaveBeenCalledWith({
         provider: "discord",
         options: {
-          redirectTo: expect.stringContaining("/auth/callback?next=%2Fdashboard%2Fsettings%2Faccount"),
+          redirectTo: `${window.location.origin}/auth/callback?next=%2Fdashboard%2Fsettings%2Faccount`,
         },
       });
     });

--- a/apps/web/src/components/settings/linked-identities-section.tsx
+++ b/apps/web/src/components/settings/linked-identities-section.tsx
@@ -134,13 +134,13 @@ export function LinkedIdentitiesSection() {
     } else {
       // Use linkIdentity to attach the provider to the current user
       // (signInWithOAuth would replace the session instead of linking)
-      const origin =
-        typeof window !== "undefined" ? window.location.origin : "";
+      const redirectTo = new URL(
+        "/auth/callback?next=%2Fdashboard%2Fsettings%2Faccount",
+        window.location.origin
+      ).toString();
       const { error } = await supabase.auth.linkIdentity({
         provider,
-        options: {
-          redirectTo: `${origin}/auth/callback?next=${encodeURIComponent("/dashboard/settings/account")}`,
-        },
+        options: { redirectTo },
       });
       if (error) {
         toast.error(`Failed to link ${provider}: ${error.message}`);

--- a/apps/web/src/components/settings/linked-identities-section.tsx
+++ b/apps/web/src/components/settings/linked-identities-section.tsx
@@ -80,7 +80,7 @@ const providerIcons: Record<string, () => React.JSX.Element> = {
  * Includes lockout protection to prevent unlinking the last authentication method
  */
 export function LinkedIdentitiesSection() {
-  const { user, signInWithOAuth } = useAuth();
+  const { user } = useAuth();
   const supabase = createClient();
   const queryClient = useQueryClient();
   const [unlinking, setUnlinking] = useState<string | null>(null);
@@ -132,11 +132,16 @@ export function LinkedIdentitiesSection() {
       const returnUrl = encodeURIComponent("/dashboard/settings/account");
       window.location.href = `/api/oauth/login?returnUrl=${returnUrl}`;
     } else {
-      // Use standard Supabase OAuth
-      const { error } = await signInWithOAuth(
+      // Use linkIdentity to attach the provider to the current user
+      // (signInWithOAuth would replace the session instead of linking)
+      const origin =
+        typeof window !== "undefined" ? window.location.origin : "";
+      const { error } = await supabase.auth.linkIdentity({
         provider,
-        "/dashboard/settings/account"
-      );
+        options: {
+          redirectTo: `${origin}/auth/callback?next=${encodeURIComponent("/dashboard/settings/account")}`,
+        },
+      });
       if (error) {
         toast.error(`Failed to link ${provider}: ${error.message}`);
       }


### PR DESCRIPTION
## Summary

- Fixes bug where connecting a new OAuth provider (e.g., Discord) would disconnect previously linked providers
- Replaces `signInWithOAuth` with `linkIdentity` in the Linked Accounts settings, which properly attaches the identity to the existing user without replacing the session
- Updates tests to reflect the new behavior

## Root Cause

`signInWithOAuth` initiates a new sign-in flow that replaces the current session. When called on an already-authenticated user, it was effectively signing them in fresh via the new provider rather than linking it to their existing account. Supabase's `linkIdentity` is the correct API for this — it attaches an OAuth identity to the currently authenticated user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the technical implementation of OAuth identity linking for better integration with authentication services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->