### PR TITLE
fix: extract actual error from edge function non-2xx responses

### DIFF
--- a/apps/web/src/app/(app)/admin/communities/actions.ts
+++ b/apps/web/src/app/(app)/admin/communities/actions.ts
@@ -350,6 +350,20 @@ export async function provisionAllCommunitiesAction(): Promise<
         if (controller.signal.aborted || error.name === "AbortError") {
           return { success: false, error: "Request timed out" };
         }
+
+        // FunctionsHttpError has a `context` property containing the Response.
+        // Try to extract the actual JSON error body from the edge function.
+        if (error.name === "FunctionsHttpError" && error.context) {
+          try {
+            const body = await error.context.json();
+            if (body?.error) {
+              return { success: false, error: body.error };
+            }
+          } catch {
+            // Response body already consumed or not JSON — fall through
+          }
+        }
+
         return { success: false, error: error.message };
       }
 


### PR DESCRIPTION
## Summary

- Fixes the "Provision PDS" button showing the generic "Edge Function returned a non-2xx status code" instead of the actual error
- Extracts the real JSON error body from the `FunctionsHttpError.context` (which is the Response object)
- Admins now see the specific failure reason (e.g., "PDS is not configured", "Admin access required")

## Root cause

The Supabase JS client throws `FunctionsHttpError` for any non-2xx status, with a generic message. The actual edge function response body (containing `{ error: "..." }`) is available on `error.context` as a Response object but wasn't being read.

## Next step

The underlying PDS provisioning failure is likely because `PDS_ADMIN_PASSWORD` isn't set as a Supabase Edge Function secret. After merging this fix, set it:

```bash
supabase secrets set PDS_ADMIN_PASSWORD="<password>" --project-ref <ref>
```