### PR TITLE
fix(cookie-consent): eliminate banner flash on return visits

### DIFF
--- a/apps/web/src/components/cookie-consent.tsx
+++ b/apps/web/src/components/cookie-consent.tsx
@@ -3,6 +3,7 @@
 import { useSyncExternalStore } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { useIsClient } from "@/hooks/use-is-client";
 
 const CONSENT_KEY = "cookie-consent";
 
@@ -34,13 +35,14 @@ function subscribeToConsent(callback: () => void) {
 }
 
 export function CookieConsent() {
+  const isClient = useIsClient();
   const status = useSyncExternalStore(
     subscribeToConsent,
     getConsentStatus,
     () => "undecided" as ConsentStatus
   );
 
-  if (status !== "undecided") return null;
+  if (!isClient || status !== "undecided") return null;
 
   return (
     <div


### PR DESCRIPTION
## Summary

- **Root cause:** `useSyncExternalStore`'s server snapshot always returned `"undecided"` (no localStorage on the server), so SSR always included the banner in the initial HTML
- **Fix:** Guard with `useIsClient()` so the component renders nothing during SSR; banner only appears after hydration when the real consent status is known
- **Tradeoff:** First-time visitors see the banner ~100ms after load instead of instantly — completely acceptable for a cookie consent prompt

## Test plan

- [ ] Accept cookies → hard-reload → banner does not flash
- [ ] Decline cookies → hard-reload → no flash
- [ ] Clear `cookie-consent` from localStorage → reload → banner appears after hydration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the cookie consent banner so it only appears on the client, preventing it from rendering before the app is fully loaded.
  * Kept the existing behavior of hiding the banner once a consent choice has already been made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->