### PR TITLE
feat: add admin button to provision all communities PDS accounts

### DIFF
--- a/apps/web/src/app/(app)/admin/communities/actions.ts
+++ b/apps/web/src/app/(app)/admin/communities/actions.ts
@@ -314,3 +314,55 @@ export async function toggleDiscordAction(
     return { success: true };
   }, "Failed to toggle Discord integration");
 }
+
+// --- Provision All Communities PDS ---
+
+export interface ProvisionResult {
+  communityId: number;
+  slug: string;
+  handle: string;
+  success: boolean;
+  did?: string;
+  error?: string;
+}
+
+export interface ProvisionAllResult {
+  success: boolean;
+  message: string;
+  results: ProvisionResult[];
+}
+
+export async function provisionAllCommunitiesAction(): Promise<
+  ActionResult & { data?: ProvisionAllResult }
+> {
+  return withAdminAction(async (supabase) => {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 120_000); // 2 min for batch
+
+    try {
+      const { data, error } =
+        await supabase.functions.invoke<ProvisionAllResult>(
+          "provision-all-communities",
+          { signal: controller.signal }
+        );
+
+      if (error) {
+        if (controller.signal.aborted || error.name === "AbortError") {
+          return { success: false, error: "Request timed out" };
+        }
+        return { success: false, error: error.message };
+      }
+
+      if (!data) {
+        return { success: false, error: "No response from edge function" };
+      }
+
+      updateTag(CacheTags.COMMUNITIES_LIST);
+      return { success: true, data };
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }, "Failed to provision communities") as Promise<
+    ActionResult & { data?: ProvisionAllResult }
+  >;
+}

--- a/apps/web/src/app/(app)/admin/communities/page.tsx
+++ b/apps/web/src/app/(app)/admin/communities/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/app/(app)/admin/community-requests/columns";
 import { CommunityDetailSheet } from "./community-detail-sheet";
 import { RequestDetailSheet } from "@/app/(app)/admin/community-requests/request-detail-sheet";
+import { ProvisionAllCommunitiesButton } from "@/components/admin/provision-all-communities-button";
 
 // --- Constants ---
 
