### PR TITLE
feat: swipe-to-close mobile species picker

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -172,16 +172,11 @@
     ]
   },
   "enabledPlugins": {
-    "frontend-design@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
     "playwright@claude-plugins-official": true,
-    "superpowers@claude-plugins-official": true,
     "linear@claude-plugins-official": true,
-    "vercel@claude-plugins-official": true,
     "code-simplifier@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
-    "pr-review-toolkit@claude-plugins-official": true,
-    "claude-md-management@claude-plugins-official": true,
-    "design-for-ai@rtd": true
+    "pr-review-toolkit@claude-plugins-official": true
   }
 }

--- a/apps/web/src/components/team-builder/pickers/__tests__/species-picker-mobile.test.tsx
+++ b/apps/web/src/components/team-builder/pickers/__tests__/species-picker-mobile.test.tsx
@@ -59,6 +59,32 @@ jest.mock("@trainers/pokemon/sprites", () => ({
   getPokemonSprite: jest.fn().mockReturnValue({ url: "/sprite.png", pixelated: false }),
 }));
 
+// ── Vaul Drawer mock — JSDOM lacks setPointerCapture used by Vaul's gesture ──
+jest.mock("@/components/ui/drawer", () => ({
+  Drawer: ({
+    children,
+    open,
+  }: {
+    children: React.ReactNode;
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) => (open ? <>{children}</> : null),
+  DrawerContent: ({
+    children,
+  }: {
+    children: React.ReactNode;
+    showHandle?: boolean;
+    className?: string;
+  }) => <div>{children}</div>,
+  DrawerTitle: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => <h2 className={className}>{children}</h2>,
+}));
+
 // ── Stub heavy child filter components ─────────────────────────────────────
 jest.mock("../species-sidebar", () => ({
   SpeciesSidebar: () => <div data-testid="species-sidebar" />,

--- a/apps/web/src/components/team-builder/pickers/species-picker-mobile.tsx
+++ b/apps/web/src/components/team-builder/pickers/species-picker-mobile.tsx
@@ -134,7 +134,7 @@ export function SpeciesPickerMobile({
     <Drawer open={open} onOpenChange={handleOpenChange}>
       <DrawerContent
         showHandle={false}
-        className="h-[95dvh] overflow-hidden rounded-t-[20px] p-0"
+        className="h-[95dvh] data-[vaul-drawer-direction=bottom]:max-h-[95dvh] overflow-hidden rounded-t-[20px] p-0"
       >
         <DrawerTitle className="sr-only">
           {view === "list" ? "Choose species" : "Filters"}

--- a/apps/web/src/components/team-builder/pickers/species-picker-mobile.tsx
+++ b/apps/web/src/components/team-builder/pickers/species-picker-mobile.tsx
@@ -13,10 +13,10 @@ import {
 
 import { Button } from "@/components/ui/button";
 import {
-  Sheet,
-  SheetContent,
-  SheetTitle,
-} from "@/components/ui/sheet";
+  Drawer,
+  DrawerContent,
+  DrawerTitle,
+} from "@/components/ui/drawer";
 import { cn } from "@/lib/utils";
 
 import { TypeSymbolIcon } from "../type-symbol-icon";
@@ -131,58 +131,51 @@ export function SpeciesPickerMobile({
   }
 
   return (
-    <Sheet open={open} onOpenChange={handleOpenChange}>
-      {/* SheetContent side="bottom" has data-[side=bottom]:h-auto built in which
-          overrides any h-[*] class. Height is controlled by the inner wrapper
-          instead so we don't fight CSS specificity. */}
-      <SheetContent
-        side="bottom"
-        showCloseButton={false}
-        className="overflow-hidden rounded-t-[20px] p-0"
+    <Drawer open={open} onOpenChange={handleOpenChange}>
+      <DrawerContent
+        showHandle={false}
+        className="h-[95dvh] overflow-hidden rounded-t-[20px] p-0"
       >
-        {/* Inner wrapper owns the fixed height and flex layout */}
-        <div className="flex h-[95dvh] flex-col overflow-hidden">
-          <SheetTitle className="sr-only">
-            {view === "list" ? "Choose species" : "Filters"}
-          </SheetTitle>
+        <DrawerTitle className="sr-only">
+          {view === "list" ? "Choose species" : "Filters"}
+        </DrawerTitle>
 
-          {/* Drag handle */}
-          <div
-            aria-hidden="true"
-            className="mx-auto mt-2 mb-1 h-1 w-9 shrink-0 rounded-full bg-muted-foreground/20"
-          />
+        {/* Drag handle */}
+        <div
+          aria-hidden="true"
+          className="mx-auto mt-2 mb-1 h-1 w-9 shrink-0 rounded-full bg-muted-foreground/20"
+        />
 
-          {/* Bounded container — gives ListView/FiltersView a fixed height to flex within */}
-          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-            {view === "list" ? (
-              <ListView
-                query={query}
-                onQueryChange={setQuery}
-                matched={matched}
-                speciesIndexCount={speciesIndex.length}
-                activeFilterCount={activeFilterCount}
-                filters={filters}
-                onFiltersChange={setFilters}
-                onOpenFilters={() => setView("filters")}
-                onPick={handlePick}
-                currentSpecies={value}
-              />
-            ) : (
-              <FiltersView
-                filters={filters}
-                onFiltersChange={setFilters}
-                format={format}
-                currentTeam={currentTeam}
-                bucketCount={bucketCount}
-                matchedCount={matched.length}
-                onBack={() => setView("list")}
-                onClearAll={clearAllFilters}
-              />
-            )}
-          </div>
+        {/* Bounded container — flex-1 fills the remaining drawer height */}
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          {view === "list" ? (
+            <ListView
+              query={query}
+              onQueryChange={setQuery}
+              matched={matched}
+              speciesIndexCount={speciesIndex.length}
+              activeFilterCount={activeFilterCount}
+              filters={filters}
+              onFiltersChange={setFilters}
+              onOpenFilters={() => setView("filters")}
+              onPick={handlePick}
+              currentSpecies={value}
+            />
+          ) : (
+            <FiltersView
+              filters={filters}
+              onFiltersChange={setFilters}
+              format={format}
+              currentTeam={currentTeam}
+              bucketCount={bucketCount}
+              matchedCount={matched.length}
+              onBack={() => setView("list")}
+              onClearAll={clearAllFilters}
+            />
+          )}
         </div>
-      </SheetContent>
-    </Sheet>
+      </DrawerContent>
+    </Drawer>
   );
 }
 

--- a/apps/web/src/components/ui/drawer.tsx
+++ b/apps/web/src/components/ui/drawer.tsx
@@ -45,14 +45,17 @@ function DrawerOverlay({
   );
 }
 
+interface DrawerContentProps
+  extends React.ComponentProps<typeof DrawerPrimitive.Content> {
+  showHandle?: boolean;
+}
+
 function DrawerContent({
   className,
   children,
   showHandle = true,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Content> & {
-  showHandle?: boolean;
-}) {
+}: DrawerContentProps) {
   return (
     <DrawerPortal data-slot="drawer-portal">
       <DrawerOverlay />

--- a/apps/web/src/components/ui/drawer.tsx
+++ b/apps/web/src/components/ui/drawer.tsx
@@ -48,8 +48,11 @@ function DrawerOverlay({
 function DrawerContent({
   className,
   children,
+  showHandle = true,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+}: React.ComponentProps<typeof DrawerPrimitive.Content> & {
+  showHandle?: boolean;
+}) {
   return (
     <DrawerPortal data-slot="drawer-portal">
       <DrawerOverlay />
@@ -61,7 +64,9 @@ function DrawerContent({
         )}
         {...props}
       >
-        <div className="bg-muted bg-muted mx-auto mt-4 hidden h-1 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        {showHandle && (
+          <div className="bg-muted bg-muted mx-auto mt-4 hidden h-1 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        )}
         {children}
       </DrawerPrimitive.Content>
     </DrawerPortal>


### PR DESCRIPTION
The drag handle on the bottom sheet was purely decorative — Sheet from @base-ui/react has no gesture listeners. Swapping to Vaul Drawer gives scroll-aware swipe-to-dismiss for free: the drawer stays open while the list has scroll room, and closes once the user reaches the top and swipes down.

Added a showHandle prop to DrawerContent so callers can suppress Vaul's wider default handle and keep the existing narrower pill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated mobile species picker component to use enhanced drawer behavior
  * Added configurable handle visibility to drawer component

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thatguyinabeanie/trainers.gg/pull/332)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->