### PR TITLE
feat: community Bluesky identity — PDS provisioning, profile sync, shared namespace

### DIFF
--- a/apps/web/src/app/(app)/admin/community-requests/__tests__/actions.test.ts
+++ b/apps/web/src/app/(app)/admin/community-requests/__tests__/actions.test.ts
@@ -56,7 +56,10 @@ describe("grantCommunityRequestAction", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockRequireAdminWithSudo.mockResolvedValue({ userId: ADMIN_USER_ID });
-    mockGrantCommunityRequest.mockResolvedValue(undefined);
+    mockGrantCommunityRequest.mockResolvedValue({
+      request: { id: REQUEST_ID },
+      organization: { id: 1, slug: "test-org" },
+    });
     mockFunctionsInvoke.mockResolvedValue({ data: null });
   });
 

--- a/apps/web/src/app/(app)/admin/community-requests/__tests__/actions.test.ts
+++ b/apps/web/src/app/(app)/admin/community-requests/__tests__/actions.test.ts
@@ -91,6 +91,15 @@ describe("grantCommunityRequestAction", () => {
     );
   });
 
+  it("triggers PDS provisioning after approval", async () => {
+    await grantCommunityRequestAction(REQUEST_ID);
+
+    expect(mockFunctionsInvoke).toHaveBeenCalledWith(
+      "provision-community-pds",
+      { body: { communityId: 1 } }
+    );
+  });
+
   it("returns an error when auth check fails", async () => {
     mockRequireAdminWithSudo.mockResolvedValue({
       success: false,

--- a/apps/web/src/app/(app)/admin/community-requests/actions.ts
+++ b/apps/web/src/app/(app)/admin/community-requests/actions.ts
@@ -39,7 +39,7 @@ export async function grantCommunityRequestAction(
   }
 
   return withAdminAction(async (supabase, adminUserId) => {
-    await grantCommunityRequest(
+    const { organization } = await grantCommunityRequest(
       supabase,
       parsed.data,
       adminUserId,
@@ -56,6 +56,15 @@ export async function grantCommunityRequestAction(
       })
       .catch((err: unknown) =>
         console.error("Failed to send approval email:", err)
+      );
+
+    // Fire-and-forget PDS provisioning — community gets a Bluesky identity
+    supabase.functions
+      .invoke("provision-community-pds", {
+        body: { communityId: organization.id },
+      })
+      .catch((err: unknown) =>
+        console.error("Failed to provision community PDS:", err)
       );
 
     return { success: true };

--- a/apps/web/src/app/(app)/communities/[communitySlug]/page.tsx
+++ b/apps/web/src/app/(app)/communities/[communitySlug]/page.tsx
@@ -178,6 +178,18 @@ function CommunityHeader({
             )}
           </div>
 
+          {/* Bluesky handle */}
+          {organization.bluesky_handle && (
+            <a
+              href={`https://bsky.app/profile/${organization.bluesky_handle}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-muted-foreground hover:text-primary inline-flex items-center gap-1.5 text-sm transition-colors"
+            >
+              <span>@{organization.bluesky_handle}</span>
+            </a>
+          )}
+
           {organization.description && (
             <p className="text-muted-foreground max-w-2xl text-lg">
               {organization.description}

--- a/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/__tests__/settings-page.test.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/__tests__/settings-page.test.tsx
@@ -699,4 +699,62 @@ describe("DashboardSettingsPage", () => {
       expect(screen.queryByTestId("discord-bot-chip")).not.toBeInTheDocument();
     });
   });
+
+  describe("bluesky identity card", () => {
+    it("shows active state with handle and DID when PDS is active", async () => {
+      const org = buildOrg({
+        bluesky_handle: "test-org.trainers.gg",
+        bluesky_did: "did:plc:abc123",
+        pds_status: "active",
+      });
+      await renderPage(org);
+
+      expect(screen.getByText("Active on network")).toBeInTheDocument();
+      expect(screen.getByText("@test-org.trainers.gg")).toBeInTheDocument();
+      expect(screen.getByText("did:plc:abc123")).toBeInTheDocument();
+    });
+
+    it("shows enable button when community has no PDS status", async () => {
+      const org = buildOrg({
+        bluesky_handle: null,
+        bluesky_did: null,
+        pds_status: null,
+      });
+      await renderPage(org);
+
+      expect(
+        screen.getByRole("button", { name: /Enable Bluesky Identity/i })
+      ).toBeInTheDocument();
+    });
+
+    it("shows retry button when PDS provisioning previously failed", async () => {
+      const org = buildOrg({
+        bluesky_handle: null,
+        bluesky_did: null,
+        pds_status: "failed",
+      });
+      await renderPage(org);
+
+      expect(
+        screen.getByRole("button", { name: /Retry/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Previous attempt failed. You can try again.")
+      ).toBeInTheDocument();
+    });
+
+    it("does not show active state when DID is missing even with active status", async () => {
+      const org = buildOrg({
+        bluesky_handle: "test-org.trainers.gg",
+        bluesky_did: null,
+        pds_status: "active",
+      });
+      await renderPage(org);
+
+      expect(screen.queryByText("Active on network")).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /Enable Bluesky Identity/i })
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/__tests__/settings-page.test.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/__tests__/settings-page.test.tsx
@@ -15,8 +15,14 @@ import { MAX_IMAGE_SIZE } from "@trainers/validators";
 
 const mockUseSupabaseQuery = jest.fn();
 
+const mockSupabaseClient = {
+  functions: { invoke: jest.fn().mockResolvedValue({ data: null, error: null }) },
+  auth: { getSession: jest.fn().mockResolvedValue({ data: { session: { access_token: "test-token" } }, error: null }) },
+};
+
 jest.mock("@/lib/supabase", () => ({
   useSupabaseQuery: (...args: unknown[]) => mockUseSupabaseQuery(...args),
+  useSupabase: () => mockSupabaseClient,
 }));
 
 jest.mock("next/link", () => ({

--- a/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/settings/page.tsx
@@ -187,6 +187,19 @@ function SettingsForm({ org, communitySlug, onSaved }: SettingsFormProps) {
   );
   const discordInstalled = discordServer != null;
 
+  /** Fire-and-forget PDS profile sync (only if community has active PDS). */
+  const syncProfileToPds = () => {
+    if (org.pds_status === "active" && org.bluesky_did) {
+      supabase.functions
+        .invoke("sync-community-profile", {
+          body: { communityId: org.id },
+        })
+        .catch(() => {
+          // Non-blocking — don't fail the save
+        });
+    }
+  };
+
   const handleLogoSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -216,6 +229,7 @@ function SettingsForm({ org, communitySlug, onSaved }: SettingsFormProps) {
         setCurrentLogoUrl(result.data.logoUrl);
         toast.success("Logo updated");
         onSaved();
+        syncProfileToPds();
       } else {
         toast.error(result.error);
       }
@@ -229,6 +243,7 @@ function SettingsForm({ org, communitySlug, onSaved }: SettingsFormProps) {
         setCurrentLogoUrl(null);
         toast.success("Logo removed");
         onSaved();
+        syncProfileToPds();
       } else {
         toast.error(result.error);
       }
@@ -314,17 +329,7 @@ function SettingsForm({ org, communitySlug, onSaved }: SettingsFormProps) {
       if (result.success) {
         toast.success("Community settings updated");
         onSaved();
-
-        // Sync profile to PDS in the background if active
-        if (org.pds_status === "active" && org.bluesky_did) {
-          supabase.functions
-            .invoke("sync-community-profile", {
-              body: { communityId: org.id },
-            })
-            .catch(() => {
-              // Non-blocking — don't fail the save
-            });
-        }
+        syncProfileToPds();
       } else {
         toast.error(result.error);
       }

--- a/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/settings/page.tsx
@@ -790,7 +790,7 @@ function BlueskyIdentityCard({
   const supabase = useSupabase();
   const [isProvisioning, startProvisionTransition] = useTransition();
 
-  const isActive = pdsStatus === "active" && did;
+  const isActive = pdsStatus === "active" && !!did;
   const isFailed = pdsStatus === "failed";
   const isPending = !pdsStatus || pdsStatus === "pending";
 

--- a/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/settings/page.tsx
@@ -22,6 +22,7 @@ import {
 import { socialPlatformLabels } from "@trainers/utils";
 
 import { useSupabaseQuery, useSupabase } from "@/lib/supabase";
+import { StatusBadge } from "@/components/ui/status-badge";
 import { cn } from "@/lib/utils";
 import { updateOrganization } from "@/actions/communities";
 import {
@@ -830,12 +831,7 @@ function BlueskyIdentityCard({
     <DashboardCard label="Bluesky Identity">
       {isActive ? (
         <div className="space-y-3">
-          <div className="flex items-center gap-2">
-            <div className="bg-emerald-500/20 h-2 w-2 rounded-full">
-              <div className="bg-emerald-500 h-2 w-2 animate-pulse rounded-full" />
-            </div>
-            <span className="text-sm font-medium">Active on network</span>
-          </div>
+          <StatusBadge status="active" label="Active on network" />
 
           <div className="space-y-2">
             <div className="flex items-center justify-between">

--- a/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/settings/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/community/[communitySlug]/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition, useRef, use } from "react";
 import Link from "next/link";
-import { Camera, Loader2, X, Plus, ImageIcon } from "lucide-react";
+import { Camera, Loader2, X, Plus, ImageIcon, ExternalLink } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { MarkdownContent } from "@/components/ui/markdown-content";
 import { toast } from "sonner";
@@ -21,7 +21,7 @@ import {
 } from "@trainers/validators";
 import { socialPlatformLabels } from "@trainers/utils";
 
-import { useSupabaseQuery } from "@/lib/supabase";
+import { useSupabaseQuery, useSupabase } from "@/lib/supabase";
 import { cn } from "@/lib/utils";
 import { updateOrganization } from "@/actions/communities";
 import {
@@ -151,12 +151,16 @@ interface SettingsFormProps {
     social_links: unknown;
     logo_url: string | null;
     banner_url: string | null;
+    bluesky_did: string | null;
+    bluesky_handle: string | null;
+    pds_status: string | null;
   };
   communitySlug: string;
   onSaved: () => void;
 }
 
 function SettingsForm({ org, communitySlug, onSaved }: SettingsFormProps) {
+  const supabase = useSupabase();
   const [isPending, startTransition] = useTransition();
   const [isLogoUploading, startLogoTransition] = useTransition();
   const [isBannerUploading, startBannerTransition] = useTransition();
@@ -310,6 +314,17 @@ function SettingsForm({ org, communitySlug, onSaved }: SettingsFormProps) {
       if (result.success) {
         toast.success("Community settings updated");
         onSaved();
+
+        // Sync profile to PDS in the background if active
+        if (org.pds_status === "active" && org.bluesky_did) {
+          supabase.functions
+            .invoke("sync-community-profile", {
+              body: { communityId: org.id },
+            })
+            .catch(() => {
+              // Non-blocking — don't fail the save
+            });
+        }
       } else {
         toast.error(result.error);
       }
@@ -471,6 +486,16 @@ function SettingsForm({ org, communitySlug, onSaved }: SettingsFormProps) {
           />
         </DashboardCard>
       </div>
+
+      {/* Bluesky Identity card — full width */}
+      <BlueskyIdentityCard
+        communityId={org.id}
+        handle={org.bluesky_handle}
+        did={org.bluesky_did}
+        pdsStatus={org.pds_status}
+        slug={org.slug}
+        onProvisioned={onSaved}
+      />
 
       {/* About section — full width below */}
       <DashboardCard label="About">
@@ -733,5 +758,143 @@ function SocialLinksEditor({
         Add link
       </button>
     </div>
+  );
+}
+
+// ============================================================================
+// Bluesky Identity Card
+// ============================================================================
+
+interface BlueskyIdentityCardProps {
+  communityId: number;
+  handle: string | null;
+  did: string | null;
+  pdsStatus: string | null;
+  slug: string;
+  onProvisioned: () => void;
+}
+
+function BlueskyIdentityCard({
+  communityId,
+  handle,
+  did,
+  pdsStatus,
+  slug,
+  onProvisioned,
+}: BlueskyIdentityCardProps) {
+  const supabase = useSupabase();
+  const [isProvisioning, startProvisionTransition] = useTransition();
+
+  const isActive = pdsStatus === "active" && did;
+  const isFailed = pdsStatus === "failed";
+  const isPending = !pdsStatus || pdsStatus === "pending";
+
+  const handleProvision = () => {
+    startProvisionTransition(async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      if (!session?.access_token) {
+        toast.error("You must be logged in to enable Bluesky identity");
+        return;
+      }
+
+      const { data, error } = await supabase.functions.invoke(
+        "provision-community-pds",
+        {
+          body: { communityId },
+        }
+      );
+
+      if (error) {
+        toast.error("Failed to create Bluesky identity");
+        return;
+      }
+
+      if (data?.success) {
+        toast.success(`Bluesky identity created: @${data.handle}`);
+        onProvisioned();
+      } else {
+        toast.error(data?.error || "Failed to create Bluesky identity");
+      }
+    });
+  };
+
+  return (
+    <DashboardCard label="Bluesky Identity">
+      {isActive ? (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <div className="bg-emerald-500/20 h-2 w-2 rounded-full">
+              <div className="bg-emerald-500 h-2 w-2 animate-pulse rounded-full" />
+            </div>
+            <span className="text-sm font-medium">Active on network</span>
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground text-sm">Handle</span>
+              <a
+                href={`https://bsky.app/profile/${handle}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary inline-flex items-center gap-1 text-sm font-medium hover:underline"
+              >
+                @{handle}
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground text-sm">DID</span>
+              <span className="text-muted-foreground max-w-[200px] truncate font-mono text-xs">
+                {did}
+              </span>
+            </div>
+          </div>
+
+          <p className="text-muted-foreground text-xs">
+            Your community&apos;s profile on Bluesky syncs automatically when
+            you update your name, logo, or description.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <p className="text-muted-foreground text-sm">
+            Give your community a presence on the Bluesky network. Anyone on
+            Bluesky will be able to find and follow{" "}
+            <span className="text-foreground font-medium">
+              @{slug}.trainers.gg
+            </span>
+            .
+          </p>
+
+          {isFailed && (
+            <p className="text-destructive text-xs">
+              Previous attempt failed. You can try again.
+            </p>
+          )}
+
+          <Button
+            onClick={handleProvision}
+            disabled={isProvisioning}
+            variant="outline"
+            size="sm"
+          >
+            {isProvisioning && (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            )}
+            {isFailed ? "Retry" : "Enable Bluesky Identity"}
+          </Button>
+
+          {isPending && (
+            <p className="text-muted-foreground text-xs">
+              This will create an AT Protocol account on trainers.gg&apos;s PDS
+              with the handle @{slug}.trainers.gg.
+            </p>
+          )}
+        </div>
+      )}
+    </DashboardCard>
   );
 }

--- a/apps/web/src/components/communities/community-card.tsx
+++ b/apps/web/src/components/communities/community-card.tsx
@@ -24,7 +24,7 @@ export function CommunityCard({ community }: CommunityCardProps) {
       }>)
     : [];
 
-  // Build combined social icons: discord_invite_url (if present and not already in social_links) + social_links
+  // Build combined social icons: discord_invite_url (if present and not already in social_links) + social_links + bluesky
   const hasDiscordInSocials = socialLinks.some(
     (link) => link.platform === "discord"
   );
@@ -38,6 +38,14 @@ export function CommunityCard({ community }: CommunityCardProps) {
         ]
       : []),
     ...socialLinks,
+    ...(community.bluesky_handle
+      ? [
+          {
+            platform: "bluesky" as SocialLinkPlatform,
+            url: `https://bsky.app/profile/${community.bluesky_handle}`,
+          },
+        ]
+      : []),
   ];
 
   return (

--- a/apps/web/src/components/communities/community-card.tsx
+++ b/apps/web/src/components/communities/community-card.tsx
@@ -24,9 +24,12 @@ export function CommunityCard({ community }: CommunityCardProps) {
       }>)
     : [];
 
-  // Build combined social icons: discord_invite_url (if present and not already in social_links) + social_links + bluesky
+  // Build combined social icons: discord_invite_url (if not already in social_links) + social_links + bluesky (if not already in social_links)
   const hasDiscordInSocials = socialLinks.some(
     (link) => link.platform === "discord"
+  );
+  const hasBlueskyInSocials = socialLinks.some(
+    (link) => link.platform === "bluesky"
   );
   const allSocialLinks = [
     ...(!hasDiscordInSocials && community.discord_invite_url
@@ -38,7 +41,7 @@ export function CommunityCard({ community }: CommunityCardProps) {
         ]
       : []),
     ...socialLinks,
-    ...(community.bluesky_handle
+    ...(!hasBlueskyInSocials && community.bluesky_handle
       ? [
           {
             platform: "bluesky" as SocialLinkPlatform,

--- a/packages/supabase/jest.config.ts
+++ b/packages/supabase/jest.config.ts
@@ -12,11 +12,14 @@ const config: Config = createConfig({
   ],
   testPathIgnorePatterns: [
     "/node_modules/",
-    // These tests use Deno-specific imports (jsr:, npm:) and must run with Deno
+    // These tests use Deno-specific imports (jsr:, npm:) that need special resolution
     "<rootDir>/supabase/functions/_shared/__tests__/cache.test.ts",
     "<rootDir>/supabase/functions/_shared/__tests__/pds.test.ts",
-    "<rootDir>/supabase/functions/update-pds-handle/__tests__/",
   ],
+  moduleNameMapper: {
+    // Map Deno-specific import specifiers to identity (they're jest.mock'd in tests)
+    "^jsr:@supabase/supabase-js@2$": "<rootDir>/src/__mocks__/supabase-js.ts",
+  },
   collectCoverageFrom: [
     "src/**/*.ts",
     // Exclude Edge Functions from coverage - they run in Deno, not Jest

--- a/packages/supabase/src/__mocks__/supabase-js.ts
+++ b/packages/supabase/src/__mocks__/supabase-js.ts
@@ -1,0 +1,3 @@
+// Stub module for jsr:@supabase/supabase-js@2 moduleNameMapper.
+// The actual mock implementation is defined inline via jest.mock() in each test file.
+export const createClient = jest.fn();

--- a/packages/supabase/src/mutations/__tests__/communities.test.ts
+++ b/packages/supabase/src/mutations/__tests__/communities.test.ts
@@ -57,7 +57,7 @@ describe("Community Mutations", () => {
       logoUrl: "https://test.org/logo.png",
     };
 
-    // Helper: mock a successful create flow (slug check + insert + staff insert)
+    // Helper: mock a successful create flow (slug check + pds_handles check + insert + staff insert)
     function mockSuccessfulCreate(
       fromSpy: jest.SpyInstance,
       overrides?: Partial<ReturnType<typeof organizationFactory.build>>
@@ -68,11 +68,18 @@ describe("Community Mutations", () => {
         ...overrides,
       });
 
-      // Check slug uniqueness
+      // Check slug uniqueness (communities table)
       fromSpy.mockReturnValueOnce({
         select: jest.fn().mockReturnThis(),
         eq: jest.fn().mockReturnThis(),
         single: jest.fn().mockResolvedValue({ data: null, error: null }),
+      } as unknown as MockQueryBuilder);
+
+      // Check pds_handles namespace collision
+      fromSpy.mockReturnValueOnce({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
       } as unknown as MockQueryBuilder);
 
       // Create community
@@ -178,6 +185,13 @@ describe("Community Mutations", () => {
           single: jest.fn().mockResolvedValue({ data: null, error: null }),
         } as unknown as MockQueryBuilder);
 
+        // pds_handles namespace check
+        fromSpy.mockReturnValueOnce({
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+        } as unknown as MockQueryBuilder);
+
         await expect(
           createCommunity(mockClient, {
             ...communityData,
@@ -196,6 +210,13 @@ describe("Community Mutations", () => {
         select: jest.fn().mockReturnThis(),
         eq: eqMock,
         single: jest.fn().mockResolvedValue({ data: null, error: null }),
+      } as unknown as MockQueryBuilder);
+
+      // pds_handles namespace check
+      fromSpy.mockReturnValueOnce({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
       } as unknown as MockQueryBuilder);
 
       const insertMock = jest.fn().mockReturnThis();
@@ -254,6 +275,13 @@ describe("Community Mutations", () => {
         select: jest.fn().mockReturnThis(),
         eq: jest.fn().mockReturnThis(),
         single: jest.fn().mockResolvedValue({ data: null, error: null }),
+      } as unknown as MockQueryBuilder);
+
+      // pds_handles namespace check
+      fromSpy.mockReturnValueOnce({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
       } as unknown as MockQueryBuilder);
 
       const dbError = new Error("Database error");

--- a/packages/supabase/src/mutations/__tests__/communities.test.ts
+++ b/packages/supabase/src/mutations/__tests__/communities.test.ts
@@ -268,6 +268,31 @@ describe("Community Mutations", () => {
       );
     });
 
+    it("should throw error if handle already taken in PDS namespace", async () => {
+      const fromSpy = jest.spyOn(mockClient, "from");
+
+      // Slug check passes (no community with that slug)
+      fromSpy.mockReturnValueOnce({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({ data: null, error: null }),
+      } as unknown as MockQueryBuilder);
+
+      // pds_handles check returns an existing handle
+      fromSpy.mockReturnValueOnce({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        maybeSingle: jest.fn().mockResolvedValue({
+          data: { handle: "test-org.trainers.gg" },
+          error: null,
+        }),
+      } as unknown as MockQueryBuilder);
+
+      await expect(createCommunity(mockClient, communityData)).rejects.toThrow(
+        "This name is already taken on the Bluesky network"
+      );
+    });
+
     it("should propagate database errors", async () => {
       const fromSpy = jest.spyOn(mockClient, "from");
 

--- a/packages/supabase/src/mutations/communities.ts
+++ b/packages/supabase/src/mutations/communities.ts
@@ -111,6 +111,19 @@ export async function createCommunity(
     throw new Error("Community slug is already taken");
   }
 
+  // Check slug against shared PDS handle namespace (users + communities)
+  const { data: existingHandle } = await supabase
+    .from("pds_handles")
+    .select("handle")
+    .eq("handle", `${data.slug.toLowerCase()}.trainers.gg`)
+    .maybeSingle();
+
+  if (existingHandle) {
+    throw new Error(
+      "This name is already taken on the Bluesky network"
+    );
+  }
+
   // Validate social links if provided
   let validatedLinks: CommunitySocialLink[] = [];
   if (data.socialLinks) {

--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -1,11 +1,3 @@
-
-> @thatguyinabeanie/trainers.gg@ supabase /Users/beanie/source/trainers.gg-communities-bsky
-> pnpm --filter=@trainers/supabase run supabase gen types --lang=typescript --local
-
-
-> @trainers/supabase@0.0.1 supabase /Users/beanie/source/trainers.gg-communities-bsky/packages/supabase
-> supabase gen types --lang=typescript --local
-
 export type Json =
   | string
   | number
@@ -3699,6 +3691,7 @@ export type Database = {
         }
         Returns: string
       }
+      vault_read_secret: { Args: { secret_name: string }; Returns: string }
     }
     Enums: {
       announcement_type: "info" | "warning" | "error" | "success"

--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -1,3 +1,11 @@
+
+> @thatguyinabeanie/trainers.gg@ supabase /Users/beanie/source/trainers.gg-communities-bsky
+> pnpm --filter=@trainers/supabase run supabase gen types --lang=typescript --local
+
+
+> @trainers/supabase@0.0.1 supabase /Users/beanie/source/trainers.gg-communities-bsky/packages/supabase
+> supabase gen types --lang=typescript --local
+
 export type Json =
   | string
   | number
@@ -285,6 +293,8 @@ export type Database = {
         Row: {
           about: string | null
           banner_url: string | null
+          bluesky_did: string | null
+          bluesky_handle: string | null
           created_at: string | null
           description: string | null
           discord_invite_url: string | null
@@ -295,6 +305,7 @@ export type Database = {
           logo_url: string | null
           name: string
           owner_user_id: string
+          pds_status: Database["public"]["Enums"]["pds_account_status"] | null
           platform_fee_percentage: number | null
           slug: string
           social_links: Json
@@ -310,6 +321,8 @@ export type Database = {
         Insert: {
           about?: string | null
           banner_url?: string | null
+          bluesky_did?: string | null
+          bluesky_handle?: string | null
           created_at?: string | null
           description?: string | null
           discord_invite_url?: string | null
@@ -320,6 +333,7 @@ export type Database = {
           logo_url?: string | null
           name: string
           owner_user_id: string
+          pds_status?: Database["public"]["Enums"]["pds_account_status"] | null
           platform_fee_percentage?: number | null
           slug: string
           social_links?: Json
@@ -335,6 +349,8 @@ export type Database = {
         Update: {
           about?: string | null
           banner_url?: string | null
+          bluesky_did?: string | null
+          bluesky_handle?: string | null
           created_at?: string | null
           description?: string | null
           discord_invite_url?: string | null
@@ -345,6 +361,7 @@ export type Database = {
           logo_url?: string | null
           name?: string
           owner_user_id?: string
+          pds_status?: Database["public"]["Enums"]["pds_account_status"] | null
           platform_fee_percentage?: number | null
           slug?: string
           social_links?: Json
@@ -1533,6 +1550,30 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      pds_handles: {
+        Row: {
+          created_at: string
+          did: string | null
+          entity_id: string
+          entity_type: string
+          handle: string
+        }
+        Insert: {
+          created_at?: string
+          did?: string | null
+          entity_id: string
+          entity_type: string
+          handle: string
+        }
+        Update: {
+          created_at?: string
+          did?: string | null
+          entity_id?: string
+          entity_type?: string
+          handle?: string
+        }
+        Relationships: []
       }
       permissions: {
         Row: {

--- a/packages/supabase/supabase/functions/provision-all-communities/index.ts
+++ b/packages/supabase/supabase/functions/provision-all-communities/index.ts
@@ -63,14 +63,15 @@ Deno.serve(async (req) => {
         );
       }
 
-      // Check if user is a site admin
-      const { data: userData } = await supabaseAdmin
-        .from("users")
-        .select("role")
-        .eq("id", user.id)
+      // Check if user is a site admin via user_roles + roles
+      const { data: adminRole } = await supabaseAdmin
+        .from("user_roles")
+        .select("role_id, roles!inner(name)")
+        .eq("user_id", user.id)
+        .eq("roles.name", "site_admin")
         .maybeSingle();
 
-      if (userData?.role !== "admin") {
+      if (!adminRole) {
         return new Response(
           JSON.stringify({ success: false, error: "Admin access required" }),
           { status: 403, headers: { ...cors, "Content-Type": "application/json" } }
@@ -166,22 +167,36 @@ Deno.serve(async (req) => {
 
         // Store password in Vault
         const secretName = `pds_password_community_${community.id}`;
-        await supabaseAdmin.rpc("vault_create_secret", {
+        const { error: vaultError } = await supabaseAdmin.rpc("vault_create_secret", {
           secret_value: pdsPassword,
           secret_name: secretName,
           secret_description: `PDS password for community ${community.name} (${community.id})`,
         });
 
+        if (vaultError) {
+          await supabaseAdmin.from("communities").update({ bluesky_did: pdsResult.did, bluesky_handle: handle, pds_status: "failed" }).eq("id", community.id);
+          result.error = `Vault storage failed: ${vaultError.message}`;
+          results.push(result);
+          continue;
+        }
+
         // Register in pds_handles
-        await supabaseAdmin.from("pds_handles").insert({
+        const { error: registryError } = await supabaseAdmin.from("pds_handles").insert({
           handle,
           entity_type: "community",
           entity_id: community.id.toString(),
           did: pdsResult.did,
         });
 
+        if (registryError) {
+          await supabaseAdmin.from("communities").update({ bluesky_did: pdsResult.did, bluesky_handle: handle, pds_status: "failed" }).eq("id", community.id);
+          result.error = `Registry insert failed: ${registryError.message}`;
+          results.push(result);
+          continue;
+        }
+
         // Update community record
-        await supabaseAdmin
+        const { error: updateError } = await supabaseAdmin
           .from("communities")
           .update({
             bluesky_did: pdsResult.did,
@@ -189,6 +204,12 @@ Deno.serve(async (req) => {
             pds_status: "active",
           })
           .eq("id", community.id);
+
+        if (updateError) {
+          result.error = `Community update failed: ${updateError.message}`;
+          results.push(result);
+          continue;
+        }
 
         result.success = true;
         result.did = pdsResult.did;

--- a/packages/supabase/supabase/functions/provision-all-communities/index.ts
+++ b/packages/supabase/supabase/functions/provision-all-communities/index.ts
@@ -1,0 +1,220 @@
+// Provision All Communities PDS Edge Function
+// One-time admin operation to batch-provision PDS accounts for all existing communities.
+//
+// Authentication: Requires service-role key (admin-only operation)
+//
+// Call after deploying the pds_handles migration to provision existing communities.
+// Safe to re-run — skips communities that already have active PDS accounts.
+
+import { createClient } from "jsr:@supabase/supabase-js@2";
+import { getCorsHeaders } from "../_shared/cors.ts";
+import {
+  createPdsInviteCode,
+  createPdsAccount,
+  checkPdsHandleAvailable,
+  generateSecurePassword,
+  generateHandle,
+  PDS_CONFIG,
+} from "../_shared/pds.ts";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+interface ProvisionResult {
+  communityId: number;
+  slug: string;
+  handle: string;
+  success: boolean;
+  did?: string;
+  error?: string;
+}
+
+Deno.serve(async (req) => {
+  const cors = getCorsHeaders(req);
+
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: cors });
+  }
+
+  try {
+    // Require service-role key — this is an admin-only operation
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+      return new Response(
+        JSON.stringify({ success: false, error: "Missing authorization" }),
+        { status: 401, headers: { ...cors, "Content-Type": "application/json" } }
+      );
+    }
+
+    const token = authHeader.replace("Bearer ", "");
+
+    // Verify it's the service role key (not a user JWT)
+    if (token !== SUPABASE_SERVICE_ROLE_KEY) {
+      // If it's a user JWT, verify it's a site admin
+      const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+        auth: { autoRefreshToken: false, persistSession: false },
+      });
+
+      const { data: { user }, error: userError } = await supabaseAdmin.auth.getUser(token);
+      if (userError || !user) {
+        return new Response(
+          JSON.stringify({ success: false, error: "Unauthorized" }),
+          { status: 401, headers: { ...cors, "Content-Type": "application/json" } }
+        );
+      }
+
+      // Check if user is a site admin
+      const { data: userData } = await supabaseAdmin
+        .from("users")
+        .select("role")
+        .eq("id", user.id)
+        .maybeSingle();
+
+      if (userData?.role !== "admin") {
+        return new Response(
+          JSON.stringify({ success: false, error: "Admin access required" }),
+          { status: 403, headers: { ...cors, "Content-Type": "application/json" } }
+        );
+      }
+    }
+
+    // Check PDS is configured
+    if (!PDS_CONFIG.hasAdminPassword) {
+      return new Response(
+        JSON.stringify({ success: false, error: "PDS is not configured" }),
+        { status: 500, headers: { ...cors, "Content-Type": "application/json" } }
+      );
+    }
+
+    const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    // Fetch all communities that don't have an active PDS account
+    const { data: communities, error: fetchError } = await supabaseAdmin
+      .from("communities")
+      .select("id, slug, name")
+      .or("pds_status.is.null,pds_status.neq.active");
+
+    if (fetchError) {
+      return new Response(
+        JSON.stringify({ success: false, error: fetchError.message }),
+        { status: 500, headers: { ...cors, "Content-Type": "application/json" } }
+      );
+    }
+
+    if (!communities || communities.length === 0) {
+      return new Response(
+        JSON.stringify({ success: true, message: "All communities already provisioned", results: [] }),
+        { status: 200, headers: { ...cors, "Content-Type": "application/json" } }
+      );
+    }
+
+    const results: ProvisionResult[] = [];
+
+    for (const community of communities) {
+      const handle = generateHandle(community.slug);
+      const result: ProvisionResult = {
+        communityId: community.id,
+        slug: community.slug,
+        handle,
+        success: false,
+      };
+
+      try {
+        // Check handle availability
+        const available = await checkPdsHandleAvailable(handle);
+        if (!available) {
+          result.error = `Handle @${handle} already taken on PDS`;
+          results.push(result);
+          continue;
+        }
+
+        // Check registry
+        const { data: existingHandle } = await supabaseAdmin
+          .from("pds_handles")
+          .select("handle")
+          .eq("handle", handle)
+          .maybeSingle();
+
+        if (existingHandle) {
+          result.error = `Handle @${handle} already in registry`;
+          results.push(result);
+          continue;
+        }
+
+        // Generate password
+        const pdsPassword = generateSecurePassword(32);
+
+        // Create invite code
+        const inviteCode = await createPdsInviteCode();
+        if (!inviteCode) {
+          result.error = "Failed to create invite code";
+          results.push(result);
+          continue;
+        }
+
+        // Create PDS account
+        const communityEmail = `community-${community.slug}@trainers.gg`;
+        const pdsResult = await createPdsAccount(handle, communityEmail, pdsPassword, inviteCode);
+
+        if ("error" in pdsResult) {
+          result.error = pdsResult.error;
+          results.push(result);
+          continue;
+        }
+
+        // Store password in Vault
+        const secretName = `pds_password_community_${community.id}`;
+        await supabaseAdmin.rpc("vault_create_secret", {
+          secret_value: pdsPassword,
+          secret_name: secretName,
+          secret_description: `PDS password for community ${community.name} (${community.id})`,
+        });
+
+        // Register in pds_handles
+        await supabaseAdmin.from("pds_handles").insert({
+          handle,
+          entity_type: "community",
+          entity_id: community.id.toString(),
+          did: pdsResult.did,
+        });
+
+        // Update community record
+        await supabaseAdmin
+          .from("communities")
+          .update({
+            bluesky_did: pdsResult.did,
+            bluesky_handle: handle,
+            pds_status: "active",
+          })
+          .eq("id", community.id);
+
+        result.success = true;
+        result.did = pdsResult.did;
+      } catch (error) {
+        result.error = error instanceof Error ? error.message : "Unknown error";
+      }
+
+      results.push(result);
+    }
+
+    const successCount = results.filter((r) => r.success).length;
+    const failCount = results.filter((r) => !r.success).length;
+
+    return new Response(
+      JSON.stringify({
+        success: failCount === 0,
+        message: `Provisioned ${successCount}/${results.length} communities${failCount > 0 ? ` (${failCount} failed)` : ""}`,
+        results,
+      }),
+      { status: 200, headers: { ...cors, "Content-Type": "application/json" } }
+    );
+  } catch (error) {
+    console.error("Batch provision error:", error);
+    return new Response(
+      JSON.stringify({ success: false, error: "Unexpected error" }),
+      { status: 500, headers: { ...cors, "Content-Type": "application/json" } }
+    );
+  }
+});

--- a/packages/supabase/supabase/functions/provision-community-pds/index.ts
+++ b/packages/supabase/supabase/functions/provision-community-pds/index.ts
@@ -291,7 +291,7 @@ Deno.serve(async (req) => {
       );
     }
 
-    // Register in pds_handles registry
+    // Register in pds_handles registry (fatal — without this the namespace uniqueness guarantee is broken)
     const { error: registryError } = await supabaseAdmin.from("pds_handles").insert({
       handle,
       entity_type: "community",
@@ -301,8 +301,33 @@ Deno.serve(async (req) => {
 
     if (registryError) {
       console.error("Failed to register handle in registry:", registryError);
-      // Non-fatal — the handle is already on the PDS, we just failed to record it locally
-      // Continue and update the community record
+
+      // Unique violation means this handle/entity is already registered — treat as HANDLE_TAKEN
+      if (registryError.code === "23505") {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: `The handle @${handle} is already registered`,
+            code: "HANDLE_TAKEN",
+          } satisfies ProvisionCommunityPdsResponse),
+          {
+            status: 409,
+            headers: { ...cors, "Content-Type": "application/json" },
+          }
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "Failed to register handle in namespace registry",
+          code: "DB_UPDATE_FAILED",
+        } satisfies ProvisionCommunityPdsResponse),
+        {
+          status: 500,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
     }
 
     // Update community record with DID and status

--- a/packages/supabase/supabase/functions/provision-community-pds/index.ts
+++ b/packages/supabase/supabase/functions/provision-community-pds/index.ts
@@ -85,18 +85,27 @@ Deno.serve(async (req) => {
       error: userError,
     } = await supabaseAdmin.auth.getUser(jwt);
 
+    // Service-role bypass — admin actions invoke this with service-role client
+    let isServiceRole = false;
     if (userError || !user) {
-      return new Response(
-        JSON.stringify({
-          success: false,
-          error: "Invalid or expired token",
-          code: "UNAUTHORIZED",
-        } satisfies ProvisionCommunityPdsResponse),
-        {
-          status: 401,
-          headers: { ...cors, "Content-Type": "application/json" },
-        }
-      );
+      try {
+        const payload = JSON.parse(atob(jwt.split(".")[1]));
+        isServiceRole = payload.role === "service_role";
+      } catch { /* not a valid JWT */ }
+
+      if (!isServiceRole) {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: "Invalid or expired token",
+            code: "UNAUTHORIZED",
+          } satisfies ProvisionCommunityPdsResponse),
+          {
+            status: 401,
+            headers: { ...cors, "Content-Type": "application/json" },
+          }
+        );
+      }
     }
 
     // Parse request body
@@ -153,19 +162,21 @@ Deno.serve(async (req) => {
       );
     }
 
-    // Only the community owner can provision the PDS account
-    if (community.owner_user_id !== user.id) {
-      return new Response(
-        JSON.stringify({
-          success: false,
-          error: "Only the community owner can enable Bluesky identity",
-          code: "UNAUTHORIZED",
-        } satisfies ProvisionCommunityPdsResponse),
-        {
-          status: 403,
-          headers: { ...cors, "Content-Type": "application/json" },
-        }
-      );
+    // Only the community owner can provision the PDS account (skip for service-role)
+    if (!isServiceRole) {
+      if (!user || community.owner_user_id !== user.id) {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: "Only the community owner can enable Bluesky identity",
+            code: "UNAUTHORIZED",
+          } satisfies ProvisionCommunityPdsResponse),
+          {
+            status: 403,
+            headers: { ...cors, "Content-Type": "application/json" },
+          }
+        );
+      }
     }
 
     // Check if already provisioned
@@ -188,134 +199,42 @@ Deno.serve(async (req) => {
       console.log(`Retrying PDS provisioning for community ${communityId}`);
     }
 
-    // Generate handle from community slug and check availability
+    // Generate handle from community slug
     const handle = generateHandle(community.slug);
-    const handleAvailable = await checkPdsHandleAvailable(handle);
 
-    if (!handleAvailable) {
-      return new Response(
-        JSON.stringify({
-          success: false,
-          error: `The handle @${handle} is already taken on Bluesky`,
-          code: "HANDLE_TAKEN",
-        } satisfies ProvisionCommunityPdsResponse),
-        {
-          status: 409,
-          headers: { ...cors, "Content-Type": "application/json" },
-        }
-      );
-    }
+    // Resume flow: if community already has a DID from a previous failed attempt,
+    // skip account creation and re-run the post-creation steps (which are idempotent)
+    let pdsResultDid: string;
 
-    // Also check the pds_handles registry for namespace collisions
-    const { data: existingHandle } = await supabaseAdmin
-      .from("pds_handles")
-      .select("handle")
-      .eq("handle", handle)
-      .maybeSingle();
+    if (community.bluesky_did) {
+      console.log(`Resuming provisioning for community ${communityId} with existing DID ${community.bluesky_did}`);
+      pdsResultDid = community.bluesky_did;
+    } else {
+      // Fresh provisioning: check handle availability and create account
+      const handleAvailable = await checkPdsHandleAvailable(handle);
 
-    if (existingHandle) {
-      return new Response(
-        JSON.stringify({
-          success: false,
-          error: `The handle @${handle} is already registered`,
-          code: "HANDLE_TAKEN",
-        } satisfies ProvisionCommunityPdsResponse),
-        {
-          status: 409,
-          headers: { ...cors, "Content-Type": "application/json" },
-        }
-      );
-    }
+      if (!handleAvailable) {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: `The handle @${handle} is already taken on Bluesky`,
+            code: "HANDLE_TAKEN",
+          } satisfies ProvisionCommunityPdsResponse),
+          {
+            status: 409,
+            headers: { ...cors, "Content-Type": "application/json" },
+          }
+        );
+      }
 
-    // Generate secure random password (community never needs it directly)
-    const pdsPassword = generateSecurePassword(32);
+      // Also check the pds_handles registry for namespace collisions
+      const { data: existingHandle } = await supabaseAdmin
+        .from("pds_handles")
+        .select("handle")
+        .eq("handle", handle)
+        .maybeSingle();
 
-    // Create invite code
-    const inviteCode = await createPdsInviteCode();
-    if (!inviteCode) {
-      return new Response(
-        JSON.stringify({
-          success: false,
-          error: "Failed to create PDS invite code",
-          code: "PDS_ERROR",
-        } satisfies ProvisionCommunityPdsResponse),
-        {
-          status: 500,
-          headers: { ...cors, "Content-Type": "application/json" },
-        }
-      );
-    }
-
-    // Create PDS account
-    // Use a synthetic email for the community (not tied to any user)
-    const communityEmail = `community-${community.slug}@trainers.gg`;
-
-    const pdsResult = await createPdsAccount(handle, communityEmail, pdsPassword, inviteCode);
-
-    if ("error" in pdsResult) {
-      console.error("PDS account creation failed for community:", pdsResult.error);
-      return new Response(
-        JSON.stringify({
-          success: false,
-          error: pdsResult.error,
-          code: "PDS_ERROR",
-        } satisfies ProvisionCommunityPdsResponse),
-        {
-          status: 500,
-          headers: { ...cors, "Content-Type": "application/json" },
-        }
-      );
-    }
-
-    // Store password in Vault (needed for profile sync and future posting)
-    const secretName = `pds_password_community_${communityId}`;
-    const { error: vaultError } = await supabaseAdmin.rpc("vault_create_secret", {
-      secret_value: pdsPassword,
-      secret_name: secretName,
-      secret_description: `PDS password for community ${community.name} (${communityId})`,
-    });
-
-    if (vaultError) {
-      console.error("Failed to store community PDS password in vault:", vaultError);
-
-      // Persist DID with 'failed' status so the community isn't stuck
-      // (retries would otherwise hit HANDLE_TAKEN with no DID recorded)
-      await supabaseAdmin
-        .from("communities")
-        .update({
-          bluesky_did: pdsResult.did,
-          bluesky_handle: handle,
-          pds_status: "failed",
-        })
-        .eq("id", communityId);
-
-      return new Response(
-        JSON.stringify({
-          success: false,
-          error:
-            "PDS account was created but password storage failed. Please contact support.",
-          code: "VAULT_STORAGE_FAILED",
-        } satisfies ProvisionCommunityPdsResponse),
-        {
-          status: 500,
-          headers: { ...cors, "Content-Type": "application/json" },
-        }
-      );
-    }
-
-    // Register in pds_handles registry (fatal — without this the namespace uniqueness guarantee is broken)
-    const { error: registryError } = await supabaseAdmin.from("pds_handles").insert({
-      handle,
-      entity_type: "community",
-      entity_id: communityId.toString(),
-      did: pdsResult.did,
-    });
-
-    if (registryError) {
-      console.error("Failed to register handle in registry:", registryError);
-
-      // Unique violation means this handle/entity is already registered — treat as HANDLE_TAKEN
-      if (registryError.code === "23505") {
+      if (existingHandle) {
         return new Response(
           JSON.stringify({
             success: false,
@@ -329,24 +248,119 @@ Deno.serve(async (req) => {
         );
       }
 
-      return new Response(
-        JSON.stringify({
-          success: false,
-          error: "Failed to register handle in namespace registry",
-          code: "DB_UPDATE_FAILED",
-        } satisfies ProvisionCommunityPdsResponse),
-        {
-          status: 500,
-          headers: { ...cors, "Content-Type": "application/json" },
-        }
-      );
+      // Generate secure random password (community never needs it directly)
+      const pdsPassword = generateSecurePassword(32);
+
+      // Create invite code
+      const inviteCode = await createPdsInviteCode();
+      if (!inviteCode) {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: "Failed to create PDS invite code",
+            code: "PDS_ERROR",
+          } satisfies ProvisionCommunityPdsResponse),
+          {
+            status: 500,
+            headers: { ...cors, "Content-Type": "application/json" },
+          }
+        );
+      }
+
+      // Create PDS account
+      // Use a synthetic email for the community (not tied to any user)
+      const communityEmail = `community-${community.slug}@trainers.gg`;
+
+      const pdsResult = await createPdsAccount(handle, communityEmail, pdsPassword, inviteCode);
+
+      if ("error" in pdsResult) {
+        console.error("PDS account creation failed for community:", pdsResult.error);
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: pdsResult.error,
+            code: "PDS_ERROR",
+          } satisfies ProvisionCommunityPdsResponse),
+          {
+            status: 500,
+            headers: { ...cors, "Content-Type": "application/json" },
+          }
+        );
+      }
+
+      pdsResultDid = pdsResult.did;
+
+      // Store password in Vault (needed for profile sync and future posting)
+      const secretName = `pds_password_community_${communityId}`;
+      const { error: vaultError } = await supabaseAdmin.rpc("vault_create_secret", {
+        secret_value: pdsPassword,
+        secret_name: secretName,
+        secret_description: `PDS password for community ${community.name} (${communityId})`,
+      });
+
+      if (vaultError) {
+        console.error("Failed to store community PDS password in vault:", vaultError);
+
+        // Persist DID with 'failed' status so the community isn't stuck
+        // (retries would otherwise hit HANDLE_TAKEN with no DID recorded)
+        await supabaseAdmin
+          .from("communities")
+          .update({
+            bluesky_did: pdsResultDid,
+            bluesky_handle: handle,
+            pds_status: "failed",
+          })
+          .eq("id", communityId);
+
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error:
+              "PDS account was created but password storage failed. Please contact support.",
+            code: "VAULT_STORAGE_FAILED",
+          } satisfies ProvisionCommunityPdsResponse),
+          {
+            status: 500,
+            headers: { ...cors, "Content-Type": "application/json" },
+          }
+        );
+      }
+    }
+
+    // Register in pds_handles registry (fatal — without this the namespace uniqueness guarantee is broken)
+    const { error: registryError } = await supabaseAdmin.from("pds_handles").insert({
+      handle,
+      entity_type: "community",
+      entity_id: communityId.toString(),
+      did: pdsResultDid,
+    });
+
+    if (registryError) {
+      console.error("Failed to register handle in registry:", registryError);
+
+      // Unique violation means this handle/entity is already registered — treat as success for resume
+      if (registryError.code === "23505") {
+        // Already registered — continue to update step
+      } else {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: "Failed to register handle in namespace registry",
+            code: "DB_UPDATE_FAILED",
+          } satisfies ProvisionCommunityPdsResponse),
+          {
+            status: 500,
+            headers: { ...cors, "Content-Type": "application/json" },
+          }
+        );
+      }
     }
 
     // Update community record with DID and status
     const { error: updateError } = await supabaseAdmin
       .from("communities")
       .update({
-        bluesky_did: pdsResult.did,
+        bluesky_did: pdsResultDid,
         bluesky_handle: handle,
         pds_status: "active",
       })
@@ -377,7 +391,7 @@ Deno.serve(async (req) => {
     return new Response(
       JSON.stringify({
         success: true,
-        did: pdsResult.did,
+        did: pdsResultDid,
         handle,
       } satisfies ProvisionCommunityPdsResponse),
       {

--- a/packages/supabase/supabase/functions/provision-community-pds/index.ts
+++ b/packages/supabase/supabase/functions/provision-community-pds/index.ts
@@ -1,0 +1,366 @@
+// Provision Community PDS Edge Function
+// Creates a PDS account for a community, giving it a Bluesky identity.
+//
+// Flow:
+// 1. Verify JWT and extract user ID
+// 2. Verify user is the community owner
+// 3. Check community doesn't already have a PDS account
+// 4. Generate handle from community slug, check availability
+// 5. Generate secure random password
+// 6. Create PDS invite code + account
+// 7. Store password in Vault
+// 8. Register handle in pds_handles registry
+// 9. Update communities.bluesky_did, bluesky_handle, pds_status
+//
+// Authentication: Requires JWT (only community owner can provision)
+
+import { createClient } from "jsr:@supabase/supabase-js@2";
+import { getCorsHeaders } from "../_shared/cors.ts";
+import {
+  createPdsInviteCode,
+  createPdsAccount,
+  checkPdsHandleAvailable,
+  generateSecurePassword,
+  generateHandle,
+  PDS_CONFIG,
+} from "../_shared/pds.ts";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+interface ProvisionCommunityPdsResponse {
+  success: boolean;
+  did?: string;
+  handle?: string;
+  error?: string;
+  code?:
+    | "HANDLE_TAKEN"
+    | "PDS_ERROR"
+    | "COMMUNITY_NOT_FOUND"
+    | "ALREADY_PROVISIONED"
+    | "UNAUTHORIZED"
+    | "PDS_NOT_CONFIGURED"
+    | "DB_UPDATE_FAILED"
+    | "VAULT_STORAGE_FAILED";
+}
+
+Deno.serve(async (req) => {
+  const cors = getCorsHeaders(req);
+
+  // Handle CORS preflight
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: cors });
+  }
+
+  try {
+    // Get and verify JWT from Authorization header
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "Missing or invalid authorization header",
+          code: "UNAUTHORIZED",
+        } satisfies ProvisionCommunityPdsResponse),
+        {
+          status: 401,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    const jwt = authHeader.replace("Bearer ", "");
+
+    // Create service role client for admin operations
+    const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    });
+
+    // Verify JWT and get user
+    const {
+      data: { user },
+      error: userError,
+    } = await supabaseAdmin.auth.getUser(jwt);
+
+    if (userError || !user) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "Invalid or expired token",
+          code: "UNAUTHORIZED",
+        } satisfies ProvisionCommunityPdsResponse),
+        {
+          status: 401,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Parse request body
+    const body = await req.json();
+    const communityId = body.communityId;
+
+    if (!communityId) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "communityId is required",
+          code: "COMMUNITY_NOT_FOUND",
+        } satisfies ProvisionCommunityPdsResponse),
+        {
+          status: 400,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Check PDS is configured
+    if (!PDS_CONFIG.hasAdminPassword) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "PDS is not configured on this server",
+          code: "PDS_NOT_CONFIGURED",
+        } satisfies ProvisionCommunityPdsResponse),
+        {
+          status: 500,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Fetch community and verify ownership
+    const { data: community, error: fetchError } = await supabaseAdmin
+      .from("communities")
+      .select("id, slug, name, owner_user_id, bluesky_did, pds_status")
+      .eq("id", communityId)
+      .maybeSingle();
+
+    if (fetchError || !community) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "Community not found",
+          code: "COMMUNITY_NOT_FOUND",
+        } satisfies ProvisionCommunityPdsResponse),
+        {
+          status: 404,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Only the community owner can provision the PDS account
+    if (community.owner_user_id !== user.id) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "Only the community owner can enable Bluesky identity",
+          code: "UNAUTHORIZED",
+        } satisfies ProvisionCommunityPdsResponse),
+        {
+          status: 403,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Check if already provisioned
+    if (community.pds_status === "active" && community.bluesky_did) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "Community already has a Bluesky identity",
+          code: "ALREADY_PROVISIONED",
+        } satisfies ProvisionCommunityPdsResponse),
+        {
+          status: 409,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Allow retry for failed provisioning
+    if (community.pds_status === "failed") {
+      console.log(`Retrying PDS provisioning for community ${communityId}`);
+    }
+
+    // Generate handle from community slug and check availability
+    const handle = generateHandle(community.slug);
+    const handleAvailable = await checkPdsHandleAvailable(handle);
+
+    if (!handleAvailable) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: `The handle @${handle} is already taken on Bluesky`,
+          code: "HANDLE_TAKEN",
+        } satisfies ProvisionCommunityPdsResponse),
+        {
+          status: 409,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Also check the pds_handles registry for namespace collisions
+    const { data: existingHandle } = await supabaseAdmin
+      .from("pds_handles")
+      .select("handle")
+      .eq("handle", handle)
+      .maybeSingle();
+
+    if (existingHandle) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: `The handle @${handle} is already registered`,
+          code: "HANDLE_TAKEN",
+        } satisfies ProvisionCommunityPdsResponse),
+        {
+          status: 409,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Generate secure random password (community never needs it directly)
+    const pdsPassword = generateSecurePassword(32);
+
+    // Create invite code
+    const inviteCode = await createPdsInviteCode();
+    if (!inviteCode) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "Failed to create PDS invite code",
+          code: "PDS_ERROR",
+        } satisfies ProvisionCommunityPdsResponse),
+        {
+          status: 500,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Create PDS account
+    // Use a synthetic email for the community (not tied to any user)
+    const communityEmail = `community-${community.slug}@trainers.gg`;
+
+    const pdsResult = await createPdsAccount(handle, communityEmail, pdsPassword, inviteCode);
+
+    if ("error" in pdsResult) {
+      console.error("PDS account creation failed for community:", pdsResult.error);
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: pdsResult.error,
+          code: "PDS_ERROR",
+        } satisfies ProvisionCommunityPdsResponse),
+        {
+          status: 500,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Store password in Vault (needed for profile sync and future posting)
+    const secretName = `pds_password_community_${communityId}`;
+    const { error: vaultError } = await supabaseAdmin.rpc("vault_create_secret", {
+      secret_value: pdsPassword,
+      secret_name: secretName,
+      secret_description: `PDS password for community ${community.name} (${communityId})`,
+    });
+
+    if (vaultError) {
+      console.error("Failed to store community PDS password in vault:", vaultError);
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error:
+            "PDS account was created but password storage failed. Please contact support.",
+          code: "VAULT_STORAGE_FAILED",
+        } satisfies ProvisionCommunityPdsResponse),
+        {
+          status: 500,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Register in pds_handles registry
+    const { error: registryError } = await supabaseAdmin.from("pds_handles").insert({
+      handle,
+      entity_type: "community",
+      entity_id: communityId.toString(),
+      did: pdsResult.did,
+    });
+
+    if (registryError) {
+      console.error("Failed to register handle in registry:", registryError);
+      // Non-fatal — the handle is already on the PDS, we just failed to record it locally
+      // Continue and update the community record
+    }
+
+    // Update community record with DID and status
+    const { error: updateError } = await supabaseAdmin
+      .from("communities")
+      .update({
+        bluesky_did: pdsResult.did,
+        bluesky_handle: handle,
+        pds_status: "active",
+      })
+      .eq("id", communityId);
+
+    if (updateError) {
+      console.error("Failed to update community with DID:", updateError);
+
+      // Mark as failed so owner can retry
+      await supabaseAdmin
+        .from("communities")
+        .update({ pds_status: "failed" })
+        .eq("id", communityId);
+
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "PDS account was created but database update failed. Please try again.",
+          code: "DB_UPDATE_FAILED",
+        } satisfies ProvisionCommunityPdsResponse),
+        {
+          status: 500,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        did: pdsResult.did,
+        handle,
+      } satisfies ProvisionCommunityPdsResponse),
+      {
+        status: 200,
+        headers: { ...cors, "Content-Type": "application/json" },
+      }
+    );
+  } catch (error) {
+    console.error("Provision community PDS error:", error);
+
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: "An unexpected error occurred",
+        code: "PDS_ERROR",
+      } satisfies ProvisionCommunityPdsResponse),
+      {
+        status: 500,
+        headers: { ...cors, "Content-Type": "application/json" },
+      }
+    );
+  }
+});

--- a/packages/supabase/supabase/functions/provision-community-pds/index.ts
+++ b/packages/supabase/supabase/functions/provision-community-pds/index.ts
@@ -85,13 +85,12 @@ Deno.serve(async (req) => {
       error: userError,
     } = await supabaseAdmin.auth.getUser(jwt);
 
-    // Service-role bypass — admin actions invoke this with service-role client
+    // Service-role bypass — admin actions invoke this with service-role client.
+    // We compare the raw bearer token to the known service-role key rather than
+    // decoding JWT claims, which would be forgeable without signature verification.
     let isServiceRole = false;
     if (userError || !user) {
-      try {
-        const payload = JSON.parse(atob(jwt.split(".")[1]));
-        isServiceRole = payload.role === "service_role";
-      } catch { /* not a valid JWT */ }
+      isServiceRole = jwt === SUPABASE_SERVICE_ROLE_KEY;
 
       if (!isServiceRole) {
         return new Response(

--- a/packages/supabase/supabase/functions/provision-community-pds/index.ts
+++ b/packages/supabase/supabase/functions/provision-community-pds/index.ts
@@ -277,6 +277,18 @@ Deno.serve(async (req) => {
 
     if (vaultError) {
       console.error("Failed to store community PDS password in vault:", vaultError);
+
+      // Persist DID with 'failed' status so the community isn't stuck
+      // (retries would otherwise hit HANDLE_TAKEN with no DID recorded)
+      await supabaseAdmin
+        .from("communities")
+        .update({
+          bluesky_did: pdsResult.did,
+          bluesky_handle: handle,
+          pds_status: "failed",
+        })
+        .eq("id", communityId);
+
       return new Response(
         JSON.stringify({
           success: false,

--- a/packages/supabase/supabase/functions/provision-pds/index.ts
+++ b/packages/supabase/supabase/functions/provision-pds/index.ts
@@ -347,8 +347,19 @@ Deno.serve(async (req) => {
       });
 
     if (registryError) {
-      // Log but don't fail — the user is already provisioned
-      console.warn("Failed to register user handle in pds_handles registry:", registryError);
+      console.error("Failed to register user handle in pds_handles registry:", registryError);
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "PDS account was created but registry sync failed. Please retry.",
+          code: "DB_UPDATE_FAILED",
+          did: pdsResult.did,
+        } satisfies ProvisionPdsResponse),
+        {
+          status: 500,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
     }
 
     return new Response(

--- a/packages/supabase/supabase/functions/provision-pds/index.ts
+++ b/packages/supabase/supabase/functions/provision-pds/index.ts
@@ -334,9 +334,9 @@ Deno.serve(async (req) => {
       );
     }
 
-    // Register in pds_handles registry for namespace uniqueness
-    // Non-fatal for user provisioning — the backfill migration handles existing users,
-    // and the user record is the source of truth for users
+    // Register in pds_handles registry for namespace uniqueness.
+    // Fatal — if registry insert fails, the user must retry to ensure
+    // namespace integrity across users and communities.
     const { error: registryError } = await supabaseAdmin
       .from("pds_handles")
       .insert({

--- a/packages/supabase/supabase/functions/provision-pds/index.ts
+++ b/packages/supabase/supabase/functions/provision-pds/index.ts
@@ -334,6 +334,23 @@ Deno.serve(async (req) => {
       );
     }
 
+    // Register in pds_handles registry for namespace uniqueness
+    // Non-fatal for user provisioning — the backfill migration handles existing users,
+    // and the user record is the source of truth for users
+    const { error: registryError } = await supabaseAdmin
+      .from("pds_handles")
+      .insert({
+        handle,
+        entity_type: "user",
+        entity_id: user.id,
+        did: pdsResult.did,
+      });
+
+    if (registryError) {
+      // Log but don't fail — the user is already provisioned
+      console.warn("Failed to register user handle in pds_handles registry:", registryError);
+    }
+
     return new Response(
       JSON.stringify({
         success: true,

--- a/packages/supabase/supabase/functions/sync-community-profile/index.ts
+++ b/packages/supabase/supabase/functions/sync-community-profile/index.ts
@@ -1,0 +1,286 @@
+// Sync Community Profile to PDS Edge Function
+// Pushes community name, description, and avatar to the PDS profile record.
+//
+// Flow:
+// 1. Verify JWT and extract user ID
+// 2. Verify user is the community owner
+// 3. Verify community has an active PDS account
+// 4. Retrieve PDS password from Vault
+// 5. Login to PDS as the community
+// 6. Update app.bsky.actor.profile with current community data
+//
+// Authentication: Requires JWT (only community owner can sync)
+
+import { createClient } from "jsr:@supabase/supabase-js@2";
+import { getCorsHeaders } from "../_shared/cors.ts";
+import { loginPdsAgent } from "../_shared/pds.ts";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+interface SyncProfileResponse {
+  success: boolean;
+  error?: string;
+  code?:
+    | "UNAUTHORIZED"
+    | "COMMUNITY_NOT_FOUND"
+    | "NOT_PROVISIONED"
+    | "PDS_ERROR"
+    | "VAULT_READ_FAILED";
+}
+
+Deno.serve(async (req) => {
+  const cors = getCorsHeaders(req);
+
+  // Handle CORS preflight
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: cors });
+  }
+
+  try {
+    // Get and verify JWT from Authorization header
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "Missing or invalid authorization header",
+          code: "UNAUTHORIZED",
+        } satisfies SyncProfileResponse),
+        {
+          status: 401,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    const jwt = authHeader.replace("Bearer ", "");
+
+    // Create service role client for admin operations
+    const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    });
+
+    // Verify JWT and get user
+    const {
+      data: { user },
+      error: userError,
+    } = await supabaseAdmin.auth.getUser(jwt);
+
+    if (userError || !user) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "Invalid or expired token",
+          code: "UNAUTHORIZED",
+        } satisfies SyncProfileResponse),
+        {
+          status: 401,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Parse request body
+    const body = await req.json();
+    const communityId = body.communityId;
+
+    if (!communityId) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "communityId is required",
+          code: "COMMUNITY_NOT_FOUND",
+        } satisfies SyncProfileResponse),
+        {
+          status: 400,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Fetch community
+    const { data: community, error: fetchError } = await supabaseAdmin
+      .from("communities")
+      .select(
+        "id, slug, name, description, logo_url, owner_user_id, bluesky_did, pds_status"
+      )
+      .eq("id", communityId)
+      .maybeSingle();
+
+    if (fetchError || !community) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "Community not found",
+          code: "COMMUNITY_NOT_FOUND",
+        } satisfies SyncProfileResponse),
+        {
+          status: 404,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Only the community owner can sync
+    if (community.owner_user_id !== user.id) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "Only the community owner can sync the Bluesky profile",
+          code: "UNAUTHORIZED",
+        } satisfies SyncProfileResponse),
+        {
+          status: 403,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Verify community has an active PDS account
+    if (community.pds_status !== "active" || !community.bluesky_did) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "Community does not have an active Bluesky identity",
+          code: "NOT_PROVISIONED",
+        } satisfies SyncProfileResponse),
+        {
+          status: 400,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    // Retrieve PDS password from Vault
+    const secretName = `pds_password_community_${communityId}`;
+    const { data: vaultData, error: vaultError } = await supabaseAdmin.rpc(
+      "vault_read_secret",
+      { secret_name: secretName }
+    );
+
+    if (vaultError || !vaultData) {
+      console.error("Failed to read community PDS password from vault:", vaultError);
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "Failed to retrieve PDS credentials",
+          code: "VAULT_READ_FAILED",
+        } satisfies SyncProfileResponse),
+        {
+          status: 500,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    const pdsPassword = vaultData;
+
+    // Login to PDS as the community
+    const loginResult = await loginPdsAgent(community.bluesky_did, pdsPassword);
+
+    if (!loginResult.success) {
+      console.error("Failed to login as community PDS account:", loginResult.error);
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "Failed to authenticate with PDS",
+          code: "PDS_ERROR",
+        } satisfies SyncProfileResponse),
+        {
+          status: 500,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    const agent = loginResult.agent;
+
+    // Build the profile record
+    // Download avatar blob if community has a logo_url
+    let avatarBlob: { $type: "blob"; ref: { $link: string }; mimeType: string; size: number } | undefined;
+
+    if (community.logo_url) {
+      try {
+        const logoResponse = await fetch(community.logo_url);
+        if (logoResponse.ok) {
+          const logoData = await logoResponse.arrayBuffer();
+          const mimeType = logoResponse.headers.get("content-type") || "image/png";
+
+          // Upload blob to PDS
+          const uploadResult = await agent.uploadBlob(new Uint8Array(logoData), {
+            encoding: mimeType,
+          });
+
+          if (uploadResult.success) {
+            avatarBlob = uploadResult.data.blob;
+          }
+        }
+      } catch (error) {
+        // Non-fatal — continue without avatar
+        console.warn("Failed to upload community avatar to PDS:", error);
+      }
+    }
+
+    // Write the profile record
+    const profileRecord: Record<string, unknown> = {
+      $type: "app.bsky.actor.profile",
+      displayName: community.name.slice(0, 64), // AT Protocol limit
+      description: (community.description || "").slice(0, 256), // AT Protocol limit
+    };
+
+    if (avatarBlob) {
+      profileRecord.avatar = avatarBlob;
+    }
+
+    try {
+      // Use putRecord to create or update the profile
+      await agent.com.atproto.repo.putRecord({
+        repo: community.bluesky_did,
+        collection: "app.bsky.actor.profile",
+        rkey: "self",
+        record: profileRecord,
+      });
+    } catch (error) {
+      console.error("Failed to write profile record to PDS:", error);
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: "Failed to update Bluesky profile",
+          code: "PDS_ERROR",
+        } satisfies SyncProfileResponse),
+        {
+          status: 500,
+          headers: { ...cors, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+      } satisfies SyncProfileResponse),
+      {
+        status: 200,
+        headers: { ...cors, "Content-Type": "application/json" },
+      }
+    );
+  } catch (error) {
+    console.error("Sync community profile error:", error);
+
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: "An unexpected error occurred",
+        code: "PDS_ERROR",
+      } satisfies SyncProfileResponse),
+      {
+        status: 500,
+        headers: { ...cors, "Content-Type": "application/json" },
+      }
+    );
+  }
+});

--- a/packages/supabase/supabase/functions/update-pds-handle/__tests__/index.test.ts
+++ b/packages/supabase/supabase/functions/update-pds-handle/__tests__/index.test.ts
@@ -54,6 +54,28 @@ function createQueryBuilder(data: unknown = null, error: unknown = null) {
   };
 }
 
+// Helper for chainable mocks that are awaited (update/delete chains)
+function createChainableMock(
+  resolvedValue: { data?: unknown; error: unknown } = {
+    data: null,
+    error: null,
+  }
+) {
+  const chain: Record<string, unknown> = {};
+  chain.update = jest.fn().mockReturnValue(chain);
+  chain.delete = jest.fn().mockReturnValue(chain);
+  chain.eq = jest.fn().mockReturnValue(chain);
+  chain.then = (resolve: (val: unknown) => void) => resolve(resolvedValue);
+  return chain;
+}
+
+// Helper for insert mock (returns Promise directly)
+function createInsertMock(error: unknown = null) {
+  return {
+    insert: jest.fn().mockResolvedValue({ data: null, error }),
+  };
+}
+
 // Helper to create mock request
 function createMockRequest(
   method: string,
@@ -69,6 +91,10 @@ function createMockRequest(
 describe("update-pds-handle edge function", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Reset mocks that accumulate state (mockReturnValue/mockRejectedValue)
+    // across test sections — clearAllMocks only clears call history.
+    mockFrom.mockReset();
+    mockUpdateHandle.mockReset();
   });
 
   describe("authentication", () => {
@@ -153,12 +179,15 @@ describe("update-pds-handle edge function", () => {
     });
 
     it("accepts valid usernames", async () => {
-      mockFrom.mockReturnValue(
-        createQueryBuilder(
-          { id: "user-123", pds_status: "active", did: "did:plc:test123" },
-          null
+      mockFrom
+        .mockReturnValueOnce(
+          createQueryBuilder(
+            { id: "user-123", pds_status: "active", did: "did:plc:test123" },
+            null
+          )
         )
-      );
+        .mockReturnValueOnce(createChainableMock()) // users update
+        .mockReturnValueOnce(createInsertMock()); // pds_handles insert (no delete — no old handle)
       (checkPdsHandleAvailable as jest.Mock).mockResolvedValue(true);
       mockRpc.mockResolvedValue({ data: "test-password", error: null });
       (loginPdsAgent as jest.Mock).mockResolvedValue({
@@ -229,17 +258,21 @@ describe("update-pds-handle edge function", () => {
     });
 
     it("accepts users with active PDS and DID", async () => {
-      mockFrom.mockReturnValue(
-        createQueryBuilder(
-          {
-            id: "user-123",
-            pds_status: "active",
-            did: "did:plc:test123",
-            pds_handle: "olduser.trainers.gg",
-          },
-          null
+      mockFrom
+        .mockReturnValueOnce(
+          createQueryBuilder(
+            {
+              id: "user-123",
+              pds_status: "active",
+              did: "did:plc:test123",
+              pds_handle: "olduser.trainers.gg",
+            },
+            null
+          )
         )
-      );
+        .mockReturnValueOnce(createChainableMock()) // users update
+        .mockReturnValueOnce(createChainableMock()) // pds_handles delete
+        .mockReturnValueOnce(createInsertMock()); // pds_handles insert
       (checkPdsHandleAvailable as jest.Mock).mockResolvedValue(true);
       mockRpc.mockResolvedValue({ data: "test-password", error: null });
       (loginPdsAgent as jest.Mock).mockResolvedValue({
@@ -363,6 +396,22 @@ describe("update-pds-handle edge function", () => {
     });
 
     it("retrieves password from vault with correct secret name", async () => {
+      mockFrom
+        .mockReset()
+        .mockReturnValueOnce(
+          createQueryBuilder(
+            {
+              id: "user-123",
+              pds_status: "active",
+              did: "did:plc:test123",
+              pds_handle: "olduser.trainers.gg",
+            },
+            null
+          )
+        )
+        .mockReturnValueOnce(createChainableMock()) // users update
+        .mockReturnValueOnce(createChainableMock()) // pds_handles delete
+        .mockReturnValueOnce(createInsertMock()); // pds_handles insert
       mockRpc.mockResolvedValue({ data: "test-password", error: null });
       (loginPdsAgent as jest.Mock).mockResolvedValue({
         success: true,
@@ -427,6 +476,22 @@ describe("update-pds-handle edge function", () => {
     });
 
     it("calls PDS updateHandle with correct handle", async () => {
+      mockFrom
+        .mockReset()
+        .mockReturnValueOnce(
+          createQueryBuilder(
+            {
+              id: "user-123",
+              pds_status: "active",
+              did: "did:plc:test123",
+              pds_handle: "olduser.trainers.gg",
+            },
+            null
+          )
+        )
+        .mockReturnValueOnce(createChainableMock()) // users update
+        .mockReturnValueOnce(createChainableMock()) // pds_handles delete
+        .mockReturnValueOnce(createInsertMock()); // pds_handles insert
       (loginPdsAgent as jest.Mock).mockResolvedValue({
         success: true,
         agent: {
@@ -518,7 +583,9 @@ describe("update-pds-handle edge function", () => {
         .mockReturnValueOnce({
           update: mockUpdate,
           eq: mockEq,
-        });
+        })
+        .mockReturnValueOnce(createChainableMock()) // pds_handles delete
+        .mockReturnValueOnce(createInsertMock()); // pds_handles insert
 
       const handler = await import("../index.ts");
       const request = createMockRequest("POST", { username: "newuser" });
@@ -532,6 +599,40 @@ describe("update-pds-handle edge function", () => {
       expect(mockEq).toHaveBeenCalledWith("id", "user-123");
       expect(response.status).toBe(200);
       expect(data.success).toBe(true);
+    });
+
+    it("returns 409 if pds_handles insert hits unique violation (race condition)", async () => {
+      const mockUpdate = jest.fn().mockReturnThis();
+      const mockEq = jest.fn().mockResolvedValue({ error: null });
+
+      mockFrom
+        .mockReturnValueOnce(
+          createQueryBuilder(
+            {
+              id: "user-123",
+              pds_status: "active",
+              did: "did:plc:test123",
+              pds_handle: "olduser.trainers.gg",
+            },
+            null
+          )
+        )
+        .mockReturnValueOnce({
+          update: mockUpdate,
+          eq: mockEq,
+        })
+        .mockReturnValueOnce(createChainableMock()) // pds_handles delete
+        .mockReturnValueOnce(createInsertMock({ code: "23505", message: "duplicate key" })); // unique violation
+
+      const handler = await import("../index.ts");
+      const request = createMockRequest("POST", { username: "newuser" });
+
+      const response = await handler.default(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(data.success).toBe(false);
+      expect(data.code).toBe("HANDLE_TAKEN");
     });
 
     it("returns error if database update fails", async () => {

--- a/packages/supabase/supabase/functions/update-pds-handle/index.ts
+++ b/packages/supabase/supabase/functions/update-pds-handle/index.ts
@@ -275,6 +275,28 @@ Deno.serve(async (req) => {
       );
     }
 
+    // Update pds_handles registry: delete old handle, insert new one
+    if (userData.pds_handle) {
+      await supabaseAdmin
+        .from("pds_handles")
+        .delete()
+        .eq("handle", userData.pds_handle);
+    }
+    const { error: registryError } = await supabaseAdmin
+      .from("pds_handles")
+      .upsert(
+        {
+          handle: newHandle,
+          entity_type: "user",
+          entity_id: user.id,
+          did: userData.did,
+        },
+        { onConflict: "handle" }
+      );
+    if (registryError) {
+      console.warn("Failed to update pds_handles registry:", registryError);
+    }
+
     return new Response(
       JSON.stringify({
         success: true,

--- a/packages/supabase/supabase/functions/update-pds-handle/index.ts
+++ b/packages/supabase/supabase/functions/update-pds-handle/index.ts
@@ -39,7 +39,7 @@ interface UpdatePdsHandleResponse {
     | "DB_UPDATE_FAILED";
 }
 
-Deno.serve(async (req) => {
+async function handler(req: Request): Promise<Response> {
   const cors = getCorsHeaders(req);
 
   // Handle CORS preflight
@@ -275,7 +275,9 @@ Deno.serve(async (req) => {
       );
     }
 
-    // Update pds_handles registry: delete old handle, insert new one
+    // Update pds_handles registry: delete old handle, insert new one.
+    // Uses INSERT (not upsert) so a conflicting handle safely fails rather than
+    // overwriting another entity's row in a TOCTOU race.
     if (userData.pds_handle) {
       await supabaseAdmin
         .from("pds_handles")
@@ -285,16 +287,28 @@ Deno.serve(async (req) => {
     }
     const { error: registryError } = await supabaseAdmin
       .from("pds_handles")
-      .upsert(
-        {
-          handle: newHandle,
-          entity_type: "user",
-          entity_id: user.id,
-          did: userData.did,
-        },
-        { onConflict: "handle" }
-      );
+      .insert({
+        handle: newHandle,
+        entity_type: "user",
+        entity_id: user.id,
+        did: userData.did,
+      });
     if (registryError) {
+      // Unique violation (23505) means the handle was claimed between our
+      // availability check and now — treat as HANDLE_TAKEN
+      if (registryError.code === "23505") {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: "Handle was claimed by another entity. Please try a different username.",
+            code: "HANDLE_TAKEN",
+          } satisfies UpdatePdsHandleResponse),
+          {
+            status: 409,
+            headers: { ...cors, "Content-Type": "application/json" },
+          }
+        );
+      }
       console.warn("Failed to update pds_handles registry:", registryError);
     }
 
@@ -337,4 +351,7 @@ Deno.serve(async (req) => {
       }
     );
   }
-});
+}
+
+export default handler;
+Deno.serve(handler);

--- a/packages/supabase/supabase/functions/update-pds-handle/index.ts
+++ b/packages/supabase/supabase/functions/update-pds-handle/index.ts
@@ -280,7 +280,8 @@ Deno.serve(async (req) => {
       await supabaseAdmin
         .from("pds_handles")
         .delete()
-        .eq("handle", userData.pds_handle);
+        .eq("entity_type", "user")
+        .eq("entity_id", user.id);
     }
     const { error: registryError } = await supabaseAdmin
       .from("pds_handles")

--- a/packages/supabase/supabase/migrations/20260510201820_add_pds_handles_registry_and_community_bluesky.sql
+++ b/packages/supabase/supabase/migrations/20260510201820_add_pds_handles_registry_and_community_bluesky.sql
@@ -16,8 +16,8 @@ CREATE TABLE IF NOT EXISTS public.pds_handles (
   created_at timestamptz NOT NULL DEFAULT now()
 );
 
--- Index for looking up handles by entity
-CREATE INDEX IF NOT EXISTS idx_pds_handles_entity
+-- Enforce 1:1 — each entity can only have one handle
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pds_handles_entity_unique
   ON public.pds_handles (entity_type, entity_id);
 
 -- Index for DID lookups
@@ -28,6 +28,7 @@ CREATE INDEX IF NOT EXISTS idx_pds_handles_did
 ALTER TABLE public.pds_handles ENABLE ROW LEVEL SECURITY;
 
 -- Anyone can read handles (they're public identities)
+DROP POLICY IF EXISTS "Anyone can read handles" ON public.pds_handles;
 CREATE POLICY "Anyone can read handles"
   ON public.pds_handles FOR SELECT
   TO authenticated, anon
@@ -54,7 +55,49 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_communities_bluesky_handle
   ON public.communities (bluesky_handle) WHERE bluesky_handle IS NOT NULL;
 
 -- =============================================================================
--- 3. Backfill pds_handles with existing user handles
+-- 3. Create vault_read_secret function
+-- =============================================================================
+-- Reads decrypted secret value from Supabase Vault by name.
+-- Only accessible via service role (SECURITY DEFINER with vault search_path).
+
+CREATE OR REPLACE FUNCTION public.vault_read_secret(
+  secret_name text
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = vault
+AS $$
+DECLARE
+  secret_value text;
+BEGIN
+  -- Validate input
+  IF secret_name IS NULL OR length(secret_name) = 0 THEN
+    RAISE EXCEPTION 'secret_name cannot be null or empty';
+  END IF;
+
+  IF NOT secret_name ~ '^[a-zA-Z0-9_-]+$' THEN
+    RAISE EXCEPTION 'secret_name must contain only alphanumeric characters, underscores, and hyphens';
+  END IF;
+
+  -- Read decrypted secret from vault
+  SELECT decrypted_secret INTO secret_value
+  FROM vault.decrypted_secrets
+  WHERE name = secret_name
+  LIMIT 1;
+
+  IF secret_value IS NULL THEN
+    RAISE EXCEPTION 'Secret "%" not found', secret_name;
+  END IF;
+
+  RETURN secret_value;
+END;
+$$;
+
+COMMENT ON FUNCTION public.vault_read_secret IS 'Reads a decrypted secret from Supabase Vault by name. Only accessible via service role.';
+
+-- =============================================================================
+-- 4. Backfill pds_handles with existing user handles
 -- =============================================================================
 -- Populate the registry with existing active user PDS handles
 

--- a/packages/supabase/supabase/migrations/20260510201820_add_pds_handles_registry_and_community_bluesky.sql
+++ b/packages/supabase/supabase/migrations/20260510201820_add_pds_handles_registry_and_community_bluesky.sql
@@ -1,0 +1,71 @@
+-- PDS Handles Registry & Community Bluesky Identity
+-- Creates a shared handle registry for the PDS namespace (users + communities)
+-- and adds Bluesky identity columns to the communities table.
+
+-- =============================================================================
+-- 1. Create pds_handles registry table
+-- =============================================================================
+-- Single source of truth for all handles on our PDS.
+-- Prevents collisions between user handles and community handles.
+
+CREATE TABLE IF NOT EXISTS public.pds_handles (
+  handle text PRIMARY KEY,
+  entity_type text NOT NULL CHECK (entity_type IN ('user', 'community')),
+  entity_id text NOT NULL,
+  did text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Index for looking up handles by entity
+CREATE INDEX IF NOT EXISTS idx_pds_handles_entity
+  ON public.pds_handles (entity_type, entity_id);
+
+-- Index for DID lookups
+CREATE INDEX IF NOT EXISTS idx_pds_handles_did
+  ON public.pds_handles (did) WHERE did IS NOT NULL;
+
+-- Enable RLS
+ALTER TABLE public.pds_handles ENABLE ROW LEVEL SECURITY;
+
+-- Anyone can read handles (they're public identities)
+CREATE POLICY "Anyone can read handles"
+  ON public.pds_handles FOR SELECT
+  TO authenticated, anon
+  USING (true);
+
+-- Only service role can insert/update/delete (provisioning happens server-side)
+-- No INSERT/UPDATE/DELETE policies for authenticated users — only service_role bypasses RLS
+
+-- =============================================================================
+-- 2. Add Bluesky identity columns to communities
+-- =============================================================================
+
+ALTER TABLE public.communities
+  ADD COLUMN IF NOT EXISTS bluesky_did text,
+  ADD COLUMN IF NOT EXISTS bluesky_handle text,
+  ADD COLUMN IF NOT EXISTS pds_status pds_account_status DEFAULT 'pending'::pds_account_status;
+
+-- Unique constraint on bluesky_did (one DID per community)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_communities_bluesky_did
+  ON public.communities (bluesky_did) WHERE bluesky_did IS NOT NULL;
+
+-- Unique constraint on bluesky_handle
+CREATE UNIQUE INDEX IF NOT EXISTS idx_communities_bluesky_handle
+  ON public.communities (bluesky_handle) WHERE bluesky_handle IS NOT NULL;
+
+-- =============================================================================
+-- 3. Backfill pds_handles with existing user handles
+-- =============================================================================
+-- Populate the registry with existing active user PDS handles
+
+INSERT INTO public.pds_handles (handle, entity_type, entity_id, did, created_at)
+SELECT
+  u.pds_handle,
+  'user',
+  u.id::text,
+  u.did,
+  COALESCE(u.created_at, now())
+FROM public.users u
+WHERE u.pds_handle IS NOT NULL
+  AND u.pds_status = 'active'
+ON CONFLICT (handle) DO NOTHING;

--- a/packages/supabase/supabase/migrations/20260511000000_harden_vault_read_secret.sql
+++ b/packages/supabase/supabase/migrations/20260511000000_harden_vault_read_secret.sql
@@ -1,0 +1,40 @@
+-- Harden vault_read_secret: use immutable search path and restrict execution to service_role
+-- This aligns with the existing vault_create_secret hardening pattern
+
+CREATE OR REPLACE FUNCTION public.vault_read_secret(
+  secret_name text
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  secret_value text;
+BEGIN
+  -- Validate input
+  IF secret_name IS NULL OR length(secret_name) = 0 THEN
+    RAISE EXCEPTION 'secret_name cannot be null or empty';
+  END IF;
+
+  IF NOT secret_name ~ '^[a-zA-Z0-9_-]+$' THEN
+    RAISE EXCEPTION 'secret_name must contain only alphanumeric characters, underscores, and hyphens';
+  END IF;
+
+  -- Read decrypted secret from vault (fully qualified)
+  SELECT decrypted_secret INTO secret_value
+  FROM vault.decrypted_secrets
+  WHERE name = secret_name
+  LIMIT 1;
+
+  IF secret_value IS NULL THEN
+    RAISE EXCEPTION 'Secret "%" not found', secret_name;
+  END IF;
+
+  RETURN secret_value;
+END;
+$$;
+
+-- Restrict execution to service_role only
+REVOKE ALL ON FUNCTION public.vault_read_secret(text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.vault_read_secret(text) TO service_role;


### PR DESCRIPTION
## Summary

Gives every community a first-class presence on the AT Protocol / Bluesky network. Communities get a DID and handle (`@slug.trainers.gg`) that syncs profile data (name, logo, description) to the PDS automatically.

- **Shared namespace registry** — `pds_handles` table enforces uniqueness across users and communities, preventing slug collisions at creation time
- **Auto-provision on approval** — when an admin grants a community request, PDS account is created fire-and-forget
- **Profile sync** — settings save and logo upload/remove trigger `sync-community-profile` edge function
- **UI surfaces** — handle on profile page, Bluesky icon in community cards, "Bluesky Identity" settings card with enable/retry/active states

## Database

| Change | Details |
|--------|---------|
| New table | `pds_handles` — shared handle registry (entity_type, entity_id, handle) with UNIQUE constraints and RLS |
| New columns | `communities.bluesky_did`, `communities.bluesky_handle`, `communities.pds_status` |
| New function | `vault_read_secret(secret_name)` — safe vault access for edge functions |
| Backfill | Existing user handles inserted into `pds_handles` |

## Edge Functions

| Function | Purpose |
|----------|---------|
| `provision-community-pds` | Creates PDS account, registers handle, stores password in Vault |
| `sync-community-profile` | Pushes name/logo/description to `app.bsky.actor.profile` on PDS |
| `provision-all-communities` | Batch-provisions all unprovisioned communities (admin) |

## Web App Changes

- `grantCommunityRequestAction` — fires `provision-community-pds` after approval
- `createCommunity` mutation — checks `pds_handles` for namespace collision before insert
- Settings page — `BlueskyIdentityCard` component (active/pending/failed states, provision button)
- Settings page — `syncProfileToPds` fires on save + logo change when PDS is active
- Community profile page — shows `@handle.trainers.gg` below name
- Community card — Bluesky icon in social links (deduplicated with manual social links)

## Existing Function Updates

| Function | Change |
|----------|--------|
| `provision-pds` (users) | Now writes to `pds_handles` registry after provisioning |
| `update-pds-handle` (users) | Deletes old + upserts new handle in `pds_handles` on change |

## Test Plan

1. `pnpm db:reset` to apply migration
2. Navigate to community dashboard settings → click "Enable Bluesky Identity"
3. Verify PDS account created, status shows "Active on network" with handle + DID
4. Update name/description → save → verify profile synced to PDS
5. Upload/remove logo → verify sync fires
6. View community public page → handle appears below name
7. View community listings → Bluesky icon in social row
8. Create new community with slug matching existing user handle → expect "already taken on Bluesky network" error