### PR TITLE
fix: close builder panels by default on mobile

### DIFF
--- a/.claude/rules/mobile-responsiveness.md
+++ b/.claude/rules/mobile-responsiveness.md
@@ -150,6 +150,26 @@ beforeEach(() => {
 
 Add a `describe("conditional mount")` block whenever you introduce a wrapper that switches between table and cards: skeleton when `!isClient`, table when desktop, cards stub when mobile.
 
+## Preventing flash of wrong initial state on mobile
+
+SSR renders with `useIsMobile() === false` (desktop assumption). When React hydrates on mobile, it re-renders to the mobile layout — but any state initialized to "desktop-open" values will still be open, and the user sees them before JavaScript can correct it.
+
+**Use `useLayoutEffect` to close panels/UI that should be hidden on mobile before the first browser paint:**
+
+```tsx
+useLayoutEffect(() => {
+  /* eslint-disable react-hooks/set-state-in-effect */
+  if (window.innerWidth < 768) {
+    setPanelOpen(false);   // or setSideDrawer(null), etc.
+  }
+  /* eslint-enable react-hooks/set-state-in-effect */
+}, []);
+```
+
+`useLayoutEffect` fires synchronously after React's DOM mutations but before the browser paints — so users never see the panel open. `useEffect` fires after paint, causing a visible flash of the panel closing.
+
+This is the correct approach for any piece of state that defaults to "open/visible" for desktop but should be "closed/hidden" on mobile. See `use-builder-state.ts` for a real example (Speed Tiers and Damage Calc panels).
+
 ## What NOT to do
 
 - Don't gate the desktop drag UI behind `hidden md:block` — keep the wrapper unconditional and split the render only.

--- a/.claude/rules/react-patterns.md
+++ b/.claude/rules/react-patterns.md
@@ -155,6 +155,26 @@ useEffect(() => {
 }, [searchTerm]);
 ```
 
+**Pre-paint state correction (no-flash)** — use `useLayoutEffect` when state must be corrected before the browser paints to avoid visible flicker. The most common case is hiding content that is wrong for the current viewport after SSR hydration (e.g., panels that should be closed on mobile):
+
+```tsx
+// Good — fires before browser paint, user never sees the wrong state
+useLayoutEffect(() => {
+  /* eslint-disable react-hooks/set-state-in-effect */
+  if (window.innerWidth < 768) {
+    setPanelOpen(false);
+  }
+  /* eslint-enable react-hooks/set-state-in-effect */
+}, []);
+
+// Bad — useEffect fires after paint; user sees the panel flash closed
+useEffect(() => {
+  if (window.innerWidth < 768) setPanelOpen(false);
+}, []);
+```
+
+`useLayoutEffect` is suppressed on the server (Next.js no-ops it for SSR) so no SSR crash occurs. Use it only for one-time mount corrections — not for derived state that can be computed during render.
+
 ## Refs
 
 `useRef` holds mutable values that don't trigger re-renders. Refs are the correct tool for:

--- a/apps/web/src/components/builder-nav.tsx
+++ b/apps/web/src/components/builder-nav.tsx
@@ -34,28 +34,32 @@ export function BuilderNav({ children }: BuilderNavProps) {
             <span className="text-primary text-lg font-bold">trainers.gg</span>
           </Link>
 
-          <span className="text-muted-foreground/50 text-sm">/</span>
+          <span className="text-muted-foreground/50 hidden text-sm sm:inline">
+            /
+          </span>
 
-          <DropdownMenu>
-            <DropdownMenuTrigger className="text-foreground hover:bg-accent focus-visible:ring-ring inline-flex items-center gap-0.5 rounded-md px-1.5 py-1 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none">
-              Builder
-              <ChevronDown className="text-muted-foreground size-3.5" />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="start"
-              sideOffset={6}
-              className="min-w-40"
-            >
-              {NAV_LINKS.map((link) => (
-                <DropdownMenuItem
-                  key={link.href}
-                  render={<Link href={link.href} className="w-full" />}
-                >
-                  {link.label}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <div className="hidden sm:block">
+            <DropdownMenu>
+              <DropdownMenuTrigger className="text-foreground hover:bg-accent focus-visible:ring-ring inline-flex items-center gap-0.5 rounded-md px-1.5 py-1 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none">
+                Builder
+                <ChevronDown className="text-muted-foreground size-3.5" />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="start"
+                sideOffset={6}
+                className="min-w-40"
+              >
+                {NAV_LINKS.map((link) => (
+                  <DropdownMenuItem
+                    key={link.href}
+                    render={<Link href={link.href} className="w-full" />}
+                  >
+                    {link.label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </div>
 
         {/* Center + Right: toolbar controls (uses internal absolute centering for name) */}

--- a/apps/web/src/components/landing/__tests__/hero-cta.test.tsx
+++ b/apps/web/src/components/landing/__tests__/hero-cta.test.tsx
@@ -41,8 +41,8 @@ const mockUseAuthContext = useAuthContext as jest.MockedFunction<
 >;
 
 describe("HeroCTA", () => {
-  // "Explore Players" always appears regardless of auth state
-  it("always renders Explore Players link to /players", () => {
+  // "Team Builder" always appears regardless of auth state
+  it("always renders Team Builder link to /builder", () => {
     mockUseAuthContext.mockReturnValue({
       isAuthenticated: false,
       loading: false,
@@ -53,8 +53,8 @@ describe("HeroCTA", () => {
 
     render(<HeroCTA />);
 
-    const exploreLink = screen.getByRole("link", { name: "Explore Players" });
-    expect(exploreLink).toHaveAttribute("href", "/players");
+    const builderLink = screen.getByRole("link", { name: "Team Builder" });
+    expect(builderLink).toHaveAttribute("href", "/builder");
   });
 
   it.each([

--- a/apps/web/src/components/landing/hero-cta.tsx
+++ b/apps/web/src/components/landing/hero-cta.tsx
@@ -28,10 +28,10 @@ function CTAButtons({ authenticated }: { authenticated: boolean }) {
         </Link>
       )}
       <Link
-        href="/players"
+        href="/builder"
         className={cn(buttonVariants({ variant: "outline", size: "lg" }))}
       >
-        Explore Players
+        Team Builder
       </Link>
     </div>
   );

--- a/apps/web/src/components/mobile-nav.tsx
+++ b/apps/web/src/components/mobile-nav.tsx
@@ -17,6 +17,7 @@ import {
   Building2,
   BarChart3,
   GraduationCap,
+  Swords,
 } from "lucide-react";
 import { useAuth } from "@/components/auth/auth-provider";
 
@@ -30,6 +31,7 @@ const authenticatedNavItems: NavItem[] = [
   { href: "/dashboard", label: "Dashboard", icon: Home },
   { href: "/tournaments", label: "Tournaments", icon: Trophy },
   { href: "/communities", label: "Communities", icon: Building2 },
+  { href: "/builder", label: "Builder", icon: Swords },
   { href: "/analytics", label: "Analytics", icon: BarChart3 },
   { href: "/coaching", label: "Coaching", icon: GraduationCap },
 ];
@@ -37,6 +39,7 @@ const authenticatedNavItems: NavItem[] = [
 const publicNavItems: NavItem[] = [
   { href: "/tournaments", label: "Tournaments", icon: Trophy },
   { href: "/communities", label: "Communities", icon: Building2 },
+  { href: "/builder", label: "Builder", icon: Swords },
   { href: "/analytics", label: "Analytics", icon: BarChart3 },
   { href: "/coaching", label: "Coaching", icon: GraduationCap },
 ];

--- a/apps/web/src/components/team-builder/__tests__/team-workspace-v2.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/team-workspace-v2.test.tsx
@@ -124,12 +124,28 @@ jest.mock("../export-menu", () => ({
   ExportMenu: () => <div data-testid="export-menu" />,
 }));
 
+const mockValidate = jest.fn();
+let mockValidationErrors: Array<{
+  severity: "error" | "warning";
+  message: string;
+  pokemonId: number;
+}> = [];
+
 jest.mock("../validation-hooks", () => ({
   useTeamValidation: () => ({
-    errors: [],
+    errors: mockValidationErrors,
     pokemonErrors: new Map(),
-    validate: jest.fn(),
+    validate: mockValidate,
   }),
+}));
+
+jest.mock("../validation/validation-popover", () => ({
+  ValidationPopover: ({
+    errors,
+  }: {
+    errors: unknown[];
+    onJumpToPokemon: (id: number) => void;
+  }) => <div data-testid="validation-popover" data-count={errors.length} />,
 }));
 
 // Controllable drawer state — default closed, tests can override
@@ -373,6 +389,7 @@ beforeEach(() => {
   mockBuilderState.activeIdx = 0;
   mockBuilderState.attackerSlot = null;
   mockUseIsMobile.mockReturnValue(false);
+  mockValidationErrors = [];
   // Default: all persistence methods succeed
   (MOCK_PERSISTENCE.addPokemon as jest.Mock).mockResolvedValue({
     success: true,
@@ -1073,5 +1090,106 @@ describe("TeamWorkspaceV2 — alt transfer", () => {
     expect(mockTransferTeam).toHaveBeenCalledWith(1, 2);
     expect(mockRouterPush).not.toHaveBeenCalled();
     expect(mockToastError).toHaveBeenCalledWith("Transfer denied");
+  });
+});
+
+// =============================================================================
+// Mobile header row — team name + validate
+// =============================================================================
+
+describe("TeamWorkspaceV2 — mobile header row", () => {
+  beforeEach(() => {
+    mockUseIsMobile.mockReturnValue(true);
+  });
+
+  it("renders the team name in the content area on mobile", () => {
+    renderWorkspace();
+    const nameBtn = screen.getByRole("button", { name: /edit team name/i });
+    expect(nameBtn).toBeInTheDocument();
+    expect(nameBtn).toHaveTextContent("Test Team");
+  });
+
+  it("renders the Validate button in the content area on mobile", () => {
+    renderWorkspace();
+    expect(screen.getByRole("button", { name: /validate/i })).toBeInTheDocument();
+  });
+
+  it("calls validate when the mobile Validate popover is opened", async () => {
+    const user = userEvent.setup();
+    renderWorkspace();
+
+    await user.click(screen.getByRole("button", { name: /validate/i }));
+
+    expect(mockValidate).toHaveBeenCalled();
+  });
+
+  it("calls persistence.updateTeam with new name when team name is saved", async () => {
+    const user = userEvent.setup();
+    renderWorkspace();
+
+    await user.click(screen.getByRole("button", { name: /edit team name/i }));
+    const input = screen.getByRole("textbox", { name: /team name/i });
+    await user.clear(input);
+    await user.type(input, "My Renamed Team");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(MOCK_PERSISTENCE.updateTeam).toHaveBeenCalledWith(1, {
+        name: "My Renamed Team",
+      });
+    });
+  });
+
+  it("calls persistence.onMutationSuccess after a successful rename", async () => {
+    const user = userEvent.setup();
+    renderWorkspace();
+
+    await user.click(screen.getByRole("button", { name: /edit team name/i }));
+    const input = screen.getByRole("textbox", { name: /team name/i });
+    await user.clear(input);
+    await user.type(input, "Renamed Team");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(MOCK_PERSISTENCE.onMutationSuccess).toHaveBeenCalled();
+    });
+  });
+
+  it("shows error toast when rename fails", async () => {
+    (MOCK_PERSISTENCE.updateTeam as jest.Mock).mockResolvedValueOnce({
+      success: false,
+      error: "Name is too long.",
+    });
+
+    const user = userEvent.setup();
+    renderWorkspace();
+
+    await user.click(screen.getByRole("button", { name: /edit team name/i }));
+    const input = screen.getByRole("textbox", { name: /team name/i });
+    await user.clear(input);
+    await user.type(input, "A Very Long Team Name That Fails Validation");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Name is too long.");
+    });
+  });
+
+  it("applies error styling to Validate button when there are validation errors", () => {
+    mockValidationErrors = [
+      { severity: "error", message: "Invalid move", pokemonId: 10 },
+    ];
+    renderWorkspace();
+    const validateBtn = screen.getByRole("button", { name: /validate/i });
+    expect(validateBtn).toHaveClass("text-destructive");
+  });
+
+  it("applies warning styling to Validate button when there are only warnings", () => {
+    mockValidationErrors = [
+      { severity: "warning", message: "Unusual item", pokemonId: 10 },
+    ];
+    renderWorkspace();
+    const validateBtn = screen.getByRole("button", { name: /validate/i });
+    expect(validateBtn).toHaveClass("text-amber-600");
   });
 });

--- a/apps/web/src/components/team-builder/__tests__/team-workspace-v2.test.tsx
+++ b/apps/web/src/components/team-builder/__tests__/team-workspace-v2.test.tsx
@@ -1109,16 +1109,18 @@ describe("TeamWorkspaceV2 — mobile header row", () => {
     expect(nameBtn).toHaveTextContent("Test Team");
   });
 
-  it("renders the Validate button in the content area on mobile", () => {
+  it("renders the validate icon button in the content area on mobile", () => {
     renderWorkspace();
-    expect(screen.getByRole("button", { name: /validate/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /team is valid/i })
+    ).toBeInTheDocument();
   });
 
-  it("calls validate when the mobile Validate popover is opened", async () => {
+  it("calls validate when the mobile validate popover is opened", async () => {
     const user = userEvent.setup();
     renderWorkspace();
 
-    await user.click(screen.getByRole("button", { name: /validate/i }));
+    await user.click(screen.getByRole("button", { name: /team is valid/i }));
 
     expect(mockValidate).toHaveBeenCalled();
   });
@@ -1175,21 +1177,25 @@ describe("TeamWorkspaceV2 — mobile header row", () => {
     });
   });
 
-  it("applies error styling to Validate button when there are validation errors", () => {
+  it("applies error styling to validate icon button when there are validation errors", () => {
     mockValidationErrors = [
       { severity: "error", message: "Invalid move", pokemonId: 10 },
     ];
     renderWorkspace();
-    const validateBtn = screen.getByRole("button", { name: /validate/i });
+    const validateBtn = screen.getByRole("button", {
+      name: /validation errors/i,
+    });
     expect(validateBtn).toHaveClass("text-destructive");
   });
 
-  it("applies warning styling to Validate button when there are only warnings", () => {
+  it("applies warning styling to validate icon button when there are only warnings", () => {
     mockValidationErrors = [
       { severity: "warning", message: "Unusual item", pokemonId: 10 },
     ];
     renderWorkspace();
-    const validateBtn = screen.getByRole("button", { name: /validate/i });
+    const validateBtn = screen.getByRole("button", {
+      name: /validation warnings/i,
+    });
     expect(validateBtn).toHaveClass("text-amber-600");
   });
 });

--- a/apps/web/src/components/team-builder/__tests__/use-builder-state.test.ts
+++ b/apps/web/src/components/team-builder/__tests__/use-builder-state.test.ts
@@ -17,8 +17,11 @@ function clearStorage() {
 // =============================================================================
 
 describe("useBuilderState — ephemeral state defaults", () => {
+  let originalInnerWidth: number;
+
   beforeEach(() => {
     clearStorage();
+    originalInnerWidth = window.innerWidth;
     // Simulate desktop so drawers default to open (JSDOM defaults innerWidth=0)
     Object.defineProperty(window, "innerWidth", {
       writable: true,
@@ -31,7 +34,7 @@ describe("useBuilderState — ephemeral state defaults", () => {
     Object.defineProperty(window, "innerWidth", {
       writable: true,
       configurable: true,
-      value: 0,
+      value: originalInnerWidth,
     });
   });
 

--- a/apps/web/src/components/team-builder/__tests__/use-builder-state.test.ts
+++ b/apps/web/src/components/team-builder/__tests__/use-builder-state.test.ts
@@ -12,31 +12,26 @@ function clearStorage() {
   window.localStorage.clear();
 }
 
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+}
+
+// Default to desktop so useLayoutEffect leaves drawers open.
+// JSDOM defaults innerWidth to 0, which would trigger the mobile close logic.
+beforeEach(() => {
+  setViewportWidth(1024);
+});
+
 // =============================================================================
 // Builder state defaults & updates
 // =============================================================================
 
 describe("useBuilderState — ephemeral state defaults", () => {
-  let originalInnerWidth: number;
-
-  beforeEach(() => {
-    clearStorage();
-    originalInnerWidth = window.innerWidth;
-    // Simulate desktop so drawers default to open (JSDOM defaults innerWidth=0)
-    Object.defineProperty(window, "innerWidth", {
-      writable: true,
-      configurable: true,
-      value: 1024,
-    });
-  });
-
-  afterEach(() => {
-    Object.defineProperty(window, "innerWidth", {
-      writable: true,
-      configurable: true,
-      value: originalInnerWidth,
-    });
-  });
+  beforeEach(clearStorage);
 
   it("starts with activeIdx=0", () => {
     const { result } = renderHook(() => useBuilderState());
@@ -49,11 +44,7 @@ describe("useBuilderState — ephemeral state defaults", () => {
   });
 
   it("closes sideDrawer and rightDrawer by default on mobile", () => {
-    Object.defineProperty(window, "innerWidth", {
-      writable: true,
-      configurable: true,
-      value: 375,
-    });
+    setViewportWidth(375);
     const { result } = renderHook(() => useBuilderState());
     expect(result.current.sideDrawer).toBe(null);
     expect(result.current.rightDrawer).toBe(null);

--- a/apps/web/src/components/team-builder/__tests__/use-builder-state.test.ts
+++ b/apps/web/src/components/team-builder/__tests__/use-builder-state.test.ts
@@ -17,16 +17,43 @@ function clearStorage() {
 // =============================================================================
 
 describe("useBuilderState — ephemeral state defaults", () => {
-  beforeEach(clearStorage);
+  beforeEach(() => {
+    clearStorage();
+    // Simulate desktop so drawers default to open (JSDOM defaults innerWidth=0)
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: 1024,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: 0,
+    });
+  });
 
   it("starts with activeIdx=0", () => {
     const { result } = renderHook(() => useBuilderState());
     expect(result.current.activeIdx).toBe(0);
   });
 
-  it("starts with sideDrawer='speed'", () => {
+  it("starts with sideDrawer='speed' on desktop", () => {
     const { result } = renderHook(() => useBuilderState());
     expect(result.current.sideDrawer).toBe("speed");
+  });
+
+  it("closes sideDrawer and rightDrawer by default on mobile", () => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: 375,
+    });
+    const { result } = renderHook(() => useBuilderState());
+    expect(result.current.sideDrawer).toBe(null);
+    expect(result.current.rightDrawer).toBe(null);
   });
 
   it("setActiveIdx updates the value", () => {

--- a/apps/web/src/components/team-builder/__tests__/use-local-team-storage.test.ts
+++ b/apps/web/src/components/team-builder/__tests__/use-local-team-storage.test.ts
@@ -71,7 +71,7 @@ describe("useLocalTeamStorage — initialization", () => {
     const { result } = renderHook(() => useLocalTeamStorage());
     expect(result.current.team.name).toBe("Untitled Team");
     expect(result.current.team.team_pokemon).toHaveLength(0);
-    expect(result.current.team.format).toBe("gen9vgc2026regi");
+    expect(result.current.team.format).toBe("championsvgc2026regma");
   });
 
   it("sets hydrated to true after mount", () => {

--- a/apps/web/src/components/team-builder/__tests__/use-local-team-storage.test.ts
+++ b/apps/web/src/components/team-builder/__tests__/use-local-team-storage.test.ts
@@ -29,7 +29,7 @@ function makeTeam(overrides?: Partial<TeamWithPokemon>): TeamWithPokemon {
   return {
     id: -1,
     name: "Untitled Team",
-    format: "gen9vgc2026regi",
+    format: "championsvgc2026regma",
     format_legal: null,
     description: null,
     notes: null,

--- a/apps/web/src/components/team-builder/builder-topbar.tsx
+++ b/apps/web/src/components/team-builder/builder-topbar.tsx
@@ -100,7 +100,7 @@ interface EditableNameProps {
   onSave: (name: string) => Promise<void>;
 }
 
-function EditableName({ defaultValue, onSave }: EditableNameProps) {
+export function EditableName({ defaultValue, onSave }: EditableNameProps) {
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState(defaultValue);
   const [saving, setSaving] = useState(false);
@@ -253,8 +253,8 @@ export function BuilderTopbar({
 
   return (
     <>
-      {/* Center: Team name — flows in flex on mobile, absolutely centered on sm+ */}
-      <div className="pointer-events-none flex items-center justify-center sm:absolute sm:inset-x-0">
+      {/* Center: Team name — hidden on mobile (shown in workspace content area instead), absolutely centered on sm+ */}
+      <div className="pointer-events-none hidden sm:absolute sm:inset-x-0 sm:flex sm:items-center sm:justify-center">
         <div className="pointer-events-auto flex items-center gap-1.5">
           <EditableName defaultValue={team.name} onSave={onNameChange} />
           {onSaveToAccount ? (
@@ -330,7 +330,7 @@ export function BuilderTopbar({
               <button
                 type="button"
                 className={cn(
-                  "border-input bg-background hover:bg-accent hover:text-accent-foreground relative inline-flex h-7 items-center gap-1.5 rounded-md border px-2.5 text-xs shadow-xs transition-colors",
+                  "border-input bg-background hover:bg-accent hover:text-accent-foreground relative hidden h-7 items-center gap-1.5 rounded-md border px-2.5 text-xs shadow-xs transition-colors sm:inline-flex",
                   hasErrors &&
                     "border-destructive/50 text-destructive hover:border-destructive hover:text-destructive",
                   hasWarnings &&

--- a/apps/web/src/components/team-builder/builder-topbar.tsx
+++ b/apps/web/src/components/team-builder/builder-topbar.tsx
@@ -98,9 +98,10 @@ interface BuilderTopbarProps {
 interface EditableNameProps {
   defaultValue: string;
   onSave: (name: string) => Promise<void>;
+  className?: string;
 }
 
-export function EditableName({ defaultValue, onSave }: EditableNameProps) {
+export function EditableName({ defaultValue, onSave, className }: EditableNameProps) {
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState(defaultValue);
   const [saving, setSaving] = useState(false);
@@ -153,7 +154,8 @@ export function EditableName({ defaultValue, onSave }: EditableNameProps) {
         autoFocus
         className={cn(
           "border-border bg-background focus-visible:ring-ring h-7 w-44 rounded-md border px-2 text-sm font-semibold shadow-xs transition-colors outline-none focus-visible:ring-2 sm:w-56",
-          saving && "opacity-60"
+          saving && "opacity-60",
+          className
         )}
         aria-label="Team name"
       />
@@ -164,7 +166,10 @@ export function EditableName({ defaultValue, onSave }: EditableNameProps) {
     <button
       type="button"
       onClick={() => setEditing(true)}
-      className="hover:bg-accent flex h-7 max-w-44 items-center gap-1 rounded-md px-2 text-sm font-semibold transition-colors sm:max-w-56"
+      className={cn(
+        "hover:bg-accent flex h-7 max-w-44 items-center gap-1 rounded-md px-2 text-sm font-semibold transition-colors sm:max-w-56",
+        className
+      )}
       aria-label="Edit team name"
     >
       <span className="truncate">{defaultValue}</span>

--- a/apps/web/src/components/team-builder/builder-topbar.tsx
+++ b/apps/web/src/components/team-builder/builder-topbar.tsx
@@ -253,8 +253,8 @@ export function BuilderTopbar({
 
   return (
     <>
-      {/* Center: Team name — absolutely centered in the nav bar */}
-      <div className="pointer-events-none absolute inset-x-0 flex items-center justify-center">
+      {/* Center: Team name — flows in flex on mobile, absolutely centered on sm+ */}
+      <div className="pointer-events-none flex items-center justify-center sm:absolute sm:inset-x-0">
         <div className="pointer-events-auto flex items-center gap-1.5">
           <EditableName defaultValue={team.name} onSave={onNameChange} />
           {onSaveToAccount ? (
@@ -263,7 +263,7 @@ export function BuilderTopbar({
               onClick={onSaveToAccount}
               disabled={isSaving}
               aria-label={isSaving ? "Saving…" : "Save to account"}
-              className="text-muted-foreground hover:text-primary disabled:text-muted-foreground/40 flex size-7 items-center justify-center rounded-md transition-colors"
+              className="text-muted-foreground hover:text-primary disabled:text-muted-foreground/40 hidden size-7 items-center justify-center rounded-md transition-colors sm:flex"
             >
               {SaveIcon}
             </button>
@@ -271,7 +271,7 @@ export function BuilderTopbar({
             <Link
               href={`/sign-in?redirect=${encodeURIComponent("/builder?action=save")}`}
               aria-label="Sign in to save"
-              className="text-muted-foreground hover:text-primary flex size-7 items-center justify-center rounded-md transition-colors"
+              className="text-muted-foreground hover:text-primary hidden size-7 items-center justify-center rounded-md transition-colors sm:flex"
             >
               {SaveIcon}
             </Link>
@@ -287,7 +287,7 @@ export function BuilderTopbar({
             render={
               <button
                 type="button"
-                className="border-input bg-background hover:bg-accent hover:text-accent-foreground inline-flex h-7 items-center gap-1 rounded-md border px-2.5 text-xs shadow-xs transition-colors"
+                className="border-input bg-background hover:bg-accent hover:text-accent-foreground hidden h-7 items-center gap-1 rounded-md border px-2.5 text-xs shadow-xs transition-colors sm:inline-flex"
               />
             }
           >

--- a/apps/web/src/components/team-builder/local-builder-workspace.tsx
+++ b/apps/web/src/components/team-builder/local-builder-workspace.tsx
@@ -176,7 +176,7 @@ export function LocalBuilderWorkspace() {
       const result = await teamsApi.saveLocal({
         altId: targetAlt.id,
         name: team.name || "Untitled Team",
-        format: team.format || "gen9vgc2026regi",
+        format: team.format || "championsvgc2026regma",
         pokemon: pokemonPayloads as Record<string, unknown>[],
       });
 

--- a/apps/web/src/components/team-builder/persistence/__tests__/use-local-team-storage.test.ts
+++ b/apps/web/src/components/team-builder/persistence/__tests__/use-local-team-storage.test.ts
@@ -38,7 +38,7 @@ describe("useLocalTeamStorage", () => {
 
     expect(result.current.team.id).toBe(-1);
     expect(result.current.team.name).toBe("Untitled Team");
-    expect(result.current.team.format).toBe("gen9vgc2026regi");
+    expect(result.current.team.format).toBe("championsvgc2026regma");
     expect(result.current.team.team_pokemon).toEqual([]);
   });
 

--- a/apps/web/src/components/team-builder/persistence/use-local-team-storage.ts
+++ b/apps/web/src/components/team-builder/persistence/use-local-team-storage.ts
@@ -24,7 +24,7 @@ const DEBOUNCE_MS = 300;
 /** Module-level ref to the pending debounce timer so clearLocalTeamStorage can cancel it. */
 let pendingWriteTimer: ReturnType<typeof setTimeout> | null = null;
 
-/** Default format for new local teams — current primary VGC format. */
+/** Default format for new local teams — Pokémon Champions (Reg M-A). */
 const DEFAULT_FORMAT = "championsvgc2026regma";
 
 // =============================================================================

--- a/apps/web/src/components/team-builder/persistence/use-local-team-storage.ts
+++ b/apps/web/src/components/team-builder/persistence/use-local-team-storage.ts
@@ -25,7 +25,7 @@ const DEBOUNCE_MS = 300;
 let pendingWriteTimer: ReturnType<typeof setTimeout> | null = null;
 
 /** Default format for new local teams — current primary VGC format. */
-const DEFAULT_FORMAT = "gen9vgc2026regi";
+const DEFAULT_FORMAT = "championsvgc2026regma";
 
 // =============================================================================
 // Helpers

--- a/apps/web/src/components/team-builder/team-workspace.tsx
+++ b/apps/web/src/components/team-builder/team-workspace.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
+import { AlertCircle, AlertTriangle, CheckCircle2 } from "lucide-react";
 import {
   DndContext,
   closestCenter,
@@ -958,8 +959,8 @@ export function TeamWorkspaceV2({
               /* Mobile: no panel group, inline layout */
               <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
                 <div className="flex min-h-0 flex-1 flex-col items-center overflow-y-auto">
-                  {/* Mobile: team name row — prominent, above secondary controls */}
-                  <div className="flex w-full max-w-[1800px] px-3 pt-2 pb-0.5">
+                  {/* Mobile: single row — name (flex-1), format, validate icon */}
+                  <div className="flex w-full max-w-[1800px] items-center gap-2 px-3 py-2">
                     <EditableName
                       defaultValue={team.name}
                       onSave={async (name) => {
@@ -974,12 +975,8 @@ export function TeamWorkspaceV2({
                         }
                         persistence.onMutationSuccess();
                       }}
-                      className="h-8 w-full max-w-full text-base"
+                      className="h-8 min-w-0 flex-1 text-base"
                     />
-                  </div>
-
-                  {/* Mobile: format + validate + layout row */}
-                  <div className="flex w-full max-w-[1800px] items-center gap-2 px-3 pb-2">
                     <WorkspaceMetadata
                       alts={alts}
                       selectedAltId={
@@ -1031,66 +1028,75 @@ export function TeamWorkspaceV2({
                         persistence.onMutationSuccess();
                       }}
                     />
-                    <div className="ml-auto flex items-center gap-1.5">
-                      <Popover
-                        open={mobileValidateOpen}
-                        onOpenChange={(open) => {
-                          if (open) validate();
-                          setMobileValidateOpen(open);
-                        }}
-                      >
-                        <PopoverTrigger
-                          render={
-                            <button
-                              type="button"
-                              className={cn(
-                                "border-input bg-background hover:bg-accent hover:text-accent-foreground relative inline-flex h-7 items-center gap-1.5 rounded-md border px-2.5 text-xs shadow-xs transition-colors",
-                                validationErrors.some(
-                                  (e) => e.severity === "error"
-                                ) &&
-                                  "border-destructive/50 text-destructive hover:border-destructive hover:text-destructive",
-                                validationErrors.some(
-                                  (e) => e.severity === "warning"
-                                ) &&
-                                  !validationErrors.some(
-                                    (e) => e.severity === "error"
-                                  ) &&
-                                  "border-amber-400/50 text-amber-600 hover:border-amber-400 dark:text-amber-400"
-                              )}
-                            />
-                          }
-                        >
-                          Validate
-                          {validationErrors.length > 0 && (
-                            <span
-                              className={cn(
-                                "absolute -top-0.5 -right-0.5 size-2 rounded-full",
-                                validationErrors.some(
-                                  (e) => e.severity === "error"
-                                )
-                                  ? "bg-destructive"
-                                  : "bg-amber-500"
-                              )}
-                              aria-hidden="true"
-                            />
-                          )}
-                        </PopoverTrigger>
-                        <PopoverContent
-                          side="bottom"
-                          align="end"
-                          className="w-auto max-w-[calc(100vw-2rem)] p-0"
-                        >
-                          <ValidationPopover
-                            errors={validationErrors}
-                            onJumpToPokemon={(id) => {
-                              handleJumpToPokemon(id);
-                              setMobileValidateOpen(false);
-                            }}
+                    <Popover
+                      open={mobileValidateOpen}
+                      onOpenChange={(open) => {
+                        if (open) validate();
+                        setMobileValidateOpen(open);
+                      }}
+                    >
+                      <PopoverTrigger
+                        render={
+                          <button
+                            type="button"
+                            aria-label={
+                              validationErrors.some(
+                                (e) => e.severity === "error"
+                              )
+                                ? "Validation errors"
+                                : validationErrors.some(
+                                      (e) => e.severity === "warning"
+                                    )
+                                  ? "Validation warnings"
+                                  : "Team is valid"
+                            }
+                            className={cn(
+                              "hover:bg-accent flex size-8 shrink-0 items-center justify-center rounded-md transition-colors",
+                              validationErrors.some(
+                                (e) => e.severity === "error"
+                              )
+                                ? "text-destructive"
+                                : validationErrors.some(
+                                      (e) => e.severity === "warning"
+                                    )
+                                  ? "text-amber-600 dark:text-amber-400"
+                                  : "text-emerald-600 dark:text-emerald-400"
+                            )}
                           />
-                        </PopoverContent>
-                      </Popover>
-                      <TeamLayoutToggle />
-                    </div>
+                        }
+                      >
+                        {validationErrors.some(
+                          (e) => e.severity === "error"
+                        ) ? (
+                          <AlertCircle className="size-5" aria-hidden="true" />
+                        ) : validationErrors.some(
+                            (e) => e.severity === "warning"
+                          ) ? (
+                          <AlertTriangle
+                            className="size-5"
+                            aria-hidden="true"
+                          />
+                        ) : (
+                          <CheckCircle2
+                            className="size-5"
+                            aria-hidden="true"
+                          />
+                        )}
+                      </PopoverTrigger>
+                      <PopoverContent
+                        side="bottom"
+                        align="end"
+                        className="w-auto max-w-[calc(100vw-2rem)] p-0"
+                      >
+                        <ValidationPopover
+                          errors={validationErrors}
+                          onJumpToPokemon={(id) => {
+                            handleJumpToPokemon(id);
+                            setMobileValidateOpen(false);
+                          }}
+                        />
+                      </PopoverContent>
+                    </Popover>
                   </div>
 
                   <section

--- a/apps/web/src/components/team-builder/team-workspace.tsx
+++ b/apps/web/src/components/team-builder/team-workspace.tsx
@@ -958,7 +958,28 @@ export function TeamWorkspaceV2({
               /* Mobile: no panel group, inline layout */
               <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
                 <div className="flex min-h-0 flex-1 flex-col items-center overflow-y-auto">
-                  <div className="flex w-full max-w-[1800px] items-center gap-3 px-3 pt-2">
+                  {/* Mobile: team name row — prominent, above secondary controls */}
+                  <div className="flex w-full max-w-[1800px] px-3 pt-2 pb-0.5">
+                    <EditableName
+                      defaultValue={team.name}
+                      onSave={async (name) => {
+                        const result = await persistence.updateTeam(team.id, {
+                          name,
+                        });
+                        if (!result.success) {
+                          toast.error(
+                            result.error ?? "Failed to rename team."
+                          );
+                          return;
+                        }
+                        persistence.onMutationSuccess();
+                      }}
+                      className="h-8 w-full max-w-full text-base"
+                    />
+                  </div>
+
+                  {/* Mobile: format + validate + layout row */}
+                  <div className="flex w-full max-w-[1800px] items-center gap-2 px-3 pb-2">
                     <WorkspaceMetadata
                       alts={alts}
                       selectedAltId={
@@ -1010,29 +1031,7 @@ export function TeamWorkspaceV2({
                         persistence.onMutationSuccess();
                       }}
                     />
-                    <div className="ml-auto">
-                      <TeamLayoutToggle />
-                    </div>
-                  </div>
-
-                  {/* Mobile: team name + validate row */}
-                  <div className="flex w-full max-w-[1800px] items-center gap-2 px-3 pb-1">
-                    <EditableName
-                      defaultValue={team.name}
-                      onSave={async (name) => {
-                        const result = await persistence.updateTeam(team.id, {
-                          name,
-                        });
-                        if (!result.success) {
-                          toast.error(
-                            result.error ?? "Failed to rename team."
-                          );
-                          return;
-                        }
-                        persistence.onMutationSuccess();
-                      }}
-                    />
-                    <div className="ml-auto">
+                    <div className="ml-auto flex items-center gap-1.5">
                       <Popover
                         open={mobileValidateOpen}
                         onOpenChange={(open) => {
@@ -1090,6 +1089,7 @@ export function TeamWorkspaceV2({
                           />
                         </PopoverContent>
                       </Popover>
+                      <TeamLayoutToggle />
                     </div>
                   </div>
 

--- a/apps/web/src/components/team-builder/team-workspace.tsx
+++ b/apps/web/src/components/team-builder/team-workspace.tsx
@@ -1100,7 +1100,7 @@ export function TeamWorkspaceV2({
                   </div>
 
                   <section
-                    className="mx-auto my-auto grid w-full max-w-[1800px] gap-2 p-3 [[data-density=compact]_&]:p-2"
+                    className="mx-auto my-auto grid w-full max-w-[1800px] gap-2 px-3 pb-3 [[data-density=compact]_&]:px-2 [[data-density=compact]_&]:pb-2"
                     data-calc-open="false"
                     data-layout={layoutMode}
                   >

--- a/apps/web/src/components/team-builder/team-workspace.tsx
+++ b/apps/web/src/components/team-builder/team-workspace.tsx
@@ -49,6 +49,13 @@ import {
 } from "@/components/ui/resizable";
 import { ImportDialog } from "./import-dialog";
 import { useTeamValidation, type ValidationError } from "./validation-hooks";
+import { EditableName } from "./builder-topbar";
+import { ValidationPopover } from "./validation/validation-popover";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { CalcBottomPanel } from "./calc/calc-bottom-panel";
 import {
   CalcStateProvider,
@@ -417,6 +424,9 @@ export function TeamWorkspaceV2({
 
   /** Controls the import sheet. */
   const [importOpen, setImportOpen] = useState(false);
+
+  /** Controls the mobile validate popover. */
+  const [mobileValidateOpen, setMobileValidateOpen] = useState(false);
 
   /** Slot index awaiting remove confirmation. null = dialog closed. */
 
@@ -1004,6 +1014,85 @@ export function TeamWorkspaceV2({
                       <TeamLayoutToggle />
                     </div>
                   </div>
+
+                  {/* Mobile: team name + validate row */}
+                  <div className="flex w-full max-w-[1800px] items-center gap-2 px-3 pb-1">
+                    <EditableName
+                      defaultValue={team.name}
+                      onSave={async (name) => {
+                        const result = await persistence.updateTeam(team.id, {
+                          name,
+                        });
+                        if (!result.success) {
+                          toast.error(
+                            result.error ?? "Failed to rename team."
+                          );
+                          return;
+                        }
+                        persistence.onMutationSuccess();
+                      }}
+                    />
+                    <div className="ml-auto">
+                      <Popover
+                        open={mobileValidateOpen}
+                        onOpenChange={(open) => {
+                          if (open) validate();
+                          setMobileValidateOpen(open);
+                        }}
+                      >
+                        <PopoverTrigger
+                          render={
+                            <button
+                              type="button"
+                              className={cn(
+                                "border-input bg-background hover:bg-accent hover:text-accent-foreground relative inline-flex h-7 items-center gap-1.5 rounded-md border px-2.5 text-xs shadow-xs transition-colors",
+                                validationErrors.some(
+                                  (e) => e.severity === "error"
+                                ) &&
+                                  "border-destructive/50 text-destructive hover:border-destructive hover:text-destructive",
+                                validationErrors.some(
+                                  (e) => e.severity === "warning"
+                                ) &&
+                                  !validationErrors.some(
+                                    (e) => e.severity === "error"
+                                  ) &&
+                                  "border-amber-400/50 text-amber-600 hover:border-amber-400 dark:text-amber-400"
+                              )}
+                            />
+                          }
+                        >
+                          Validate
+                          {validationErrors.length > 0 && (
+                            <span
+                              className={cn(
+                                "absolute -top-0.5 -right-0.5 size-2 rounded-full",
+                                validationErrors.some(
+                                  (e) => e.severity === "error"
+                                )
+                                  ? "bg-destructive"
+                                  : "bg-amber-500"
+                              )}
+                              aria-hidden="true"
+                            />
+                          )}
+                        </PopoverTrigger>
+                        <PopoverContent
+                          side="bottom"
+                          align="end"
+                          className="w-auto max-w-[calc(100vw-2rem)] p-0"
+                        >
+                          <ValidationPopover
+                            errors={validationErrors}
+                            onJumpToPokemon={(id) => {
+                              handleJumpToPokemon(id);
+                              setMobileValidateOpen(false);
+                            }}
+                          />
+                        </PopoverContent>
+                      </Popover>
+                    </div>
+                  </div>
+
                   <section
                     className="mx-auto my-auto grid w-full max-w-[1800px] gap-2 p-3 [[data-density=compact]_&]:p-2"
                     data-calc-open="false"

--- a/apps/web/src/components/team-builder/use-builder-state.ts
+++ b/apps/web/src/components/team-builder/use-builder-state.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 
 // =============================================================================
 // Types
@@ -173,6 +173,18 @@ export function useBuilderState(): BuilderState {
   const [sideDrawer, setSideDrawer] = useState<SideDrawerKey>("speed");
   const [rightDrawer, setRightDrawer] = useState<RightDrawerKey>("calc");
   const [bottomDrawer, setBottomDrawer] = useState<BottomDrawerKey>(null);
+
+  // Close side panels on mobile before first paint so the editor is immediately
+  // visible. useLayoutEffect fires before the browser paints, preventing any
+  // flash of panel content.
+  useLayoutEffect(() => {
+    /* eslint-disable react-hooks/set-state-in-effect */
+    if (window.innerWidth < 768) {
+      setSideDrawer(null);
+      setRightDrawer(null);
+    }
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, []);
 
   const [panelHeightPct, setPanelHeightPctState] = useState<number>(
     DEFAULT_PANEL_HEIGHT_PCT

--- a/apps/web/src/components/team-builder/use-builder-state.ts
+++ b/apps/web/src/components/team-builder/use-builder-state.ts
@@ -178,12 +178,12 @@ export function useBuilderState(): BuilderState {
   // visible. useLayoutEffect fires before the browser paints, preventing any
   // flash of panel content.
   useLayoutEffect(() => {
-    /* eslint-disable react-hooks/set-state-in-effect */
     if (window.innerWidth < 768) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- deliberate pre-paint correction: panels must close before browser paints to avoid flash
       setSideDrawer(null);
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- deliberate pre-paint correction: panels must close before browser paints to avoid flash
       setRightDrawer(null);
     }
-    /* eslint-enable react-hooks/set-state-in-effect */
   }, []);
 
   const [panelHeightPct, setPanelHeightPctState] = useState<number>(

--- a/apps/web/src/components/team-builder/use-builder-state.ts
+++ b/apps/web/src/components/team-builder/use-builder-state.ts
@@ -176,14 +176,15 @@ export function useBuilderState(): BuilderState {
 
   // Close side panels on mobile before first paint so the editor is immediately
   // visible. useLayoutEffect fires before the browser paints, preventing any
-  // flash of panel content.
+  // flash of panel content. setState here is a deliberate pre-paint correction —
+  // not a reaction to external data — so the set-state-in-effect rule is suppressed.
   useLayoutEffect(() => {
+    /* eslint-disable react-hooks/set-state-in-effect */
     if (window.innerWidth < 768) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- deliberate pre-paint correction: panels must close before browser paints to avoid flash
       setSideDrawer(null);
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- deliberate pre-paint correction: panels must close before browser paints to avoid flash
       setRightDrawer(null);
     }
+    /* eslint-enable react-hooks/set-state-in-effect */
   }, []);
 
   const [panelHeightPct, setPanelHeightPctState] = useState<number>(


### PR DESCRIPTION
## Summary

- **Mobile builder panels closed by default** — Speed Tiers and Damage Calc panels now start closed on mobile (< 768px) so the Pokémon editor is immediately visible; uses `useLayoutEffect` (fires before browser paint) to prevent any flash
- **Mobile builder header** — collapsed into a single row: team name (editable, flex-1) + format selector + icon-only validate button (green ✓ / amber ⚠ / red ✗ based on validation state); layout toggle removed from mobile
- **Default format changed to Pokémon Champions (Reg M-A)** — new local teams default to `championsvgc2026regma` instead of the old VGC format
- **Mobile nav + homepage CTA** — added "Builder" entry to the mobile navigation; replaced "Explore Players" homepage CTA with "Team Builder" linking to `/builder`
- **Documents `useLayoutEffect` pre-paint correction pattern** in `.claude/rules/react-patterns.md` and `.claude/rules/mobile-responsiveness.md`

## Test plan

- [ ] Open builder at a mobile viewport (< 768px) — editor should be visible immediately, no panels shown
- [ ] Tap "Speed tiers" in the dockbar — panel opens; tap again — closes
- [ ] Tap "Damage calc" in the dockbar — panel opens; tap again — closes
- [ ] Open builder at a desktop viewport — Speed Tiers and Damage Calc should both be open by default (unchanged)
- [ ] Confirm no panel flash on mobile (panels should never appear then disappear on load)
- [ ] Mobile builder header row shows name ✏ | format ▼ | validate icon (single row, no layout toggle)
- [ ] Validate icon is green when team is empty/valid, amber for warnings, red for errors
- [ ] New local team defaults to Champions: Reg M-A format
- [ ] Homepage hero shows "Team Builder" button linking to `/builder`
- [ ] Mobile nav includes "Builder" link

https://claude.ai/code/session_01YLUf68NLyEhXuKRW8feJUk