### PR TITLE
fix: guard requestIdleCallback for Safari mobile compatibility

### DIFF
--- a/apps/web/src/components/team-builder/team-workspace.tsx
+++ b/apps/web/src/components/team-builder/team-workspace.tsx
@@ -438,8 +438,13 @@ export function TeamWorkspaceV2({
   useEffect(() => {
     const formatId = format?.id;
     if (!formatId) return;
-    const id = requestIdleCallback(() => warmSpeciesIndex(formatId));
-    return () => cancelIdleCallback(id);
+    // requestIdleCallback is unavailable in Safari < 16.4 — fall back to setTimeout
+    if (typeof requestIdleCallback === "function") {
+      const id = requestIdleCallback(() => warmSpeciesIndex(formatId));
+      return () => cancelIdleCallback(id);
+    }
+    const id = setTimeout(() => warmSpeciesIndex(formatId), 1);
+    return () => clearTimeout(id);
   }, [format?.id]);
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `requestIdleCallback` / `cancelIdleCallback` are not available in Safari < 16.4 (March 2023)
- The species index warming effect in `TeamWorkspaceV2` called `requestIdleCallback` unconditionally, throwing a `ReferenceError` on mount in affected Safari versions
- This caused the brief editor flash followed by the "Application error: a client-side exception has occurred" crash on Safari mobile
- Fix: feature-detect `requestIdleCallback` and fall back to `setTimeout(..., 1)` — preserves the "defer until after first paint" intent while being universally compatible

## Test plan

- [ ] Load `builder.trainers.gg` on Safari mobile (or desktop Safari with older engine) — editor should load without crashing
- [ ] Load on Chrome/Firefox — species picker should still warm on first open (no regression)
- [ ] Open the species picker immediately after page load — should feel instant on both paths

https://claude.ai/code/session_01B3YewveKnCBnY3zgFzfH6a

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3YewveKnCBnY3zgFzfH6a)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved team workspace preloading functionality with enhanced browser compatibility across Safari and other browsers through adaptive loading strategies that optimize performance and resource efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thatguyinabeanie/trainers.gg/pull/314)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->