@@ -130,16 +131,19 @@ export default function AdminCommunitiesPage() {
 
   return (
     <div className="space-y-4">
-      {/* Header row: title + search */}
+      {/* Header row: title + actions + search */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <h2 className="text-lg font-semibold">
-          {isRequestsOnly ? "Community Requests" : "Communities"}
-          {!isLoading && !isAll && (
-            <span className="text-muted-foreground ml-2 text-sm font-normal">
-              ({totalCount})
-            </span>
-          )}
-        </h2>
+        <div className="flex items-center gap-3">
+          <h2 className="text-lg font-semibold">
+            {isRequestsOnly ? "Community Requests" : "Communities"}
+            {!isLoading && !isAll && (
+              <span className="text-muted-foreground ml-2 text-sm font-normal">
+                ({totalCount})
+              </span>
+            )}
+          </h2>
+          {!isRequestsOnly && <ProvisionAllCommunitiesButton />}
+        </div>
         <div className="relative w-full sm:w-64">
           <Search className="text-muted-foreground absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
           <Input

--- a/apps/web/src/components/admin/provision-all-communities-button.tsx
+++ b/apps/web/src/components/admin/provision-all-communities-button.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useState } from "react";
+import { Cloud, Loader2, CheckCircle2, XCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from "@/components/ui/alert-dialog";
+import {
+  provisionAllCommunitiesAction,
+  type ProvisionAllResult,
+} from "@/app/(app)/admin/communities/actions";
+
+export function ProvisionAllCommunitiesButton() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [result, setResult] = useState<ProvisionAllResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  async function handleProvision() {
+    setIsLoading(true);
+    setResult(null);
+    setError(null);
+
+    const response = await provisionAllCommunitiesAction();
+
+    if (response.success && response.data) {
+      setResult(response.data);
+    } else {
+      setError(response.error ?? "Unknown error");
+    }
+
+    setIsLoading(false);
+  }
+
+  function handleClose() {
+    setDialogOpen(false);
+    // Reset state when closing after completion
+    if (!isLoading) {
+      setResult(null);
+      setError(null);
+    }
+  }
+
+  return (
+    <AlertDialog open={dialogOpen} onOpenChange={setDialogOpen}>
+      <AlertDialogTrigger
+        render={
+          <Button variant="outline" size="sm">
+            <Cloud className="size-4" />
+            Provision PDS
+          </Button>
+        }
+      />
+      <AlertDialogPortal>
+        <AlertDialogOverlay />
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Provision All Communities</AlertDialogTitle>
+            <AlertDialogDescription>
+              {!result && !error && !isLoading && (
+                <>
+                  This will create PDS accounts for all communities that
+                  don&apos;t have one yet. Communities with active accounts will
+                  be skipped.
+                </>
+              )}
+              {isLoading && (
+                <span className="flex items-center gap-2">
+                  <Loader2 className="size-4 animate-spin" />
+                  Provisioning communities... This may take a moment.
+                </span>
+              )}
+              {error && (
+                <span className="flex items-center gap-2 text-red-600 dark:text-red-400">
+                  <XCircle className="size-4 shrink-0" />
+                  {error}
+                </span>
+              )}
+              {result && (
+                <span className="flex items-center gap-2 text-emerald-600 dark:text-emerald-400">
+                  <CheckCircle2 className="size-4 shrink-0" />
+                  {result.message}
+                </span>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          {/* Per-community results */}
+          {result && result.results.length > 0 && (
+            <div className="max-h-48 space-y-1 overflow-y-auto rounded-md border p-3 text-sm">
+              {result.results.map((r) => (
+                <div
+                  key={r.communityId}
+                  className="flex items-center justify-between gap-2"
+                >
+                  <span className="font-mono text-xs">@{r.handle}</span>
+                  {r.success ? (
+                    <span className="text-emerald-600 dark:text-emerald-400">
+                      ✓
+                    </span>
+                  ) : (
+                    <span
+                      className="max-w-48 truncate text-red-600 dark:text-red-400"
+                      title={r.error}
+                    >
+                      {r.error}
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          <AlertDialogFooter>
+            {!result && !error ? (
+              <>
+                <AlertDialogCancel disabled={isLoading}>
+                  Cancel
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={(e) => {
+                    e.preventDefault(); // Keep dialog open during operation
+                    handleProvision();
+                  }}
+                  disabled={isLoading}
+                >
+                  {isLoading ? (
+                    <>
+                      <Loader2 className="size-4 animate-spin" />
+                      Provisioning...
+                    </>
+                  ) : (
+                    "Provision"
+                  )}
+                </AlertDialogAction>
+              </>
+            ) : (
+              <Button variant="outline" onClick={handleClose}>
+                Close
+              </Button>
+            )}
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialogPortal>
+    </AlertDialog>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a "Provision PDS" button to `/admin/communities` that batch-provisions PDS accounts for all communities missing one
- Uses `withAdminAction` (requires site_admin + sudo) → invokes `provision-all-communities` edge function
- Shows confirmation dialog with per-community success/failure results

## Changes

| File | What |
|------|------|
| `apps/web/src/app/(app)/admin/communities/actions.ts` | New `provisionAllCommunitiesAction` server action with 2-min timeout |
| `apps/web/src/components/admin/provision-all-communities-button.tsx` | Client component: button + confirmation dialog + results display |
| `apps/web/src/app/(app)/admin/communities/page.tsx` | Renders button in page header |

## How to use

1. Navigate to `/admin/communities`
2. Click "Provision PDS" button in the header
3. Confirm in the dialog
4. View per-community results (success ✓ or error message)

Safe to re-run — skips communities that already have active PDS accounts.